### PR TITLE
Simplify strong detection with iterator

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -99,12 +99,7 @@ fn contains_strong(handle: &Handle) -> bool {
             return true;
         }
     }
-    for child in handle.children.borrow().iter() {
-        if contains_strong(child) {
-            return true;
-        }
-    }
-    false
+    handle.children.borrow().iter().any(contains_strong)
 }
 
 /// Converts a `<table>` DOM node into Markdown table lines and calls


### PR DESCRIPTION
## Summary
- use iterator `any` for checking bold descendants

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint -c .markdownlint-cli2.jsonc '**/*.md'` *(fails: multiple pre-existing lint issues)*
- `nixie docs/`

------
https://chatgpt.com/codex/tasks/task_e_684e2cab760c83228a15b803959ef0b5