### PR TITLE
Refactor table reflow helpers

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -27,7 +27,7 @@ compiles a release binary for every matrix row.
 
 `cross` is installed from a specific git tag to avoid unexpected behavior from
 its main branch. Each binary is placed in an `artifacts/<os>-<arch>` directory
-using the naming pattern `mdtablefix-<os>-<arch>[.exe]`. A SHA-256 checksum is
+using the naming pattern `mdtablefix-<os>-<arch>[.exe]`. An SHA-256 checksum is
 written alongside each binary for download verification.
 
 After every build completes, the artifact is uploaded so that the GitHub

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1200,8 +1200,8 @@ and Parameterization**
 | Feature                                  | Standard #[test] Approach                                     | rstest Approach                                                                  |
 | ---------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Fixture Injection                        | Manual calls to setup functions within each test.             | Fixture name as argument in #[rstest] function; fixture defined with #[fixture]. |
-| Parameterized Tests (Specific Cases)     | Loop inside one test, or multiple distinct #[test] functions. | #[case(...)] attributes on #[rstest] function.                                   |
-| Parameterized Tests (Value Combinations) | Nested loops inside one test, or complex manual generation.   | #[values(...)] attributes on arguments of #[rstest] function.                    |
+| Parameterized Tests (Specific Cases)     | Loop inside one test, or multiple distinct #[test] functions. | #[case(…)] attributes on #[rstest] function.                                     |
+| Parameterized Tests (Value Combinations) | Nested loops inside one test, or complex manual generation.   | #[values(…)] attributes on arguments of #[rstest] function.                      |
 | Async Fixture Setup                      | Manual async block and .await calls inside test.              | async fn fixtures, with #[future] and #[awt] for ergonomic .awaiting.            |
 | Reusing Parameter Sets                   | Manual duplication of cases or custom helper macros.          | rstest_reuse crate with #[template] and #[apply] attributes.                     |
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -70,11 +70,11 @@ pub(crate) fn calculate_widths(rows: &[Vec<String>], max_cols: usize) -> Vec<usi
     widths
 }
 
-pub(crate) fn format_rows(rows: Vec<Vec<String>>, widths: &[usize], indent: &str) -> Vec<String> {
-    rows.into_iter()
+pub(crate) fn format_rows(rows: &[Vec<String>], widths: &[usize], indent: &str) -> Vec<String> {
+    rows.iter()
         .map(|row| {
             let padded: Vec<String> = row
-                .into_iter()
+                .iter()
                 .enumerate()
                 .map(|(i, c)| format!("{:<width$}", c, width = widths[i]))
                 .collect();


### PR DESCRIPTION
## Summary
- extract helper functions for indent trimming, separator detection, row parsing, and formatting
- use `ParsedTable` struct to return parsed table data
- simplify `reflow_table` by chaining the new helpers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878ca58b4948322a868d08003131112

## Summary by Sourcery

Decompose reflow_table into smaller helper functions and a ParsedTable struct to streamline table reflow logic

Enhancements:
- Extract helpers for indent trimming, separator line extraction, row parsing/validation, and formatting
- Introduce ParsedTable struct to encapsulate intermediate table state and simplify reflow_table implementation