### PR TITLE
Add thematic break formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--in-place] [FILE...]
 - With file paths provided, the corrected tables are printed to stdout.
 - Use `--wrap` to also reflow paragraphs and list items to 80 columns.
 - Use `--renumber` to rewrite ordered lists with sequential numbering.
-- Use `--breaks` to normalize thematic breaks to 70 underscores.
+- Use `--breaks` to normalize thematic breaks to a line of 70 underscores
+  (configurable via the `THEMATIC_BREAK_LEN` constant).
 - Use `--in-place` to overwrite files.
 - If no files are supplied, input is read from stdin and results are written to stdout.
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ cargo install --path .
 ## Command-line usage
 
 ```bash
-mdtablefix [--wrap] [--renumber] [--in-place] [FILE...]
+mdtablefix [--wrap] [--renumber] [--breaks] [--in-place] [FILE...]
 ```
 
 - With file paths provided, the corrected tables are printed to stdout.
 - Use `--wrap` to also reflow paragraphs and list items to 80 columns.
 - Use `--renumber` to rewrite ordered lists with sequential numbering.
+- Use `--breaks` to normalize thematic breaks to 70 underscores.
 - Use `--in-place` to overwrite files.
 - If no files are supplied, input is read from stdin and results are written to stdout.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,10 @@ static BULLET_RE: std::sync::LazyLock<Regex> =
 static NUMBERED_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").unwrap());
 
+/// Width of a normalised thematic break.
+/// The width used when rewriting thematic breaks.
+pub const THEMATIC_BREAK_LEN: usize = 70;
+
 static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$").unwrap()
 });
@@ -558,7 +562,7 @@ pub fn format_breaks(lines: &[String]) -> Vec<String> {
         }
 
         if !in_code && THEMATIC_BREAK_RE.is_match(line.trim_end()) {
-            out.push("_".repeat(70));
+            out.push("_".repeat(THEMATIC_BREAK_LEN));
         } else {
             out.push(line.clone());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,10 @@ static BULLET_RE: std::sync::LazyLock<Regex> =
 static NUMBERED_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").unwrap());
 
+static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$").unwrap()
+});
+
 /// Returns `true` if the line is a fenced code block delimiter (e.g., three backticks or "~~~").
 ///
 /// # Examples
@@ -531,6 +535,33 @@ pub fn renumber_lists(lines: &[String]) -> Vec<String> {
             counters.pop();
         }
         out.push(line.clone());
