### PR TITLE
Add renumber list table test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -896,6 +896,21 @@ fn test_renumber_mult_paragraph_items() {
 }
 
 #[test]
+fn test_renumber_table_in_list() {
+    let input = vec!["1. first", "    | A | B |", "    | 1 | 2 |", "5. second"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    let expected = vec!["1. first", "    | A | B |", "    | 1 | 2 |", "2. second"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
 fn test_format_breaks_basic() {
     let input = vec!["foo", "***", "bar"]
         .into_iter()


### PR DESCRIPTION
## Summary
- ensure tables inside ordered lists don't reset indent counters

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687805a932388322b46e26700d9ad697

## Summary by Sourcery

Tests:
- Add test_renumber_table_in_list to ensure renumber_lists continues list numbering across tables in list items