### PR TITLE
Improve wrapping logic for hyphenated words

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 `mdtablefix` unb0rks and reflows Markdown tables so that each column has a
 uniform width. It can wrap paragraphs and list items to 80 columns when the
-`--wrap` option is used. The tool ignores fenced code blocks and respects
-escaped pipes (`\|`), making it safe for mixed content.
+`--wrap` option is used. Hyphenated words are treated as single units during
+wrapping, so `very-long-word` moves to the next line rather than splitting at
+the hyphen. The tool ignores fenced code blocks and respects escaped pipes
+(`\|`), making it safe for mixed content.
 
 ## Installation
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -750,3 +750,16 @@ fn test_renumber_mult_paragraph_items() {
 
     assert_eq!(renumber_lists(&input), expected);
 }
+
+#[test]
+fn test_wrap_hyphenated_word() {
+    let line = format!("{} extremely-very-long-word end", "A".repeat(60));
+    let output = process_stream(&[line]);
+    assert_eq!(
+        output,
+        vec![
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+            "extremely-very-long-word end".to_string(),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- keep hyphenated words intact during wrapping using `NoHyphenation`
- update README to mention the new behaviour
- add unit test for `wrap_text`
- add integration test for hyphenated wrapping

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/html-table-support.md docs/release-process.md docs/rust-testing-with-rstest-fixtures.md`

------
https://chatgpt.com/codex/tasks/task_e_6873ae41e18c8322950cb5e37d57086b