### PR TITLE
Add hyphenated word wrap test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,9 +763,9 @@ mod tests {
     fn wrap_text_does_not_insert_spaces_in_hyphenated_words() {
         let input = vec![
             concat!(
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt \
-                 elit-sed ",
-                "fermentum congue. Vivamus dictum nulla sed consectetur volutpat."
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt ",
+                "elit-sed fermentum congue. Vivamus dictum nulla sed consectetur ",
+                "volutpat."
             )
             .to_string(),
         ];


### PR DESCRIPTION
## Summary
- add a regression test covering hyphenated words when wrapping
- remove redundant assertion checking for stray space after hyphen
- avoid compile issues by building the input string with `concat!`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6875fac6b5608322a057d88ff845287f

## Summary by Sourcery

Add a regression test to ensure wrap_text does not insert spaces in hyphenated words when wrapping.

Enhancements:
- Construct the long input string using concat! macro to avoid compile issues with string literals

Tests:
- Add wrap_text_does_not_insert_spaces_in_hyphenated_words test covering hyphenated word wrap behavior

Chores:
- Remove redundant assertion that checked for stray spaces after hyphens