### PR TITLE
Refactor conditionals into predicates

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -72,21 +72,14 @@ fn collect_text(handle: &Handle, out: &mut String, last_space: &mut bool) {
 /// Returns `true` if `handle` is an HTML element with the given tag name.
 fn is_element(handle: &Handle, tag: &str) -> bool {
     if let NodeData::Element { name, .. } = &handle.data {
-        name.local.as_ref() == tag
+        name.local.as_ref().eq_ignore_ascii_case(tag)
     } else {
         false
     }
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data {
-        let tag = name.local.as_ref();
-        tag == "td" || tag == "th"
-    } else {
-        false
-    }
-}
+fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {
@@ -352,6 +345,7 @@ mod tests {
         let body = html.children.borrow()[1].clone();
         let table = body.children.borrow()[0].clone();
         assert!(is_element(&table, "table"));
+        assert!(is_element(&table, "TABLE"));
         assert!(!is_element(&table, "tr"));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,12 @@ fn format_separator_cells(widths: &[usize], sep_cells: &[String]) -> Vec<String>
 }
 
 /// Returns the separator index if it lies within `len`.
-fn sep_index_within(idx: Option<usize>, len: usize) -> Option<usize> { idx.filter(|&i| i < len) }
+fn sep_index_within(idx: Option<usize>, len: usize) -> Option<usize> {
+    match idx {
+        Some(i) if i < len => Some(i),
+        _ => None,
+    }
+}
 
 /// Returns `true` if rows have mismatched lengths when not split within lines.
 fn rows_mismatched(rows: &[Vec<String>], split_within_line: bool) -> bool {
@@ -110,8 +115,8 @@ fn rows_mismatched(rows: &[Vec<String>], split_within_line: bool) -> bool {
     let Some(first_len) = rows.first().map(Vec::len) else {
         return false;
     };
-    rows[1..]
-        .iter()
+    rows.iter()
+        .skip(1)
         .any(|row| row.len() != first_len && !row.iter().all(|c| SEP_RE.is_match(c)))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,22 @@ fn format_separator_cells(widths: &[usize], sep_cells: &[String]) -> Vec<String>
         .collect()
 }
 
+/// Returns the separator index if it lies within `len`.
+fn sep_index_within(idx: Option<usize>, len: usize) -> Option<usize> { idx.filter(|&i| i < len) }
+
+/// Returns `true` if rows have mismatched lengths when not split within lines.
+fn rows_mismatched(rows: &[Vec<String>], split_within_line: bool) -> bool {
+    if split_within_line {
+        return false;
+    }
+    let Some(first_len) = rows.first().map(Vec::len) else {
+        return false;
+    };
+    rows[1..]
+        .iter()
+        .any(|row| row.len() != first_len && !row.iter().all(|c| SEP_RE.is_match(c)))
+}
+
 /// Reflow a broken markdown table.
 ///
 /// # Panics
@@ -149,19 +165,12 @@ pub fn reflow_table(lines: &[String]) -> Vec<String> {
     let cleaned = reflow::clean_rows(rows);
 
     let mut output_rows = cleaned.clone();
-    if let Some(idx) = sep_row_idx
-        && idx < output_rows.len()
-    {
+    if let Some(idx) = sep_index_within(sep_row_idx, output_rows.len()) {
         output_rows.remove(idx);
     }
 
-    if !split_within_line && let Some(first_len) = cleaned.first().map(Vec::len) {
-        let mismatch = cleaned[1..]
-            .iter()
-            .any(|row| row.len() != first_len && !row.iter().all(|c| SEP_RE.is_match(c)));
-        if mismatch {
-            return lines.to_vec();
-        }
+    if rows_mismatched(&cleaned, split_within_line) {
+        return lines.to_vec();
     }
 
     let widths = reflow::calculate_widths(&cleaned, max_cols);
@@ -509,4 +518,40 @@ pub fn rewrite_no_wrap(path: &Path) -> std::io::Result<()> {
     let lines: Vec<String> = text.lines().map(str::to_string).collect();
     let fixed = process_stream_no_wrap(&lines);
     fs::write(path, fixed.join("\n") + "\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sep_index_within_bounds() {
+        assert_eq!(sep_index_within(Some(1), 3), Some(1));
+        assert_eq!(sep_index_within(Some(3), 3), None);
+        assert_eq!(sep_index_within(None, 3), None);
+    }
+
+    #[test]
+    fn detect_row_mismatch() {
+        let rows = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["1".to_string(), "2".to_string()],
+        ];
+        assert!(!rows_mismatched(&rows, false));
+
+        let mismatch = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["1".to_string()],
+        ];
+        assert!(rows_mismatched(&mismatch, false));
+
+        let with_sep = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["---".to_string(), "---".to_string()],
+            vec!["1".to_string(), "2".to_string()],
+        ];
+        assert!(!rows_mismatched(&with_sep, false));
+
+        assert!(!rows_mismatched(&mismatch, true));
+    }
 }


### PR DESCRIPTION
## Summary
- move complex `if let` logic into small predicate helpers
- add tests and docs for new helpers

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685029b693d883229b56ca29caee83ef

## Summary by Sourcery

Refactor conditional checks into dedicated predicate functions to simplify HTML and markdown table handling

Enhancements:
- Extract common element and table-cell detection into is_element and is_table_cell helpers
- Introduce sep_index_within and rows_mismatched predicates for separator indexing and row consistency checks
- Replace inline conditional logic in HTML parsing and table reflow with the new predicate helpers

Documentation:
- Add doc comments for all new predicate helpers

Tests:
- Add unit tests for is_element, is_table_cell, sep_index_within, and rows_mismatched functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal logic for HTML element detection and table processing, resulting in cleaner and more maintainable code.
- **Tests**
	- Added new unit tests to verify correct behaviour of HTML element detection and table row consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->