### PR TITLE
Add missing table reflow test cases

### DIFF
--- a/tests/data/month_seconds_expected.txt
+++ b/tests/data/month_seconds_expected.txt
@@ -1,0 +1,14 @@
+| Month       | Seconds    |
+| ----------- | ---------: |
+| January     | 0          |
+| February    | 2,678,400  |
+| March       | 5,097,600  |
+| April       | 7,776,000  |
+| May         | 10,368,000 |
+| June        | 13,046,400 |
+| July        | 15,638,400 |
+| August      | 18,316,800 |
+| September   | 20,995,200 |
+| October     | 23,587,200 |
+| November    | 26,265,600 |
+| December    | 28,857,600 |

--- a/tests/data/month_seconds_input.txt
+++ b/tests/data/month_seconds_input.txt
@@ -1,0 +1,5 @@
+| Month | Seconds | |-----------|--------:| | January | 0 | | February |
+2,678,400 | | March | 5,097,600 | | April | 7,776,000 | | May | 10,368,000 | |
+June | 13,046,400 | | July | 15,638,400 | | August | 18,316,800 | | September |
+20,995,200 | | October | 23,587,200 | | November | 26,265,600 | | December |
+28,857,600 |

--- a/tests/data/offset_table_expected.txt
+++ b/tests/data/offset_table_expected.txt
@@ -1,0 +1,6 @@
+| Offset | Size (bytes) | Field               | Meaning                                                                          |
+| -----: | ------------ | ------------------- | -------------------------------------------------------------------------------- |
+| 0      | 4            | **Protocol ID**     | ASCII **"TRTP"** (0x54 52 54 50). Distinguishes Hotline from other TCP services. |
+| 4      | 4            | **Sub-protocol ID** | Application-specific tag (e.g. "CHAT", "FILE"). Can be 0.                        |
+| 8      | 2            | **Version**         | Currently **0x0001**. A server should refuse versions it does not understand.    |
+| 10     | 2            | **Sub-version**     | Application-defined; often used for build/revision numbers.                      |

--- a/tests/data/offset_table_input.txt
+++ b/tests/data/offset_table_input.txt
@@ -1,0 +1,9 @@
+| Offset | Size (bytes) | Field | Meaning | | -----: | ------------ |
+------------------- |
+\--------------------------------------------------------------------------------
+| | 0 | 4 | **Protocol ID** | ASCII **"TRTP"** (0x54 52 54 50). Distinguishes
+Hotline from other TCP services. | | 4 | 4 | **Sub-protocol ID** |
+Application-specific tag (e.g. "CHAT", "FILE"). Can be 0. | | 8 | 2 |
+**Version** | Currently **0x0001**. A server should refuse versions it does not
+understand. | | 10 | 2 | **Sub-version** | Application-defined; often used for
+build/revision numbers. |

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -493,6 +493,32 @@ fn test_option_table_output_matches() {
 }
 
 #[test]
+fn test_month_seconds_table_output_matches() {
+    let input: Vec<String> = include_str!("data/month_seconds_input.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = include_str!("data/month_seconds_expected.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(reflow_table(&input), expected);
+}
+
+#[test]
+fn test_offset_table_output_matches() {
+    let input: Vec<String> = include_str!("data/offset_table_input.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = include_str!("data/offset_table_expected.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(reflow_table(&input), expected);
+}
+
+#[test]
 /// Tests that `process_stream` correctly processes a complex Markdown table representing logical types by comparing its output to expected results loaded from a file.
 fn test_process_stream_logical_type_table() {
     let input: Vec<String> = include_str!("data/logical_type_input.txt")


### PR DESCRIPTION
## Summary
- add two malformed table fixtures and expected results
- handle escaped horizontal rules when parsing tables
- detect inline separator rows and format them correctly
- extend integration tests with new table cases

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e91bb15908322979c2ec23a0430dc

## Summary by Sourcery

Enhance table reflow to skip escaped horizontal rules, detect inline separator rows, and correctly format malformed tables, and add integration tests with fixtures for new cases.

Bug Fixes:
- Handle escaped horizontal rules and inline separator rows correctly when reflowing tables

Enhancements:
- Remove invalid default separators and leverage actual separator rows from input during table formatting

Tests:
- Add integration tests and fixtures for month_seconds and offset malformed table cases