### PR TITLE
Improve indentation handling in renumber_lists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,8 +678,13 @@ pub fn renumber_lists(lines: &[String]) -> Vec<String> {
             continue;
         }
 
-        let indent_part: String = line.chars().take_while(|c| c.is_whitespace()).collect();
-        let indent = indent_len(&indent_part);
+        // Avoid allocating when just measuring indentation
+        let indent_end = line
+            .char_indices()
+            .find(|&(_, c)| !c.is_whitespace())
+            .map_or_else(|| line.len(), |(i, _)| i);
+        let indent_str = &line[..indent_end];
+        let indent = indent_len(indent_str);
         drop_deeper(indent, &mut counters);
         out.push(line.clone());
     }


### PR DESCRIPTION
## Summary
- optimise `renumber_lists` by slicing the leading whitespace instead of allocating a `String`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68763897bcc883229487e1c8e853443b

## Summary by Sourcery

Enhancements:
- Slice leading whitespace to compute indentation length instead of collecting chars into a String