### PR TITLE
Add lines_vec macro for test fixtures

### DIFF
--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -857,6 +857,13 @@ Good fixture and test organization mirrors good software design principles. As t
   quickly building `Vec<String>` from string slices. Use it in fixtures to
   avoid repetitive `.to_string()` calls.
 
+```rust
+#[fixture]
+fn example_table() -> Vec<String> {
+    lines_vec!("a", "b", "c")
+}
+```
+
 General testing advice, such as keeping tests small and focused and mocking external dependencies 17, also applies and is well-supported by `rstest`'s design.
 
 ## IX. `rstest` in Context: Comparison and Considerations

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -853,6 +853,9 @@ Good fixture and test organization mirrors good software design principles. As t
 - **Scope Management (**`#[once]` **vs. Regular):** Make conscious decisions about fixture lifetimes. Use `#[once]` sparingly, only for genuinely expensive, read-only, and safely static resources, being mindful of its "never dropped" nature.12 Prefer regular (per-test) fixtures for test isolation and proper resource management.
 - **Modularity:** Group related fixtures and tests into modules. This improves navigation and understanding of the test suite.
 - **Readability:** Utilize features like `#[from]` for renaming 12 and `#[default]` / `#[with]` for configurable fixtures to enhance the clarity of both fixture definitions and their usage in tests.
