### PR TITLE
Add footnote collection wrapping test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -746,17 +746,6 @@ fn test_wrap_footnote_with_inline_code() {
 ///
 /// This regression test ensures that the footnote collection remains
 /// unchanged when passed to `process_stream`.
-///
-/// # Examples
-///
-/// ```
-/// let input = vec![
-///     "[^1]: <https://falcon.readthedocs.io>".to_string(),
-///     "[^2]: <https://asgi.readthedocs.io>".to_string(),
-/// ];
-/// let output = process_stream(&input);
-/// assert_eq!(output, input);
-/// ```
 #[test]
 fn test_wrap_footnote_collection() {
     let input = vec![
@@ -781,14 +770,6 @@ fn test_wrap_footnote_collection() {
 /// Verifies that short list items are not wrapped or altered by the stream processing logic.
 ///
 /// Ensures that a single-line bullet list item remains unchanged after processing.
-///
-/// # Examples
-///
-/// ```
-/// let input = vec!["- short item".to_string()];
-/// let output = process_stream(&input);
-/// assert_eq!(output, input);
-/// ```
 fn test_wrap_short_list_item() {
     let input = vec!["- short item".to_string()];
     let output = process_stream(&input);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -742,6 +742,21 @@ fn test_wrap_footnote_with_inline_code() {
     common::assert_wrapped_list_item(&output, "  [^code_note]: ", 2);
 }
 
+/// Checks that a sequence of footnotes is not altered by wrapping.
+///
+/// This regression test ensures that the footnote collection remains
+/// unchanged when passed to `process_stream`.
+///
+/// # Examples
+///
+/// ```
+/// let input = vec![
+///     "[^1]: <https://falcon.readthedocs.io>".to_string(),
+///     "[^2]: <https://asgi.readthedocs.io>".to_string(),
+/// ];
+/// let output = process_stream(&input);
+/// assert_eq!(output, input);
+/// ```
 #[test]
 fn test_wrap_footnote_collection() {
     let input = vec![

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -743,6 +743,26 @@ fn test_wrap_footnote_with_inline_code() {
 }
 
 #[test]
+fn test_wrap_footnote_collection() {
+    let input = vec![
+        "[^1]: <https://falcon.readthedocs.io>",
+        "[^2]: <https://asgi.readthedocs.io>",
+        "[^3]: <https://www.starlette.io>",
+        "[^4]: <https://www.starlette.io/websockets/>",
+        "[^5]: <https://channels.readthedocs.io>",
+        "[^6]: <https://channels.readthedocs.io/en/stable/topics/consumers.html>",
+        "[^7]: <https://fastapi.tiangolo.com/advanced/websockets/>",
+        "[^8]: <https://websockets.readthedocs.io>",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<Vec<_>>();
+
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+#[test]
 /// Verifies that short list items are not wrapped or altered by the stream processing logic.
 ///
 /// Ensures that a single-line bullet list item remains unchanged after processing.


### PR DESCRIPTION
## Summary
- add regression test ensuring consecutive footnotes remain on separate lines during wrapping

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6878198d63c08322a935d4d10a3ac982

## Summary by Sourcery

Tests:
- Introduce test_wrap_footnote_collection verifying that processing a sequence of footnote definitions preserves their original ordering and formatting