### PR TITLE
Improve conditional readability with predicates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ use regex::Regex;
 /// let cells = split_cells(line);
 /// assert_eq!(cells, vec!["cell1", "cell2", "cell3"]);
 /// ```
+fn next_is_pipe(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> bool {
+    chars.peek() == Some(&'|')
+}
 #[must_use]
 pub fn split_cells(line: &str) -> Vec<String> {
     let mut s = line.trim();
@@ -46,9 +49,7 @@ pub fn split_cells(line: &str) -> Vec<String> {
     let mut chars = s.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch == '\\' {
-            if let Some(&next) = chars.peek()
-                && next == '|'
-            {
+            if next_is_pipe(&mut chars) {
                 // `\|` escapes the pipe so it becomes part of the cell
                 chars.next();
                 current.push('|');

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -114,7 +114,7 @@ pub(crate) fn detect_separator(
     let mut sep_row_idx: Option<usize> = None;
 
     let sep_invalid = invalid_separator(sep_cells.as_ref(), max_cols);
-    if sep_invalid && second_row_is_separator(rows) {
+    if should_use_second_row_as_separator(sep_invalid, rows) {
         sep_cells = Some(rows[1].clone());
         sep_row_idx = Some(1);
     }
@@ -127,6 +127,10 @@ fn invalid_separator(sep_cells: Option<&Vec<String>>, max_cols: usize) -> bool {
         Some(c) => c.len() != max_cols,
         None => true,
     }
+}
+
+fn should_use_second_row_as_separator(sep_invalid: bool, rows: &[Vec<String>]) -> bool {
+    sep_invalid && second_row_is_separator(rows)
 }
 
 fn second_row_is_separator(rows: &[Vec<String>]) -> bool {


### PR DESCRIPTION
## Summary
- refactor table cell parser to use `next_is_pipe`
- filter ignored HTML tags with `is_ignored_tag`
- detect `<strong>`/`<b>` tags via `is_bold_tag`
- clarify separator validation using `should_use_second_row_as_separator`

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6875754902248322a73b518208513235

## Summary by Sourcery

Improve conditional readability by extracting and applying predicate helper functions across HTML parsing, cell splitting, and table separator detection

Enhancements:
- Introduce is_ignored_tag helper and replace inline checks in HTML text collection
- Extract is_bold_tag helper and simplify bold tag detection in contains_strong
- Add next_is_pipe predicate to clarify escape logic in split_cells
- Add should_use_second_row_as_separator helper to clarify separator validation in detect_separator