### PR TITLE
Optimize thematic break generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,9 @@ static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(
     Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$").unwrap()
 });
 
+static THEMATIC_BREAK_LINE: std::sync::LazyLock<String> =
+    std::sync::LazyLock::new(|| "_".repeat(THEMATIC_BREAK_LEN));
+
 /// Returns `true` if the line is a fenced code block delimiter (e.g., three backticks or "~~~").
 ///
 /// # Examples
@@ -567,7 +570,7 @@ pub fn format_breaks(lines: &[String]) -> Vec<String> {
         }
 
         if !in_code && THEMATIC_BREAK_RE.is_match(line.trim_end()) {
-            out.push("_".repeat(THEMATIC_BREAK_LEN));
+            out.push(THEMATIC_BREAK_LINE.clone());
         } else {
             out.push(line.clone());
         }


### PR DESCRIPTION
## Summary
- initialize a lazily-evaluated `THEMATIC_BREAK_LINE` string
- reuse that static string when normalizing thematic breaks

## Testing
- `markdownlint README.md docs/*.md`
- `nixie README.md docs/*.md`
- `cargo +nightly-2025-06-10 fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68743155736c83229ba3a102b7264737