### PR TITLE
Add regression test for long inline code item

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -715,6 +715,21 @@ fn test_wrap_multiple_inline_code_spans() {
     let output = process_stream(&input);
     common::assert_wrapped_list_item(&output, "- ", 2);
 }
+#[test]
+fn test_wrap_long_inline_code_item() {
+    let input = vec![
+        concat!(
+            "- `async def on_unhandled(self, ws: WebSocketLike, message: Union[str, bytes])`:",
+            " A fallback handler for messages that are not dispatched by the more specific",
+            " message handlers. This can be used for raw text/binary data or messages that",
+            " don't conform to the expected structured format."
+        )
+        .to_string(),
+    ];
+    let output = process_stream(&input);
+    common::assert_wrapped_list_item(&output, "- ", 4);
+    assert!(output.first().unwrap().ends_with("`:"));
+}
 
 #[test]
 fn test_wrap_footnote_multiline() {


### PR DESCRIPTION
## Summary
- add test to ensure long inline code spans with trailing punctuation are not split

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783becaad08322a9beec46b82cdc44