### PR TITLE
Document HTML preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ fn main() -> std::io::Result<()> {
 ## HTML table support
 
 `mdtablefix` recognises simple `<table>` elements embedded in Markdown.
-Those tables are converted to Markdown before the regular reflow logic so
-Markdown and HTML tables are formatted consistently.
+Before the main table reflow runs these HTML tables are converted to Markdown in
+a preprocessing stage handled by `convert_html_tables`.
 
-The crate relies on `html5ever` and `markup5ever_rcdom` to parse the table
-structure. Only basic tables using `<tr>`, `<th>` and `<td>` tags are
-supported, and attributes or tag casing does not affect detection.
+Only basic tables composed of `<tr>`, `<th>` and `<td>` tags are detected, and
+attributes or tag casing do not matter. After conversion the regular reflow
+logic aligns them alongside Markdown tables. See
+[`docs/html-table-support.md`](docs/html-table-support.md) for details.
 
 ## Testing
 

--- a/docs/html-table-support.md
+++ b/docs/html-table-support.md
@@ -1,0 +1,12 @@
+# HTML Table Support in `mdtablefix`
+
+`mdtablefix` can format simple HTML `<table>` elements embedded in Markdown. These
+HTML tables are transformed into Markdown before the main table reflow logic runs.
+That preprocessing is handled by the `convert_html_tables` function.
+
+Only straightforward tables with `<tr>`, `<th>` and `<td>` tags are detected.
+Attributes and tag casing are ignored, and complex nested or styled tables are
+not supported. After conversion each HTML table is represented as a Markdown
+table so the usual reflow algorithm can align its columns consistently with the
+rest of the document.
+


### PR DESCRIPTION
## Summary
- explain HTML preprocessing step in README
- add a dedicated doc for HTML table support

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx markdownlint-cli '**/*.md'` *(fails: MD013, MD007, ...)*
- `nixie $(find . -name '*.md')`


------
https://chatgpt.com/codex/tasks/task_e_684cf305c15c832286ac332ecd60ed48

## Summary by Sourcery

Document the HTML table preprocessing stage by updating the README and adding a dedicated guide for HTML table support.

Documentation:
- Explain HTML table preprocessing step in the README using the `convert_html_tables` function before the main reflow logic
- Add `docs/html-table-support.md` with details on supported HTML table tags and conversion to Markdown for consistent formatting