### PR TITLE
Refactor reflow_table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,6 @@ static FENCE_RE: std::sync::LazyLock<Regex> =
 static BULLET_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)").unwrap());
 
-
 /// Returns `true` if the line is a fenced code block delimiter (e.g., three backticks or "~~~").
 ///
 /// # Examples

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1,0 +1,112 @@
+// Helper functions for reflowing markdown tables.
+//
+// These small utilities break down the steps of `reflow_table` so each
+// piece can be understood and tested independently.
+
+use crate::{format_separator_cells, split_cells};
+use regex::Regex;
+
+static SENTINEL_RE: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\|\s*\|\s*").unwrap());
+
+pub(crate) fn parse_rows(trimmed: &[String]) -> (Vec<Vec<String>>, bool) {
+    let raw = trimmed.join(" ");
+    let chunks: Vec<&str> = SENTINEL_RE.split(&raw).collect();
+    let split_within_line = chunks.len() > trimmed.len();
+    let mut cells = Vec::new();
+    for (idx, chunk) in chunks.iter().enumerate() {
+        let mut ch = (*chunk).to_string();
+        if idx != chunks.len() - 1 {
+            ch = ch.trim_end().to_string() + " |ROW_END|";
+        }
+        cells.extend(split_cells(&ch));
+    }
+    let mut rows = Vec::new();
+    let mut current = Vec::new();
+    for cell in cells {
+        if cell == "ROW_END" {
+            if !current.is_empty() {
+                rows.push(current);
+                current = Vec::new();
+            }
+        } else {
+            current.push(cell);
+        }
+    }
+    if !current.is_empty() {
+        rows.push(current);
+    }
+    (rows, split_within_line)
+}
+
+pub(crate) fn clean_rows(rows: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    let mut cleaned = Vec::new();
+    for mut row in rows {
+        row.retain(|c| !c.is_empty());
+        cleaned.push(row);
+    }
+    cleaned
+}
+
+pub(crate) fn calculate_widths(rows: &[Vec<String>], max_cols: usize) -> Vec<usize> {
+    let mut widths = vec![0; max_cols];
+    for row in rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(cell.len());
+        }
+    }
+    widths
+}
+
+pub(crate) fn format_rows(rows: Vec<Vec<String>>, widths: &[usize], indent: &str) -> Vec<String> {
+    rows.into_iter()
+        .map(|row| {
+            let padded: Vec<String> = row
+                .into_iter()
+                .enumerate()
+                .map(|(i, c)| format!("{:<width$}", c, width = widths[i]))
+                .collect();
+            format!("{}| {} |", indent, padded.join(" | "))
+        })
+        .collect()
+}
+
+pub(crate) fn insert_separator(
+    out: Vec<String>,
+    sep_cells: Option<Vec<String>>,
+    widths: &[usize],
+    indent: &str,
+) -> Vec<String> {
+    if let Some(mut cells) = sep_cells {
+        while cells.len() < widths.len() {
+            cells.push(String::new());
+        }
+        let sep_padded = format_separator_cells(widths, &cells);
+        let sep_line_out = format!("{}| {} |", indent, sep_padded.join(" | "));
+        if let Some(first) = out.first().cloned() {
+            let mut with_sep = vec![first, sep_line_out];
+            with_sep.extend(out.into_iter().skip(1));
+            return with_sep;
+        }
+        return vec![sep_line_out];
+    }
+    out
+}
+
+pub(crate) fn detect_separator(
+    sep_line: Option<&String>,
+    rows: &[Vec<String>],
+    max_cols: usize,
+) -> (Option<Vec<String>>, Option<usize>) {
+    let mut sep_cells: Option<Vec<String>> = sep_line.map(|l| split_cells(l));
+    let mut sep_row_idx: Option<usize> = None;
+    let sep_invalid = match sep_cells.as_ref() {
+        Some(c) => c.len() != max_cols,
+        None => true,
+    };
+    if sep_invalid && rows.len() > 1 && rows[1].iter().all(|c| crate::SEP_RE.is_match(c)) {
+        sep_cells = Some(rows[1].clone());
+        sep_row_idx = Some(1);
+    }
+    (sep_cells, sep_row_idx)
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -284,9 +284,13 @@ fn test_cli_wrap_option() {
         .write_stdin(format!("{input}\n"))
         .output()
         .unwrap();
+    
     assert!(output.status.success());
     let text = String::from_utf8_lossy(&output.stdout);
-    assert!(text.lines().count() > 1, "expected wrapped output on multiple lines");
+    assert!(
+        text.lines().count() > 1,
+        "expected wrapped output on multiple lines"
+    );
     assert!(text.lines().all(|l| l.len() <= 80));
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -284,7 +284,6 @@ fn test_cli_wrap_option() {
         .write_stdin(format!("{input}\n"))
         .output()
         .unwrap();
-    
     assert!(output.status.success());
     let text = String::from_utf8_lossy(&output.stdout);
     assert!(


### PR DESCRIPTION
## Summary
- refactor `reflow_table` by pulling parsing and formatting helpers into new `reflow.rs`
- expose `SEP_RE` for the helper module

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/html-table-support.md docs/rust-testing-with-rstest-fixtures.md` *(fails: 298 errors)*
- `nixie docs/html-table-support.md docs/rust-testing-with-rstest-fixtures.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_684e986fa8b88322ba8e0b81b5bcb7ed

## Summary by Sourcery

Refactor the `reflow_table` implementation by pulling out parsing and formatting helpers into a dedicated `reflow` module and expose the `SEP_RE` regex at the crate level.

Enhancements:
- Extract table parsing, cleaning, width calculation, formatting, and separator insertion logic into a new `reflow.rs` helper module
- Delegate core reflow steps in `lib.rs` to the new `reflow` module functions for cleaner code
- Expose `SEP_RE` as a `pub(crate)` static regex for helper modules