### PR TITLE
Fix detection of indented fences

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -6,7 +6,7 @@
 use regex::Regex;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^(```|~~~).*").unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").unwrap());
 
 static BULLET_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)").unwrap());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -278,6 +278,28 @@ fn test_process_stream_ignores_code_fences() {
 }
 
 #[rstest]
+fn test_process_stream_ignores_indented_fences() {
+    let lines = lines_vec!(
+        "   ```javascript",
+        "   socket.onmessage = function(event) {",
+        "       const message = JSON.parse(event.data);",
+        "       switch(message.type) {",
+        "           case \"serverNewMessage\":",
+        "               // Display message.payload.user and message.payload.text",
+        "               break;",
+        "           case \"serverUserJoined\":",
+        "               // Update user list with message.payload.user",
+        "               break;",
+        "           // Handle other message types...",
+        "       }",
+        "   };",
+        "",
+        "   ```",
+    );
+    assert_eq!(process_stream(&lines), lines);
+}
+
+#[rstest]
 /// Verifies that the CLI fails when the `--in-place` flag is used without specifying a file.
 ///
 /// This test ensures that running `mdtablefix --in-place` without a file argument results in a


### PR DESCRIPTION
## Summary
- detect code fences even when they are indented
- add regression test for wrapping indented fenced blocks

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6878d976c7a88322941e85538d9fab07

## Summary by Sourcery

Fix detection of indented code fences by relaxing the fence regex to support leading spaces and adding a regression test

Bug Fixes:
- Detect code fences even when indented

Enhancements:
- Update fence detection regex to allow leading whitespace before ```, ~~~

Tests:
- Add regression test ensuring indented fenced code blocks are ignored