+    }
+
+    out
+}
+
+#[must_use]
+/// Reformat thematic breaks as 70 underscores.
+///
+/// Thematic breaks are lines composed of three or more matching `-`, `_`, or
+/// `*` characters (optionally separated by spaces or tabs) with up to three
+/// leading spaces. Lines inside fenced code blocks are ignored.
+pub fn format_breaks(lines: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(lines.len());
+    let mut in_code = false;
+
+    for line in lines {
+        if FENCE_RE.is_match(line) {
+            in_code = !in_code;
+            out.push(line.clone());
+            continue;
+        }
+
+        if !in_code && THEMATIC_BREAK_RE.is_match(line.trim_end()) {
+            out.push("_".repeat(70));
+        } else {
+            out.push(line.clone());
+        }
     }
 
     out

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use clap::Parser;
-use mdtablefix::{process_stream, process_stream_no_wrap, renumber_lists};
+use mdtablefix::{format_breaks, process_stream, process_stream_no_wrap, renumber_lists};
 
 #[derive(Parser)]
 #[command(about = "Reflow broken markdown tables")]
@@ -13,17 +13,26 @@ struct Cli {
     /// Rewrite files in place
     #[arg(long = "in-place", requires = "files")]
     in_place: bool,
+    #[command(flatten)]
+    opts: FormatOpts,
+    /// Markdown files to fix
+    files: Vec<PathBuf>,
+}
+
+#[derive(clap::Args)]
+struct FormatOpts {
     /// Wrap paragraphs and list items to 80 columns
     #[arg(long = "wrap")]
     wrap: bool,
     /// Renumber ordered list items
     #[arg(long = "renumber")]
     renumber: bool,
-    /// Markdown files to fix
-    files: Vec<PathBuf>,
+    /// Reformat thematic breaks as underscores
+    #[arg(long = "breaks")]
+    breaks: bool,
 }
 
-fn process_lines(lines: &[String], wrap: bool, renumber: bool) -> Vec<String> {
+fn process_lines(lines: &[String], wrap: bool, renumber: bool, breaks: bool) -> Vec<String> {
     let mut out = if wrap {
         process_stream(lines)
     } else {
@@ -32,13 +41,16 @@ fn process_lines(lines: &[String], wrap: bool, renumber: bool) -> Vec<String> {
     if renumber {
         out = renumber_lists(&out);
     }
+    if breaks {
+        out = format_breaks(&out);
+    }
     out
 }
 
-fn rewrite_path(path: &Path, wrap: bool, renumber: bool) -> std::io::Result<()> {
+fn rewrite_path(path: &Path, wrap: bool, renumber: bool, breaks: bool) -> std::io::Result<()> {
     let content = fs::read_to_string(path)?;
     let lines: Vec<String> = content.lines().map(str::to_string).collect();
-    let fixed = process_lines(&lines, wrap, renumber);
+    let fixed = process_lines(&lines, wrap, renumber, breaks);
     fs::write(path, fixed.join("\n") + "\n")
 }
 
@@ -72,18 +84,18 @@ fn main() -> anyhow::Result<()> {
         let mut input = String::new();
         io::stdin().read_to_string(&mut input)?;
         let lines: Vec<String> = input.lines().map(str::to_string).collect();
-        let fixed = process_lines(&lines, cli.wrap, cli.renumber);
+        let fixed = process_lines(&lines, cli.opts.wrap, cli.opts.renumber, cli.opts.breaks);
         println!("{}", fixed.join("\n"));
         return Ok(());
     }
 
     for path in cli.files {
         if cli.in_place {
-            rewrite_path(&path, cli.wrap, cli.renumber)?;
+            rewrite_path(&path, cli.opts.wrap, cli.opts.renumber, cli.opts.breaks)?;
         } else {
             let content = fs::read_to_string(&path)?;
             let lines: Vec<String> = content.lines().map(str::to_string).collect();
-            let fixed = process_lines(&lines, cli.wrap, cli.renumber);
+            let fixed = process_lines(&lines, cli.opts.wrap, cli.opts.renumber, cli.opts.breaks);
             println!("{}", fixed.join("\n"));
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::Write};
 
 use assert_cmd::Command;
 use mdtablefix::{
+    THEMATIC_BREAK_LEN,
     convert_html_tables,
     format_breaks,
     process_stream,
@@ -819,7 +820,7 @@ fn test_format_breaks_basic() {
         .collect::<Vec<_>>();
     let mut expected = Vec::new();
     expected.push("foo".to_string());
-    expected.push("_".repeat(70));
+    expected.push("_".repeat(THEMATIC_BREAK_LEN));
     expected.push("bar".to_string());
     assert_eq!(format_breaks(&input), expected);
 }
@@ -834,6 +835,35 @@ fn test_format_breaks_ignores_code() {
 }
 
 #[test]
+fn test_format_breaks_mixed_chars() {
+    let input = vec!["-*-*-"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(format_breaks(&input), input);
+}
+
+#[test]
+fn test_format_breaks_with_spaces_and_indent() {
+    let input = vec!["  -  -  -  "]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let expected = vec!["_".repeat(THEMATIC_BREAK_LEN)];
+    assert_eq!(format_breaks(&input), expected);
+}
+
+#[test]
+fn test_format_breaks_with_tabs_and_underscores() {
+    let input = vec!["\t_\t_\t_\t"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let expected = vec!["_".repeat(THEMATIC_BREAK_LEN)];
+    assert_eq!(format_breaks(&input), expected);
+}
+
+#[test]
 fn test_cli_breaks_option() {
     let output = Command::cargo_bin("mdtablefix")
         .unwrap()
@@ -844,6 +874,6 @@ fn test_cli_breaks_option() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        format!("{}\n", "_".repeat(70))
+        format!("{}\n", "_".repeat(THEMATIC_BREAK_LEN))
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -818,10 +818,11 @@ fn test_format_breaks_basic() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let mut expected = Vec::new();
-    expected.push("foo".to_string());
-    expected.push("_".repeat(THEMATIC_BREAK_LEN));
-    expected.push("bar".to_string());
+    let expected = vec![
+        "foo".to_string(),
+        "_".repeat(THEMATIC_BREAK_LEN),
+        "bar".to_string(),
+    ];
     assert_eq!(format_breaks(&input), expected);
 }
 


### PR DESCRIPTION
## Summary
- introduce a `--breaks` option in the CLI
- implement `format_breaks` to normalise thematic breaks
- update README with usage of new option
- extend tests for break formatting and CLI support

## Testing
- `cargo +nightly-2025-06-10 fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint *.md docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_6873b23756788322b41601109565b38f

## Summary by Sourcery

Introduce a --breaks option to the CLI and implement logic to normalize thematic break lines as 70 underscores, integrating it into the processing pipeline and documenting and testing the new feature.

New Features:
- Add --breaks CLI option to normalize thematic breaks to 70 underscores

Enhancements:
- Implement format_breaks function to detect and replace thematic break lines outside fenced code blocks
- Integrate breaks formatting into the processing pipeline for both stdin and file inputs

Documentation:
- Update README to document the new --breaks option usage

Tests:
- Add unit tests for basic break formatting and code block exemption and an integration test for the CLI breaks option