### PR TITLE
Add table detection tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,11 @@ pub fn process_stream(lines: &[String]) -> Vec<String> {
             continue;
         }
 
+        if in_table && !line.trim().is_empty() {
+            buf.push(line.trim_end().to_string());
+            continue;
+        }
+
         if !buf.is_empty() {
             if in_table {
                 out.extend(reflow_table(&buf));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -487,3 +487,29 @@ fn test_option_table_output_matches() {
         .collect();
     assert_eq!(reflow_table(&input), expected);
 }
+
+#[test]
+fn test_process_stream_logical_type_table() {
+    let input: Vec<String> = include_str!("data/logical_type_input.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = include_str!("data/logical_type_expected.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(process_stream(&input), expected);
+}
+
+#[test]
+fn test_process_stream_option_table() {
+    let input: Vec<String> = include_str!("data/option_table_input.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = include_str!("data/option_table_expected.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(process_stream(&input), expected);
+}


### PR DESCRIPTION
## Summary
- add new tests checking process_stream recognizes logical and option tables
- update table detection to treat non-empty continuation lines as table rows

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e42e6b8448322a90a98f52d641a25