### PR TITLE
Improve borrow clarity in contains_strong

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -99,7 +99,8 @@ fn contains_strong(handle: &Handle) -> bool {
             return true;
         }
     }
-    handle.children.borrow().iter().any(contains_strong)
+    let children = handle.children.borrow();
+    children.iter().any(contains_strong)
 }
 
 /// Converts a `<table>` DOM node into Markdown table lines and calls


### PR DESCRIPTION
## Summary
- reduce borrow scope when checking for strong tags

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e2e5a42308322800569386e852455