### PR TITLE
Ensure uniform column widths

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -225,3 +225,31 @@ fn test_uniform_example_two() {
         }
     }
 }
+
+#[test]
+fn test_non_table_lines_unchanged() {
+    let input = vec![
+        "# Title".to_string(),
+        "".to_string(),
+        "Para text.".to_string(),
+        "".to_string(),
+        "| a | b |".to_string(),
+        "| 1 | 22 |".to_string(),
+        "".to_string(),
+        "* bullet".to_string(),
+        "".to_string(),
+    ];
+    let output = process_stream(&input);
+    let expected = vec![
+        "# Title".to_string(),
+        "".to_string(),
+        "Para text.".to_string(),
+        "".to_string(),
+        "| a | b  |".to_string(),
+        "| 1 | 22 |".to_string(),
+        "".to_string(),
+        "* bullet".to_string(),
+        "".to_string(),
+    ];
+    assert_eq!(output, expected);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -164,7 +164,7 @@ fn test_cli_process_file(broken_table: Vec<String>) {
     let file_path = dir.path().join("sample.md");
     let mut f = File::create(&file_path).unwrap();
     for line in &broken_table {
-        writeln!(f, "{}", line).unwrap();
+        writeln!(f, "{line}").unwrap();
     }
     f.flush().unwrap();
     drop(f);
@@ -192,7 +192,7 @@ fn test_uniform_example_one() {
     let widths: Vec<usize> = output[0]
         .trim_matches('|')
         .split('|')
-        .map(|c| c.len())
+        .map(str::len)
         .collect();
     for row in output {
         let cols: Vec<&str> = row.trim_matches('|').split('|').collect();
@@ -216,7 +216,7 @@ fn test_uniform_example_two() {
     let widths: Vec<usize> = output[0]
         .trim_matches('|')
         .split('|')
-        .map(|c| c.len())
+        .map(str::len)
         .collect();
     for row in output {
         let cols: Vec<&str> = row.trim_matches('|').split('|').collect();
@@ -230,26 +230,26 @@ fn test_uniform_example_two() {
 fn test_non_table_lines_unchanged() {
     let input = vec![
         "# Title".to_string(),
-        "".to_string(),
+        String::new(),
         "Para text.".to_string(),
-        "".to_string(),
+        String::new(),
         "| a | b |".to_string(),
         "| 1 | 22 |".to_string(),
-        "".to_string(),
+        String::new(),
         "* bullet".to_string(),
-        "".to_string(),
+        String::new(),
     ];
     let output = process_stream(&input);
     let expected = vec![
         "# Title".to_string(),
-        "".to_string(),
+        String::new(),
         "Para text.".to_string(),
-        "".to_string(),
+        String::new(),
         "| a | b  |".to_string(),
         "| 1 | 22 |".to_string(),
-        "".to_string(),
+        String::new(),
         "* bullet".to_string(),
-        "".to_string(),
+        String::new(),
     ];
     assert_eq!(output, expected);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,3 +175,53 @@ fn test_cli_process_file(broken_table: Vec<String>) {
         .success()
         .stdout("| A | B |\n| 1 | 2 |\n| 3 | 4 |\n");
 }
+
+#[test]
+fn test_uniform_example_one() {
+    let input = vec![
+        "| Logical type | PostgreSQL | SQLite notes |".to_string(),
+        "|--------------|-------------------------|---------------------------------------------------------------------------------|".to_string(),
+        "| strings | `TEXT` (or `VARCHAR`) | `TEXT` - SQLite ignores the length specifier anyway |".to_string(),
+        "| booleans | `BOOLEAN DEFAULT FALSE` | declare as `BOOLEAN`; Diesel serialises to 0 / 1 so this is fine |".to_string(),
+        "| integers | `INTEGER` / `BIGINT` | ditto |".to_string(),
+        "| decimals | `NUMERIC` | stored as FLOAT in SQLite; Diesel `Numeric` round-trips, but beware precision |".to_string(),
+        "| blobs / raw | `BYTEA` | `BLOB` |".to_string(),
+    ];
+    let output = reflow_table(&input);
+    assert!(!output.is_empty());
+    let widths: Vec<usize> = output[0]
+        .trim_matches('|')
+        .split('|')
+        .map(|c| c.len())
+        .collect();
+    for row in output {
+        let cols: Vec<&str> = row.trim_matches('|').split('|').collect();
+        for (i, col) in cols.iter().enumerate() {
+            assert_eq!(col.len(), widths[i]);
+        }
+    }
+}
+
+#[test]
+fn test_uniform_example_two() {
+    let input = vec![
+        "| Option | How it works | When to choose it |".to_string(),
+        "|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|".to_string(),
+        "| **B. Pure-Rust migrations** | Implement `diesel::migration::Migration<DB>` in a Rust file (`up.rs` / `down.rs`) and compile with both `features = [\"postgres\", \"sqlite\"]`. The query builder emits backend-specific SQL at runtime. | You prefer the type-checked DSL and can live with slightly slower compile times. |".to_string(),
+        "| **C. Lowest-common-denominator SQL** | Write one `up.sql`/`down.sql` that *already* works on both engines. This demands avoiding SERIAL/IDENTITY, JSONB, `TIMESTAMPTZ`, etc. | Simple schemas, embedded use-case only, you are happy to supply integer primary keys manually. |".to_string(),
+        "| **D. Two separate migration trees** | Maintain `migrations/sqlite` and `migrations/postgres` directories with identical version numbers. Use `embed_migrations!(\"migrations/<backend>\")` to compile the right set. | You ship a single binary with migrations baked in. |".to_string(),
+    ];
+    let output = reflow_table(&input);
+    assert!(!output.is_empty());
+    let widths: Vec<usize> = output[0]
+        .trim_matches('|')
+        .split('|')
+        .map(|c| c.len())
+        .collect();
+    for row in output {
+        let cols: Vec<&str> = row.trim_matches('|').split('|').collect();
+        for (i, col) in cols.iter().enumerate() {
+            assert_eq!(col.len(), widths[i]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- pad table columns to equal width
- test uniform width behaviour on sample tables
- expose `split_cells` for doctests
- fix doctest snippets

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c6cef66708322aba3799b34b2a8f8

## Summary by Sourcery

Pad Markdown table columns to uniform width in reflow_table, expose split_cells publicly, update doctest imports, and add integration tests to verify uniform column widths.

New Features:
- Pad table columns to equal width in reflow_table
- Expose split_cells publicly for external use and doctests

Enhancements:
- Refactor row processing in reflow_table to separate cleaning and width calculation

Documentation:
- Update doctest snippets to import split_cells, reflow_table, process_stream, and rewrite functions

Tests:
- Add integration tests to verify uniform column widths for sample tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved table formatting with column-wise alignment, ensuring cells are padded to uniform widths for better readability.
- **Documentation**
	- Updated code examples to clarify usage and imports for public functions.
- **Tests**
	- Added integration tests to verify consistent column alignment in reflowed Markdown tables and preservation of non-table content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->