### PR TITLE
Add uppercase table test

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -14,8 +14,10 @@ use std::sync::LazyLock;
 
 use crate::is_fence;
 
+/// Matches the start of an HTML `<table>` tag, ignoring case.
 static TABLE_START_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^<table(?:\s|>|$)").unwrap());
+/// Matches the end of an HTML `</table>` tag, ignoring case.
 static TABLE_END_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)</table>").unwrap());
 
 /// Extracts the text content of a DOM node, collapsing consecutive

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -427,6 +427,12 @@ fn test_convert_html_table_with_attrs_basic() {
 }
 
 #[test]
+fn test_convert_html_table_uppercase() {
+    let expected = vec!["| A | B |", "| --- | --- |", "| 1 | 2 |"];
+    assert_eq!(convert_html_tables(&html_table_uppercase()), expected);
+}
+
+#[test]
 fn test_convert_html_table_with_colspan() {
     let expected = vec!["| A |", "| --- |", "| 1 | 2 |"];
     assert_eq!(convert_html_tables(&html_table_with_colspan()), expected);


### PR DESCRIPTION
## Summary
- test convert_html_tables with uppercase HTML tags

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e922375508322b950f19389fdd8d1

## Summary by Sourcery

Tests:
- Add test_convert_html_table_uppercase to verify conversion of uppercase HTML table tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new integration test to verify correct conversion of HTML tables with uppercase tags to Markdown format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->