### PR TITLE
Add --renumber option to mdtablefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ cargo install --path .
 ## Command-line usage
 
 ```bash
-mdtablefix [--wrap] [--in-place] [FILE...]
+mdtablefix [--wrap] [--renumber] [--in-place] [FILE...]
 ```
 
 - With file paths provided, the corrected tables are printed to stdout.
 - Use `--wrap` to also reflow paragraphs and list items to 80 columns.
+- Use `--renumber` to rewrite ordered lists with sequential numbering.
 - Use `--in-place` to overwrite files.
 - If no files are supplied, input is read from stdin and results are written to stdout.
 


### PR DESCRIPTION
## Summary
- add `--renumber` flag to CLI
- implement `renumber_lists` helper
- test renumbering both via library and CLI
- document the new option
- add extra tests for nested and multi-paragraph lists

## Testing
- `cargo +nightly-2025-06-10 fmt --all`
- `cargo +nightly-2025-06-10 clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo +nightly-2025-06-10 test`
- `markdownlint README.md docs/html-table-support.md docs/release-process.md docs/rust-testing-with-rstest-fixtures.md src/**/*.rs tests/**/*.rs`
- `nixie README.md docs/html-table-support.md docs/release-process.md docs/rust-testing-with-rstest-fixtures.md`

------
https://chatgpt.com/codex/tasks/task_e_68737ddcc5748322a24a6922938f2116

## Summary by Sourcery

Introduce ordered list renumbering capability via a new --renumber flag, backed by a renumber_lists helper, with updated command processing, tests, and documentation.

New Features:
- Add --renumber CLI option to sequentially renumber ordered Markdown lists
- Implement renumber_lists helper to renumber list items by indentation level across code fences

Enhancements:
- Extend process_lines and rewrite_path to apply renumbering when the flag is used

Documentation:
- Update README to document the new --renumber option

Tests:
- Add integration tests for basic renumbering, fenced code blocks, nested lists, multi-paragraph items
- Add CLI test to verify --renumber flag functionality