### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Lint
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: cargo test
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Run coverage
+        run: cargo tarpaulin --out Xml
+      - name: Upload coverage
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: codecov/codecov-action@v3
+        with:
+          files: cobertura.xml
+          token: ${{ env.CS_ACCESS_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: cargo test
       - name: Install cargo-tarpaulin


### PR DESCRIPTION
## Summary
- add CI workflow to run formatting, lint, tests, and coverage

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `find . -name '*.md' -print0 | xargs -0 nixie`


------
https://chatgpt.com/codex/tasks/task_e_684c62b12a748322ad075c854edcd144

## Summary by Sourcery

Add GitHub Actions CI workflow to run formatting checks, linting, tests, and coverage reporting on pull requests to the main branch.

CI:
- Introduce a CI workflow that installs dependencies, runs cargo fmt --check, cargo clippy with warnings as errors, and cargo test.
- Generate test coverage using cargo-tarpaulin and upload reports to Codecov when a token is available.