### PR TITLE
Fix HTML helper comment

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -177,8 +177,7 @@ fn table_lines_to_markdown(lines: &[String]) -> Vec<String> {
     out
 }
 
-/// Buffers a single line of HTML, updating nesting depth and emitting completed
-/// Buffers a line of HTML table markup and processes the buffer into Markdown when the table is fully closed.
+/// Appends HTML table lines, tracking `<table>` depth and converting them to Markdown when closed.
 ///
 /// Tracks the nesting depth of `<table>` tags, appending each line to the buffer. When all opened tables are closed (depth reaches zero), converts the buffered HTML table lines to Markdown and appends them to the output vector. Resets the buffer and updates the HTML state accordingly.
 fn push_html_line(


### PR DESCRIPTION
## Summary
- clarify comment above `push_html_line`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/**/*.md README.md` *(fails: fenced code blocks need languages)*
- `nixie docs/html-table-support.md docs/release-process.md docs/rust-testing-with-rstest-fixtures.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_68501e0ba230832282069603c416524a