### PR TITLE
Improve HTML table detection

### DIFF
--- a/docs/html-table-support.md
+++ b/docs/html-table-support.md
@@ -8,3 +8,4 @@ consistently.
 The crate `markup5ever_rcdom` provides a minimal DOM which `html5ever` populates
 and which is traversed to extract rows and cells. Only basic tables containing
 `<tr>`, `<th>` and `<td>` elements are supported.
+`mdtablefix` detects table elements regardless of attribute usage or tag case.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -74,6 +74,36 @@ fn html_table() -> Vec<String> {
 }
 
 #[fixture]
+fn html_table_with_attrs() -> Vec<String> {
+    vec![
+        "<table class=\"x\">".to_string(),
+        "<tr><th>A</th><th>B</th></tr>".to_string(),
+        "<tr><td>1</td><td>2</td></tr>".to_string(),
+        "</table>".to_string(),
+    ]
+}
+
+#[fixture]
+fn html_table_uppercase() -> Vec<String> {
+    vec![
+        "<TABLE>".to_string(),
+        "<tr><th>A</th><th>B</th></tr>".to_string(),
+        "<tr><td>1</td><td>2</td></tr>".to_string(),
+        "</TABLE>".to_string(),
+    ]
+}
+
+#[fixture]
+fn html_table_mixed_case() -> Vec<String> {
+    vec![
+        "<TaBlE>".to_string(),
+        "<tr><th>A</th><th>B</th></tr>".to_string(),
+        "<tr><td>1</td><td>2</td></tr>".to_string(),
+        "</TaBlE>".to_string(),
+    ]
+}
+
+#[fixture]
 fn multiple_tables() -> Vec<String> {
     vec![
         "| A | B |".to_string(),
@@ -133,6 +163,24 @@ fn test_reflow_preserves_indentation(indented_table: Vec<String>) {
 fn test_process_stream_html_table(html_table: Vec<String>) {
     let expected = vec!["| A | B |", "| --- | --- |", "| 1 | 2 |"];
     assert_eq!(process_stream(&html_table), expected);
+}
+
+#[rstest]
+fn test_process_stream_html_table_with_attrs(html_table_with_attrs: Vec<String>) {
+    let expected = vec!["| A | B |", "| --- | --- |", "| 1 | 2 |"];
+    assert_eq!(process_stream(&html_table_with_attrs), expected);
+}
+
+#[rstest]
+fn test_process_stream_html_table_uppercase(html_table_uppercase: Vec<String>) {
+    let expected = vec!["| A | B |", "| --- | --- |", "| 1 | 2 |"];
+    assert_eq!(process_stream(&html_table_uppercase), expected);
+}
+
+#[rstest]
+fn test_process_stream_html_table_mixed_case(html_table_mixed_case: Vec<String>) {
+    let expected = vec!["| A | B |", "| --- | --- |", "| 1 | 2 |"];
+    assert_eq!(process_stream(&html_table_mixed_case), expected);
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary
- recognize `<table>` tags with attributes or mixed casing
- convert uppercase, mixed-case, and attributed tables
- test additional HTML table scenarios
- document that tag matching is case-insensitive

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `markdownlint "**/*.md" | head -n 20`
- `nixie docs`


------
https://chatgpt.com/codex/tasks/task_e_684cd07b681c8322a960b83aa1cbdfd1

## Summary by Sourcery

Improve HTML table detection to handle case-insensitive tags and attributes, and add corresponding tests and documentation.

Enhancements:
- Use case-insensitive regex patterns to detect `<table>` and `</table>` tags regardless of casing or attributes

Documentation:
- Document that table tag matching is case-insensitive and supports attributes

Tests:
- Add fixtures and tests for HTML tables with attributes, uppercase tags, and mixed-case tags