+- **Utility Macros:** The integration tests define a `lines_vec!` macro for
+  quickly building `Vec<String>` from string slices. Use it in fixtures to
+  avoid repetitive `.to_string()` calls.
 
 General testing advice, such as keeping tests small and focused and mocking external dependencies 17, also applies and is well-supported by `rstest`'s design.
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,7 @@
+/// Utility helpers shared across integration tests.
+
+macro_rules! lines_vec {
+    ($($line:expr),* $(,)?) => {
+        vec![$($line.to_string()),*]
+    };
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,6 +5,13 @@ use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;
 
+/// Builds a `Vec<String>` from string slices.
+macro_rules! lines_vec {
+    ($($line:expr),* $(,)?) => {
+        vec![$($line.to_string()),*]
+    };
+}
+
 #[fixture]
 /// Provides a sample Markdown table with broken rows for testing purposes.
 ///
@@ -17,10 +24,7 @@ use tempfile::tempdir;
 /// assert_eq!(table[0], "| A | B |    |");
 /// ```
 fn broken_table() -> Vec<String> {
-    vec![
-        "| A | B |    |".to_string(),
-        "| 1 | 2 |  | 3 | 4 |".to_string(),
-    ]
+    lines_vec!("| A | B |    |", "| 1 | 2 |  | 3 | 4 |",)
 }
 
 #[fixture]
@@ -35,113 +39,97 @@ fn broken_table() -> Vec<String> {
 /// assert_eq!(table, vec![String::from("| A | |"), String::from("| 1 | 2 | 3 |")]);
 /// ```
 fn malformed_table() -> Vec<String> {
-    vec!["| A | |".to_string(), "| 1 | 2 | 3 |".to_string()]
+    lines_vec!("| A | |", "| 1 | 2 | 3 |")
 }
 
 #[fixture]
 fn header_table() -> Vec<String> {
-    vec![
-        "| A | B |    |".to_string(),
-        "| --- | --- |".to_string(),
-        "| 1 | 2 |  | 3 | 4 |".to_string(),
-    ]
+    lines_vec!("| A | B |    |", "| --- | --- |", "| 1 | 2 |  | 3 | 4 |",)
 }
 
 #[fixture]
 fn escaped_pipe_table() -> Vec<String> {
-    vec![
-        "| X | Y |    |".to_string(),
-        "| a \\| b | 1 |  | 2 | 3 |".to_string(),
-    ]
+    lines_vec!("| X | Y |    |", "| a \\| b | 1 |  | 2 | 3 |",)
 }
 
 #[fixture]
 fn indented_table() -> Vec<String> {
-    vec![
-        "  | I | J |    |".to_string(),
-        "  | 1 | 2 |  | 3 | 4 |".to_string(),
-    ]
+    lines_vec!("  | I | J |    |", "  | 1 | 2 |  | 3 | 4 |",)
 }
 
 #[fixture]
 fn html_table() -> Vec<String> {
-    vec![
-        "<table>".to_string(),
-        "<tr><th>A</th><th>B</th></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</table>".to_string(),
-    ]
+    lines_vec!(
+        "<table>",
+        "<tr><th>A</th><th>B</th></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</table>",
+    )
 }
 
 #[fixture]
 fn html_table_with_attrs() -> Vec<String> {
-    vec![
-        "<table class=\"x\">".to_string(),
-        "<tr><th>A</th><th>B</th></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</table>".to_string(),
-    ]
+    lines_vec!(
+        "<table class=\"x\">",
+        "<tr><th>A</th><th>B</th></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</table>",
+    )
 }
 
 #[fixture]
 fn html_table_with_colspan() -> Vec<String> {
-    vec![
-        "<table>".to_string(),
-        "<tr><th colspan=\"2\">A</th></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</table>".to_string(),
-    ]
+    lines_vec!(
+        "<table>",
+        "<tr><th colspan=\"2\">A</th></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</table>",
+    )
 }
 
 #[fixture]
 fn html_table_no_header() -> Vec<String> {
-    vec![
-        "<table>".to_string(),
-        "<tr><td>A</td><td>B</td></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</table>".to_string(),
-    ]
+    lines_vec!(
+        "<table>",
+        "<tr><td>A</td><td>B</td></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</table>",
+    )
 }
 
 #[fixture]
 fn html_table_empty() -> Vec<String> {
-    vec!["<table></table>".to_string()]
+    lines_vec!("<table></table>")
 }
 
 #[fixture]
 fn html_table_unclosed() -> Vec<String> {
-    vec!["<table>".to_string(), "<tr><td>1</td></tr>".to_string()]
+    lines_vec!("<table>", "<tr><td>1</td></tr>")
 }
 
 #[fixture]
 fn html_table_uppercase() -> Vec<String> {
-    vec![
-        "<TABLE>".to_string(),
-        "<tr><th>A</th><th>B</th></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</TABLE>".to_string(),
-    ]
+    lines_vec!(
+        "<TABLE>",
+        "<tr><th>A</th><th>B</th></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</TABLE>",
+    )
 }
 
 #[fixture]
 fn html_table_mixed_case() -> Vec<String> {
-    vec![
-        "<TaBlE>".to_string(),
-        "<tr><th>A</th><th>B</th></tr>".to_string(),
-        "<tr><td>1</td><td>2</td></tr>".to_string(),
-        "</TaBlE>".to_string(),
-    ]
+    lines_vec!(
+        "<TaBlE>",
+        "<tr><th>A</th><th>B</th></tr>",
+        "<tr><td>1</td><td>2</td></tr>",
+        "</TaBlE>",
+    )
 }
 
 #[fixture]
 fn multiple_tables() -> Vec<String> {
-    vec![
-        "| A | B |".to_string(),
-        "| 1 | 22 |".to_string(),
-        String::new(),
-        "| X | Y |".to_string(),
-        "| 3 | 4 |".to_string(),
-    ]
+    lines_vec!("| A | B |", "| 1 | 22 |", "", "| X | Y |", "| 3 | 4 |",)
 }
 
 #[rstest]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,12 +5,8 @@ use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;
 
-/// Builds a `Vec<String>` from string slices.
-macro_rules! lines_vec {
-    ($($line:expr),* $(,)?) => {
-        vec![$($line.to_string()),*]
-    };
-}
+#[macro_use]
+mod common;
 
 #[fixture]
 /// Provides a sample Markdown table with broken rows for testing purposes.


### PR DESCRIPTION
## Summary
- introduce `lines_vec!` macro for building `Vec<String>` in tests
- refactor integration test fixtures to use the macro
- document the helper in the testing guide

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md` *(fails: many pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e8afbfcb883228d4566fe1aa0cd27

## Summary by Sourcery

Introduce a `lines_vec!` macro to simplify building `Vec<String>` in tests, refactor existing integration test fixtures to use the macro, and document its usage in the testing guide.

Enhancements:
- Add `lines_vec!` macro for concise `Vec<String>` construction in tests
- Refactor all integration test fixtures to replace manual `.to_string()`-wrapped vectors with `lines_vec!` calls

Documentation:
- Document the `lines_vec!` helper in the Rust testing guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated best practices to include guidance on using utility macros for constructing vectors of strings in tests, reducing repetitive code.
- **Refactor**
  - Simplified test fixtures by introducing a macro for easier creation of string vectors, improving code readability without changing test behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->