### PR TITLE
Use Cow in format_breaks

### DIFF
--- a/src/breaks.rs
+++ b/src/breaks.rs
@@ -28,7 +28,7 @@ pub fn format_breaks(lines: &[String]) -> Vec<Cow<'_, str>> {
         }
 
         if !in_code && THEMATIC_BREAK_RE.is_match(line.trim_end()) {
-            out.push(Cow::Owned(THEMATIC_BREAK_LINE.clone()));
+            out.push(Cow::Borrowed(THEMATIC_BREAK_LINE.as_str()));
         } else {
             out.push(Cow::Borrowed(line.as_str()));
         }
@@ -51,7 +51,7 @@ mod tests {
             .collect::<Vec<_>>();
         let expected: Vec<Cow<str>> = vec![
             input[0].as_str().into(),
-            Cow::Owned("_".repeat(THEMATIC_BREAK_LEN)),
+            Cow::Borrowed(THEMATIC_BREAK_LINE.as_str()),
             input[2].as_str().into(),
         ];
         assert_eq!(format_breaks(&input), expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fs,
     io::{self, Read},
     path::{Path, PathBuf},
@@ -42,7 +43,10 @@ fn process_lines(lines: &[String], opts: FormatOpts) -> Vec<String> {
         out = renumber_lists(&out);
     }
     if opts.breaks {
-        out = format_breaks(&out);
+        out = format_breaks(&out)
+            .into_iter()
+            .map(Cow::into_owned)
+            .collect();
     }
     out
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write};
+use std::{borrow::Cow, fs::File, io::Write};
 
 use assert_cmd::Command;
 use mdtablefix::{
@@ -1036,10 +1036,10 @@ fn test_format_breaks_basic() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let expected = vec![
-        "foo".to_string(),
-        "_".repeat(THEMATIC_BREAK_LEN),
-        "bar".to_string(),
+    let expected: Vec<Cow<str>> = vec![
+        input[0].as_str().into(),
+        Cow::Owned("_".repeat(THEMATIC_BREAK_LEN)),
+        input[2].as_str().into(),
     ];
     assert_eq!(format_breaks(&input), expected);
 }
@@ -1050,7 +1050,8 @@ fn test_format_breaks_ignores_code() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    assert_eq!(format_breaks(&input), input);
+    let expected: Vec<Cow<str>> = input.iter().map(|s| s.as_str().into()).collect();
+    assert_eq!(format_breaks(&input), expected);
 }
 
 #[test]
@@ -1059,7 +1060,8 @@ fn test_format_breaks_mixed_chars() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    assert_eq!(format_breaks(&input), input);
+    let expected: Vec<Cow<str>> = input.iter().map(|s| s.as_str().into()).collect();
+    assert_eq!(format_breaks(&input), expected);
 }
 
 #[test]
@@ -1068,7 +1070,7 @@ fn test_format_breaks_with_spaces_and_indent() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let expected = vec!["_".repeat(THEMATIC_BREAK_LEN)];
+    let expected: Vec<Cow<str>> = vec![Cow::Owned("_".repeat(THEMATIC_BREAK_LEN))];
     assert_eq!(format_breaks(&input), expected);
 }
 
@@ -1078,7 +1080,7 @@ fn test_format_breaks_with_tabs_and_underscores() {
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let expected = vec!["_".repeat(THEMATIC_BREAK_LEN)];
+    let expected: Vec<Cow<str>> = vec![Cow::Owned("_".repeat(THEMATIC_BREAK_LEN))];
     assert_eq!(format_breaks(&input), expected);
 }
 


### PR DESCRIPTION
## Summary
- avoid cloning unchanged lines when formatting thematic breaks
- convert CLI path to handle `Cow<str>` outputs
- update tests for new return type

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68784ce217488322a5f4ac92ae30fe63

## Summary by Sourcery

Refactor format_breaks to use Cow<str> for improved efficiency and update related code and tests to accommodate the new return type.

Enhancements:
- Optimize format_breaks to avoid unnecessary cloning by returning Cow<str> instead of String.

Tests:
- Update unit and integration tests to handle the new Cow<str> return type from format_breaks.