### PR TITLE
Add cross-platform release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,16 @@ jobs:
             ext: ""
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.3.0
         with:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Cache cross binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cross
+          key: cross-v0.2.1-${{ runner.os }}
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.1
       - name: Cache cargo registry
@@ -77,14 +82,16 @@ jobs:
         run: cross build --release --target ${{ matrix.target }}
       - name: Prepare artifact
         run: |
-          mkdir -p artifacts
+          mkdir -p artifacts/${{ matrix.os }}-${{ matrix.arch }}
           cp target/${{ matrix.target }}/release/${{ env.REPO_NAME }}${{ matrix.ext }} \
-            artifacts/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
+            artifacts/${{ matrix.os }}-${{ matrix.arch }}/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
+          sha256sum artifacts/${{ matrix.os }}-${{ matrix.arch }}/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }} > \
+            artifacts/${{ matrix.os }}-${{ matrix.arch }}/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}.sha256
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
-          path: artifacts/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
+          path: artifacts/${{ matrix.os }}-${{ matrix.arch }}
 
   release:
     needs: build
@@ -98,8 +105,10 @@ jobs:
         with:
           path: artifacts
       - run: |
-          for file in artifacts/${{ env.REPO_NAME }}-*; do
-            gh release upload "${{ github.ref_name }}" "$file"
+          for dir in artifacts/${{ env.REPO_NAME }}-*; do
+            for file in "$dir"/*; do
+              gh release upload "${{ github.ref_name }}" "$file"
+            done
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,49 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            ext: ""
+          - os: linux
+            arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            ext: ""
+          - os: windows
+            arch: x86_64
+            target: x86_64-pc-windows-msvc
+            ext: ".exe"
+          - os: windows
+            arch: aarch64
+            target: aarch64-pc-windows-msvc
+            ext: ".exe"
+          - os: macos
+            arch: x86_64
+            target: x86_64-apple-darwin
+            ext: ""
+          - os: macos
+            arch: aarch64
+            target: aarch64-apple-darwin
+            ext: ""
+          - os: freebsd
+            arch: x86_64
+            target: x86_64-unknown-freebsd
+            ext: ""
+          - os: freebsd
+            arch: aarch64
+            target: aarch64-unknown-freebsd
+            ext: ""
+          - os: openbsd
+            arch: x86_64
+            target: x86_64-unknown-openbsd
+            ext: ""
+          - os: openbsd
+            arch: aarch64
+            target: aarch64-unknown-openbsd
+            ext: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -18,6 +61,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -29,12 +74,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Build release binary
-        run: cargo build --release
+        run: cross build --release --target ${{ matrix.target }}
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifacts
+          cp target/${{ matrix.target }}/release/${{ env.REPO_NAME }}${{ matrix.ext }} \
+            artifacts/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.REPO_NAME }}
-          path: target/release/${{ env.REPO_NAME }}
+          name: ${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: artifacts/${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
 
   release:
     needs: build
@@ -44,10 +94,12 @@ jobs:
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          files: target/release/${{ env.REPO_NAME }}
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ env.REPO_NAME }}
-      - run: gh release upload "${{ github.ref_name }}" ${{ env.REPO_NAME }}
+          path: artifacts
+      - run: |
+          for file in artifacts/${{ env.REPO_NAME }}-*; do
+            gh release upload "${{ github.ref_name }}" "$file"
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           profile: minimal
           override: true
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.1
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,17 @@
+# Release Process
+
+This project publishes prebuilt binaries for multiple operating systems and architectures.
+
+The GitHub Actions workflow `release.yml` builds and uploads binaries for:
+
+- Linux (x86_64 and aarch64)
+- FreeBSD (x86_64 and aarch64)
+- macOS (x86_64 and aarch64)
+- Windows (x86_64 and aarch64)
+- OpenBSD (x86_64 and aarch64)
+
+Each binary is named using the pattern
+`mdtablefix-<os>-<arch>` with an `.exe` suffix on Windows.
+
+Binaries are uploaded as soon as they are built so they are available from the
+workflow run while other targets build.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,5 +13,21 @@ The GitHub Actions workflow `release.yml` builds and uploads binaries for:
 Each binary is named using the pattern
 `mdtablefix-<os>-<arch>` with an `.exe` suffix on Windows.
 
-Binaries are uploaded as soon as they are built so they are available from the
+Binaries are uploaded as soon as they are built, so they are available from the
 workflow run while other targets build.
+
+## Workflow details
+
+The `release.yml` workflow defines a matrix of operating system and
+architecture combinations. Each entry includes the target triple used by
+`cross` and a filename extension for Windows. During the build job `cross`
+compiles a release binary for every matrix row.
+
+`cross` is installed from a specific git tag to avoid unexpected behavior from
+its main branch. Each binary is placed in an `artifacts` directory using the
+naming pattern `mdtablefix-<os>-<arch>[.exe]`.
+
+After every build completes the artifact is uploaded so that the GitHub Actions
+interface provides it immediately. Once the matrix has finished the `release`
+job downloads all artifacts and uploads them to the GitHub release using
+`gh release upload`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,8 +1,10 @@
 # Release Process
 
-This project publishes prebuilt binaries for multiple operating systems and architectures.
+This project publishes prebuilt binaries for multiple operating systems and
+architectures.
 
-The GitHub Actions workflow `release.yml` builds and uploads binaries for:
+The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
+binaries for:
 
 - Linux (x86_64 and aarch64)
 - FreeBSD (x86_64 and aarch64)
@@ -10,24 +12,25 @@ The GitHub Actions workflow `release.yml` builds and uploads binaries for:
 - Windows (x86_64 and aarch64)
 - OpenBSD (x86_64 and aarch64)
 
-Each binary is named using the pattern
-`mdtablefix-<os>-<arch>` with an `.exe` suffix on Windows.
+Each binary is named using the pattern `mdtablefix-<os>-<arch>` with an `.exe`
+suffix on Windows.
 
 Binaries are uploaded as soon as they are built, so they are available from the
 workflow run while other targets build.
 
 ## Workflow details
 
-The `release.yml` workflow defines a matrix of operating system and
-architecture combinations. Each entry includes the target triple used by
-`cross` and a filename extension for Windows. During the build job `cross`
-compiles a release binary for every matrix row.
+The `release.yml` workflow defines a matrix of operating system and architecture
+combinations. Each entry includes the target triple used by `cross` and a
+filename extension for Windows. During the build job, `cross` compiles a release
+binary for every matrix row.
 
 `cross` is installed from a specific git tag to avoid unexpected behavior from
-its main branch. Each binary is placed in an `artifacts` directory using the
-naming pattern `mdtablefix-<os>-<arch>[.exe]`.
+its main branch. Each binary is placed in an `artifacts/<os>-<arch>` directory
+using the naming pattern `mdtablefix-<os>-<arch>[.exe]`. A SHA-256 checksum is
+written alongside each binary for download verification.
 
-After every build completes the artifact is uploaded so that the GitHub Actions
-interface provides it immediately. Once the matrix has finished the `release`
+After every build completes, the artifact is uploaded so that the GitHub Actions
+interface provides it immediately. Once the matrix has finished, the `release`
 job downloads all artifacts and uploads them to the GitHub release using
 `gh release upload`.


### PR DESCRIPTION
## Summary
- release x64/aarch64 binaries for linux, freebsd, macos, windows and openbsd
- upload each binary as soon as it builds
- document how releases are produced

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/release-process.md`


------
https://chatgpt.com/codex/tasks/task_e_684ed4dd83848322b20ee72a8d67d9fb

## Summary by Sourcery

Enable cross-platform release binary production by extending GitHub Actions with a build matrix, cross compilation, immediate artifact uploads, and accompanying documentation.

New Features:
- Publish prebuilt x86_64 and aarch64 binaries across Linux, FreeBSD, macOS, Windows, and OpenBSD.

Enhancements:
- Refactor the release workflow to use a matrix strategy and cross for cross-compilation.

CI:
- Install cross in CI, build each target via matrix, upload artifacts per OS-architecture, and batch upload them in the release job.

Documentation:
- Add docs/release-process.md to document the multi-platform release workflow and artifact naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release process now provides prebuilt binaries for multiple operating systems (Linux, Windows, macOS, FreeBSD, OpenBSD) and CPU architectures (x86_64, aarch64).
  - Multi-platform cross-compilation and individual platform-specific binary uploads have been introduced for improved release management.

- **Documentation**
  - Added documentation outlining the release process and supported platforms for prebuilt binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->