### PR TITLE
Add blockquote wrapping

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -51,3 +51,12 @@ pub fn assert_wrapped_list_item(output: &[String], prefix: &str, expected: usize
     }
     assert!(open.is_none(), "unclosed code span");
 }
+
+/// Assert that every line in a blockquote starts with the given prefix and is at most 80
+/// characters.
+pub fn assert_wrapped_blockquote(output: &[String], prefix: &str, expected: usize) {
+    assert!(!output.is_empty(), "output slice is empty");
+    assert_eq!(output.len(), expected);
+    assert!(output.iter().all(|l| l.starts_with(prefix)));
+    assert!(output.iter().all(|l| l.len() <= 80));
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -761,6 +761,24 @@ fn test_wrap_short_list_item() {
 }
 
 #[test]
+fn test_wrap_blockquote() {
+    let input = vec![
+        "> **Deprecated**: A :class:`WebSocketRouter` and its `add_route` API should be used to \
+         instantiate resources."
+            .to_string(),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(
+        output,
+        vec![
+            "> **Deprecated**: A :class:`WebSocketRouter` and its `add_route` API should be"
+                .to_string(),
+            "> used to instantiate resources.".to_string(),
+        ]
+    );
+}
+
+#[test]
 /// Tests that lines with hard line breaks (trailing spaces) are preserved after processing.
 ///
 /// Ensures that the `process_stream` function does not remove or alter lines ending with Markdown

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -779,6 +779,72 @@ fn test_wrap_blockquote() {
 }
 
 #[test]
+fn test_wrap_blockquote_nested() {
+    let input = vec![
+        concat!(
+            "> > This nested quote contains enough text to require wrapping so that we ",
+            "can verify multi-level handling."
+        )
+        .to_string(),
+    ];
+    let output = process_stream(&input);
+    common::assert_wrapped_blockquote(&output, "> > ", 2);
+    let joined = output
+        .iter()
+        .map(|l| l.trim_start_matches("> > "))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(joined, input[0].trim_start_matches("> > "));
+}
+
+#[test]
+fn test_wrap_blockquote_with_blank_lines() {
+    let input = vec![
+        concat!(
+            "> The first paragraph in this quote is deliberately long enough to wrap ",
+            "across multiple lines so"
+        )
+        .to_string(),
+        "> demonstrate the behaviour.".to_string(),
+        ">".to_string(),
+        concat!(
+            "> The second paragraph is also extended to trigger wrapping in order to ",
+            "ensure blank lines"
+        )
+        .to_string(),
+        "> are preserved correctly.".to_string(),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output[3], ">");
+    common::assert_wrapped_blockquote(&output[..3], "> ", 3);
+    common::assert_wrapped_blockquote(&output[4..], "> ", 3);
+}
+
+#[test]
+fn test_wrap_blockquote_extra_whitespace() {
+    let input = vec![
+        ">    Extra spacing should not prevent correct wrapping of this quoted text that exceeds \
+         the line width."
+            .to_string(),
+    ];
+    let output = process_stream(&input);
+    common::assert_wrapped_blockquote(&output, ">    ", 2);
+    let joined = output
+        .iter()
+        .map(|l| l.trim_start_matches(">    "))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(joined, input[0].trim_start_matches(">    "));
+}
+
+#[test]
+fn test_wrap_blockquote_short() {
+    let input = vec!["> short".to_string()];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+#[test]
 /// Tests that lines with hard line breaks (trailing spaces) are preserved after processing.
 ///
 /// Ensures that the `process_stream` function does not remove or alter lines ending with Markdown


### PR DESCRIPTION
## Summary
- handle blockquote lines when wrapping text
- wrap blockquotes in place without losing the prefix
- test blockquote wrapping behaviour

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68781522ed488322a5ad86c250c46eea

## Summary by Sourcery

Add support for wrapping markdown blockquotes to the specified width while preserving their quote prefixes.

New Features:
- Handle and wrap markdown blockquote lines in place without losing the ">" prefix.

Tests:
- Add integration test for blockquote wrapping behavior.