### PR TITLE
Refactor list renumbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 uniform width. It can wrap paragraphs and list items to 80 columns when the
 `--wrap` option is used. Hyphenated words are treated as single units during
 wrapping, so `very-long-word` moves to the next line rather than splitting at
-the hyphen. The tool ignores fenced code blocks and respects escaped pipes
-(`\|`), making it safe for mixed content.
+the hyphen. The tool ignores fenced code blocks and respects escaped pipes (`\|
+`), making it safe for mixed content.
 
 ## Installation
 
@@ -28,10 +28,13 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--in-place] [FILE...]
 - With file paths provided, the corrected tables are printed to stdout.
 - Use `--wrap` to also reflow paragraphs and list items to 80 columns.
 - Use `--renumber` to rewrite ordered lists with sequential numbering.
+- Tabs are interpreted as four spaces when counting indentation for
+  `--renumber`.
 - Use `--breaks` to normalize thematic breaks to a line of 70 underscores
   (configurable via the `THEMATIC_BREAK_LEN` constant).
 - Use `--in-place` to overwrite files.
-- If no files are supplied, input is read from stdin and results are written to stdout.
+- If no files are supplied, input is read from stdin and results are written
+  to stdout.
 
 ### Example
 
@@ -76,14 +79,14 @@ fn main() -> std::io::Result<()> {
 
 ## HTML table support
 
-`mdtablefix` recognises simple `<table>` elements embedded in Markdown.
-Before the main table reflow runs these HTML tables are converted to Markdown in
-a preprocessing stage handled by `convert_html_tables`.
+`mdtablefix` recognises simple `<table>` elements embedded in Markdown. Before
+the main table reflow runs these HTML tables are converted to Markdown in a
+preprocessing stage handled by `convert_html_tables`.
 
 Only basic tables composed of `<tr>`, `<th>` and `<td>` tags are detected, and
 attributes or tag casing do not matter. After conversion the regular reflow
-logic aligns them alongside Markdown tables. See
-[`docs/html-table-support.md`](docs/html-table-support.md) for details.
+logic aligns them alongside Markdown tables. See [`docs/html-table-support.md`]
+(docs/html-table-support.md) for details.
 
 ## Testing
 
@@ -92,5 +95,5 @@ is organised using the [`rstest`](https://crates.io/crates/rstest) crate.
 
 ## License
 
-This project is licensed under the ISC license.
-See the [LICENSE](LICENSE) file for details.
+This project is licensed under the ISC license. See the [LICENSE](LICENSE) file
+for details.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -840,6 +840,21 @@ fn test_renumber_nested_lists() {
 }
 
 #[test]
+fn test_renumber_tabs_in_indent() {
+    let input = vec!["1. first", "\t1. sub first", "\t5. sub second", "2. second"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    let expected = vec!["1. first", "\t1. sub first", "\t2. sub second", "2. second"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
 fn test_renumber_mult_paragraph_items() {
     let input = vec!["1. first", "", "    still first paragraph", "", "2. second"]
         .into_iter()


### PR DESCRIPTION
## Summary
- extract `parse_numbered` helper for numbered line parsing
- simplify `renumber_lists` using a stack and map

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687555d1e5308322a8e4f5878f0cd6cb

## Summary by Sourcery

Refactor list renumbering by extracting parsing and indentation helpers, simplify the renumber_lists implementation with a stack-based counter, treat tabs as four spaces for indentation, update documentation, and add a test for tab-indented lists

Enhancements:
- Extract parse_numbered, indent_len, and drop_deeper helper functions to modularise list renumbering
- Simplify renumber_lists by leveraging the new helpers and a stack-based counter
- Treat tabs as four spaces when measuring indentation for ordered lists

Documentation:
- Update README to document tab-based indentation handling and fix line-wrapping formatting

Tests:
- Add integration test for renumbering lists with tab-indented items