### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Package binary
         id: package
         run: |
-          mkdir dist
+          mkdir -p dist
           cp target/release/mdtablefix dist/mdtablefix-linux
           version="${GITHUB_REF_NAME#v}"
           cd dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release Binary
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*-*'
 
 jobs:
   release:
@@ -19,14 +19,19 @@ jobs:
       - name: Build release binary
         run: cargo build --release
       - name: Package binary
+        id: package
         run: |
           mkdir dist
           cp target/release/mdtablefix dist/mdtablefix-linux
+          version="${GITHUB_REF_NAME#v}"
           cd dist
-          tar -czf mdtablefix-linux.tar.gz mdtablefix-linux
+          tar -czf "mdtablefix-${version}-linux.tar.gz" mdtablefix-linux
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
       - name: Upload to release
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/mdtablefix-linux.tar.gz
+          files: dist/mdtablefix-${{ steps.package.outputs.version }}-linux.tar.gz
           prerelease: ${{ contains(github.ref, '-') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release Binary
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
-      - 'v[0-9]*.[0-9]*.[0-9]*-*'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?'
 
 jobs:
   release:
@@ -16,6 +16,16 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Build release binary
         run: cargo build --release
       - name: Package binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Binary
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Package binary
+        run: |
+          mkdir dist
+          cp target/release/mdtablefix dist/mdtablefix-linux
+          cd dist
+          tar -czf mdtablefix-linux.tar.gz mdtablefix-linux
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/mdtablefix-linux.tar.gz
+          prerelease: ${{ contains(github.ref, '-') }}
+


### PR DESCRIPTION
## Summary
- automate packaging of Linux binary on tag release

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `markdownlint '**/*.md'` *(fails: MD013, MD040, MD033, MD047, etc.)*
- `nixie docs/rust-testing-with-rstest-fixtures.md`

------
https://chatgpt.com/codex/tasks/task_e_684c60bffc5c8322803506f560f66df1

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow (release.yml) that builds the Rust project in release mode, packages the Linux binary into a tar.gz archive, and uploads it to the GitHub release when a matching tag is pushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow to build and package binaries for tagged releases, with assets uploaded directly to GitHub Releases. Pre-release tags are handled and marked accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->