### PR TITLE
Add URL wrapping regression test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,4 +912,22 @@ mod tests {
             vec!["This has a `dangling".to_string(), "code span.".to_string()]
         );
     }
+
+    #[test]
+    fn wrap_text_preserves_links() {
+        let input = vec![
+            "`falcon-pachinko` is an extension library for the".to_string(),
+            "[Falcon](https://falcon.readthedocs.io) web framework. It adds a structured"
+                .to_string(),
+            "approach to asynchronous WebSocket routing and background worker integration."
+                .to_string(),
+        ];
+        let wrapped = wrap_text(&input, 80);
+        assert_eq!(wrapped.iter().filter(|l| l.contains("https://")).count(), 1);
+        assert!(
+            wrapped
+                .iter()
+                .any(|l| l.contains("https://falcon.readthedocs.io"))
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,7 +912,7 @@ mod tests {
             vec!["This has a `dangling".to_string(), "code span.".to_string()]
         );
     }
-    
+
     /// Validate that URLs are not broken by re-wrapping paragraphs containing hyperlinks.
     #[test]
     fn wrap_text_preserves_links() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,8 +912,8 @@ mod tests {
             vec!["This has a `dangling".to_string(), "code span.".to_string()]
         );
     }
-    // Regression: issue #76 – wrapping must keep inline links intact
-
+    
+    /// Validate that URLs are not broken by re-wrapping paragraphs containing hyperlinks.
     #[test]
     fn wrap_text_preserves_links() {
         let input = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,6 +912,7 @@ mod tests {
             vec!["This has a `dangling".to_string(), "code span.".to_string()]
         );
     }
+    // Regression: issue #76 – wrapping must keep inline links intact
 
     #[test]
     fn wrap_text_preserves_links() {
@@ -923,7 +924,8 @@ mod tests {
                 .to_string(),
         ];
         let wrapped = wrap_text(&input, 80);
-        assert_eq!(wrapped.iter().filter(|l| l.contains("https://")).count(), 1);
+        let joined = wrapped.join("\n");
+        assert_eq!(joined.matches("https://").count(), 1);
         assert!(
             wrapped
                 .iter()


### PR DESCRIPTION
## Summary
- ensure wrapping keeps URLs intact

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687818b3147c83228e862263c4aab005

## Summary by Sourcery

Tests:
- Add wrap_text_preserves_links unit test to verify URLs remain intact after wrapping