### PR TITLE
Add text wrapping to mdtablefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "regex",
  "rstest",
  "tempfile",
+ "textwrap",
 ]
 
 [[package]]
@@ -727,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,10 +806,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ clap = { version = "4", features = ["derive"] }
 regex = "1"
 html5ever = "0.27"
 markup5ever_rcdom = "0.3"
-textwrap = "0.16"
+textwrap = "^0.16"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4", features = ["derive"] }
 regex = "1"
 html5ever = "0.27"
 markup5ever_rcdom = "0.3"
+textwrap = "0.16"
 
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mdtablefix
 
 `mdtablefix` reflows Markdown tables so that each column has a uniform width.
-It also wraps paragraphs and list items at 80 columns.
+It also wraps paragraphs and list items to 80 columns.
 The tool ignores fenced code blocks and respects escaped pipes (`\|`),
 making it safe for mixed content.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # mdtablefix
 
 `mdtablefix` reflows Markdown tables so that each column has a uniform width.
-It ignores fenced code blocks and respects escaped pipes (`\|`),
+It also wraps paragraphs and list items at 80 columns.
+The tool ignores fenced code blocks and respects escaped pipes (`\|`),
 making it safe for mixed content.
 
 ## Installation
@@ -85,4 +86,3 @@ is organised using the [`rstest`](https://crates.io/crates/rstest) crate.
 
 This project is licensed under the ISC license.
 See the [LICENSE](LICENSE) file for details.
-

--- a/src/html.rs
+++ b/src/html.rs
@@ -176,7 +176,9 @@ fn table_lines_to_markdown(lines: &[String]) -> Vec<String> {
 }
 
 /// Buffers a single line of HTML, updating nesting depth and emitting completed
-/// tables when an end tag is encountered.
+/// Buffers a line of HTML table markup and processes the buffer into Markdown when the table is fully closed.
+///
+/// Tracks the nesting depth of `<table>` tags, appending each line to the buffer. When all opened tables are closed (depth reaches zero), converts the buffered HTML table lines to Markdown and appends them to the output vector. Resets the buffer and updates the HTML state accordingly.
 fn push_html_line(
     line: &str,
     buf: &mut Vec<String>,
@@ -196,7 +198,27 @@ fn push_html_line(
     }
 }
 
-/// Converts any HTML tables in `lines` to Markdown syntax.
+/// Replaces HTML tables in the provided lines with equivalent Markdown table syntax.
+///
+/// Scans the input lines for HTML `<table>` blocks, converts each detected table to Markdown using `table_lines_to_markdown`, and preserves all other content unchanged. Handles nested tables and maintains original line formatting outside of tables.
+///
+/// # Arguments
+///
+/// * `lines` - A slice of strings representing lines of Markdown, possibly containing HTML tables.
+///
+/// # Returns
+///
+/// A vector of strings with HTML tables replaced by Markdown tables, leaving other lines intact.
+///
+/// # Examples
+///
+/// ```
+/// let html_lines = vec![
+///     "<table><tr><th>Header</th></tr><tr><td>Cell</td></tr></table>".to_string()
+/// ];
+/// let md_lines = html_table_to_markdown(&html_lines);
+/// assert!(md_lines[0].starts_with("| Header |"));
+/// ```
 pub(crate) fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
     let mut out = Vec::new();
     let mut buf = Vec::new();
@@ -231,6 +253,22 @@ pub(crate) fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
 /// Fenced code blocks are left untouched, allowing raw HTML examples to be
 /// documented without modification.
 #[must_use]
+/// Converts HTML tables embedded in Markdown lines to Markdown table syntax.
+///
+/// Scans the input lines, detects HTML table blocks outside of fenced code blocks, and replaces them with equivalent Markdown tables. Fenced code blocks are left unmodified. Handles nested tables and preserves original line formatting outside of tables.
+///
+/// # Examples
+///
+/// ```
+/// let lines = vec![
+///     "<table>".to_string(),
+///     "  <tr><th>Header</th></tr>".to_string(),
+///     "  <tr><td>Cell</td></tr>".to_string(),
+///     "</table>".to_string(),
+/// ];
+/// let result = convert_html_tables(&lines);
+/// assert!(result[0].starts_with("| Header |"));
+/// ```
 pub fn convert_html_tables(lines: &[String]) -> Vec<String> {
     let mut out = Vec::new();
     let mut buf = Vec::new();

--- a/src/html.rs
+++ b/src/html.rs
@@ -184,7 +184,7 @@ fn push_html_line(
     in_html: &mut bool,
     out: &mut Vec<String>,
 ) {
-    buf.push(line.trim_end().to_string());
+    buf.push(line.to_string());
     *depth += TABLE_START_RE.find_iter(line).count();
     if TABLE_END_RE.is_match(line) {
         *depth = depth.saturating_sub(TABLE_END_RE.find_iter(line).count());
@@ -204,7 +204,7 @@ pub(crate) fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
 
     for line in lines {
         if depth > 0 || TABLE_START_RE.is_match(line.trim_start()) {
-            buf.push(line.trim_end().to_string());
+            buf.push(line.to_string());
             depth += TABLE_START_RE.find_iter(line).count();
             if TABLE_END_RE.is_match(line) {
                 depth = depth.saturating_sub(TABLE_END_RE.find_iter(line).count());
@@ -216,7 +216,7 @@ pub(crate) fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
             continue;
         }
 
-        out.push(line.trim_end().to_string());
+        out.push(line.to_string());
     }
 
     if !buf.is_empty() {
@@ -246,12 +246,12 @@ pub fn convert_html_tables(lines: &[String]) -> Vec<String> {
                 depth = 0;
             }
             in_code = !in_code;
-            out.push(line.trim_end().to_string());
+            out.push(line.to_string());
             continue;
         }
 
         if in_code {
-            out.push(line.trim_end().to_string());
+            out.push(line.to_string());
             continue;
         }
 
@@ -266,7 +266,7 @@ pub fn convert_html_tables(lines: &[String]) -> Vec<String> {
             continue;
         }
 
-        out.push(line.trim_end().to_string());
+        out.push(line.to_string());
     }
 
     if !buf.is_empty() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -503,8 +503,7 @@ fn test_wrap_paragraph() {
 #[test]
 fn test_wrap_list_item() {
     let input = vec![
-        "- This bullet item is exceptionally long and must be wrapped to keep \
-prefix formatting intact."
+        r"- This bullet item is exceptionally long and must be wrapped to keep prefix formatting intact."
             .to_string(),
     ];
     let output = process_stream(&input);
@@ -516,6 +515,13 @@ prefix formatting intact."
     for line in output.iter().skip(1) {
         assert!(line.starts_with("  "));
     }
+}
+
+#[test]
+fn test_wrap_short_list_item() {
+    let input = vec!["- short item".to_string()];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -476,6 +476,10 @@ fn test_logical_type_table_output_matches() {
 }
 
 #[test]
+/// Verifies that reflowing the option table input produces the expected output.
+///
+/// Loads the input and expected output from external files and asserts that the
+/// `reflow_table` function transforms the input table to match the expected result.
 fn test_option_table_output_matches() {
     let input: Vec<String> = include_str!("data/option_table_input.txt")
         .lines()
@@ -489,6 +493,9 @@ fn test_option_table_output_matches() {
 }
 
 #[test]
+/// Tests that long paragraphs are wrapped at 80 columns by `process_stream`.
+///
+/// Ensures that a single long paragraph is split into multiple lines, each not exceeding 80 characters.
 fn test_wrap_paragraph() {
     let input = vec![
         "This is a very long paragraph that should be wrapped at eighty columns \
@@ -518,6 +525,17 @@ fn test_wrap_list_item() {
 }
 
 #[test]
+/// Verifies that short list items are not wrapped or altered by the stream processing logic.
+///
+/// Ensures that a single-line bullet list item remains unchanged after processing.
+///
+/// # Examples
+///
+/// ```
+/// let input = vec!["- short item".to_string()];
+/// let output = process_stream(&input);
+/// assert_eq!(output, input);
+/// ```
 fn test_wrap_short_list_item() {
     let input = vec!["- short item".to_string()];
     let output = process_stream(&input);
@@ -525,6 +543,9 @@ fn test_wrap_short_list_item() {
 }
 
 #[test]
+/// Tests that lines with hard line breaks (trailing spaces) are preserved after processing.
+///
+/// Ensures that the `process_stream` function does not remove or alter lines ending with Markdown hard line breaks.
 fn test_preserve_hard_line_breaks() {
     let input = vec![
         "Line one with break.  ".to_string(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -509,8 +509,23 @@ prefix formatting intact."
     ];
     let output = process_stream(&input);
     assert!(output.len() > 1);
+    assert!(output[0].starts_with("- "));
     for line in &output {
         assert!(line.len() <= 80);
-        assert!(line.starts_with("- "));
     }
+    for line in output.iter().skip(1) {
+        assert!(line.starts_with("  "));
+    }
+}
+
+#[test]
+fn test_preserve_hard_line_breaks() {
+    let input = vec![
+        "Line one with break.  ".to_string(),
+        "Line two follows.".to_string(),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output.len(), 2);
+    assert_eq!(output[0], "Line one with break.");
+    assert_eq!(output[1], "Line two follows.");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -487,3 +487,30 @@ fn test_option_table_output_matches() {
         .collect();
     assert_eq!(reflow_table(&input), expected);
 }
+
+#[test]
+fn test_wrap_paragraph() {
+    let input = vec![
+        "This is a very long paragraph that should be wrapped at eighty columns \
+         so it needs to contain enough words to exceed that limit."
+            .to_string(),
+    ];
+    let output = process_stream(&input);
+    assert!(output.len() > 1);
+    assert!(output.iter().all(|l| l.len() <= 80));
+}
+
+#[test]
+fn test_wrap_list_item() {
+    let input = vec![
+        "- This bullet item is exceptionally long and must be wrapped to keep \
+prefix formatting intact."
+            .to_string(),
+    ];
+    let output = process_stream(&input);
+    assert!(output.len() > 1);
+    for line in &output {
+        assert!(line.len() <= 80);
+        assert!(line.starts_with("- "));
+    }
+}


### PR DESCRIPTION
## Summary
- wrap paragraphs and list items at 80 columns
- describe new behaviour in README
- test paragraph and list item wrapping

## Testing
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `npx markdownlint-cli2 README.md`
- `nixie **/*.md`


------
https://chatgpt.com/codex/tasks/task_e_684e3e0cdbc08322b183dc70fb60e179

## Summary by Sourcery

Add automatic text wrapping for Markdown content after table reflow, including helper functions for wrapping logic, update documentation, and add tests to ensure wrapping at 80 columns.

New Features:
- Wrap Markdown paragraphs and list items at 80 columns

Enhancements:
- Introduce wrap_text and flush_paragraph helpers with BULLET_RE to implement wrapping while preserving indentation and list prefixes
- Apply text wrapping after table reflow in process_stream

Build:
- Add textwrap crate dependency

Documentation:
- Update README to document the new wrapping behavior

Tests:
- Add integration tests to verify paragraph and list item wrapping at 80 columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic wrapping of paragraphs and list items at 80 characters, improving readability while preserving Markdown formatting and indentation.
- **Documentation**
  - Updated the README to mention the new text wrapping feature and clarified handling of fenced code blocks and escaped pipes.
- **Tests**
  - Introduced integration tests to verify correct line wrapping for paragraphs, list items, and preservation of hard line breaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->