### PR TITLE
Fix clippy empty line after doc comment

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
 //! Utility helpers shared across integration tests.
+
 /// Build a `Vec<String>` from a list of string slices.
 ///
 /// This macro is primarily used in tests to reduce boilerplate when

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,4 @@
-/// Utility helpers shared across integration tests.
-
+//! Utility helpers shared across integration tests.
 macro_rules! lines_vec {
     ($($line:expr),* $(,)?) => {
         vec![$($line.to_string()),*]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,8 @@
 //! Utility helpers shared across integration tests.
+/// Build a `Vec<String>` from a list of string slices.
+///
+/// This macro is primarily used in tests to reduce boilerplate when
+/// constructing example tables or other collections of lines.
 macro_rules! lines_vec {
     ($($line:expr),* $(,)?) => {
         vec![$($line.to_string()),*]


### PR DESCRIPTION
## Summary
- use an inner doc comment in tests/common

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ea412cc308322a05966bd60ef1c72

## Summary by Sourcery

Bug Fixes:
- Replace the outer `///` doc comment with an inner `//!` comment in `tests/common/mod.rs` to fix the clippy warning about an empty line after a doc comment.