### PR TITLE
Implement markdown table fixer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[command(about = "Reflow broken markdown tables")]
 struct Cli {
     /// Rewrite files in place
-    #[arg(long = "in-place")]
+    #[arg(long = "in-place", requires = "files")]
     in_place: bool,
     /// Markdown files to fix
     files: Vec<PathBuf>,
@@ -36,10 +36,6 @@ struct Cli {
 /// ```
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-
-    if cli.in_place && cli.files.is_empty() {
-        anyhow::bail!("--in-place requires at least one file");
-    }
 
     if cli.files.is_empty() {
         let mut input = String::new();


### PR DESCRIPTION
## Summary
- implement table reflow logic in library crate
- provide CLI for fixing markdown files
- add tests with `rstest`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx markdownlint-cli2 '**/*.md' '#node_modules'` *(fails: 339 errors)*
- `npx nixie '**/*.md' '#node_modules'` *(failed: Syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_684c37f2c8a08322b6a26c4313108ab2

## Summary by Sourcery

Implement markdown table-fixing library and CLI tool, reflowing broken tables with optional in-place file edits and comprehensive test coverage

New Features:
- Provide `reflow_table` and `process_stream` library functions to automatically reflow broken markdown tables
- Add `mdtablefix` CLI with support for file arguments, stdin input, and an `--in-place` mode

Enhancements:
- Skip code fences during table processing to avoid reflowing content inside code blocks
- Implement `rewrite` function for in-place file updates

Build:
- Update Cargo.toml with runtime dependencies (`anyhow`, `clap`, `regex`) and dev-dependencies (`rstest`, `assert_cmd`, `tempfile`)

Tests:
- Add unit and integration tests using `rstest`, `assert_cmd`, and `tempfile` to cover table reflow and CLI behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of escaped pipe characters in markdown tables, ensuring they are treated as literal characters within cells.
	- Table reflow now preserves original indentation and header separator lines for better formatting.
- **Bug Fixes**
	- Enhanced table parsing to ensure consistent column counts and correct formatting, even with complex markdown tables.
- **Tests**
	- Added new tests to verify correct handling of headers, escaped pipes, and indentation in tables.
- **Chores**
	- Command-line argument validation is now handled automatically, providing clearer error messages for invalid input combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->