### PR TITLE
Add footnote wrap handling

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -717,6 +717,17 @@ fn test_wrap_multiple_inline_code_spans() {
 }
 
 #[test]
+fn test_wrap_footnote_multiline() {
+    let input = vec![
+        "[^note]: This footnote is sufficiently long to require wrapping across multiple lines so \
+         we can verify indentation."
+            .to_string(),
+    ];
+    let output = process_stream(&input);
+    common::assert_wrapped_list_item(&output, "[^note]: ", 2);
+}
+
+#[test]
 /// Verifies that short list items are not wrapped or altered by the stream processing logic.
 ///
 /// Ensures that a single-line bullet list item remains unchanged after processing.


### PR DESCRIPTION
## Summary
- support wrapping footnote definitions with proper indentation
- verify multi-line footnotes wrap correctly

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6876cdda278c83228287b9522ef84593