### PR TITLE
Add backslash break test

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -431,4 +431,23 @@ mod tests {
                 .any(|l| l.contains("https://falcon.readthedocs.io"))
         );
     }
+
+    #[test]
+    fn wrap_text_respects_backslash_linebreaks() {
+        let input = vec![
+            "Scenarios live under `tests/features/`. Step implementations in `tests` share \\"
+                .to_string(),
+            "a common `World` struct that uses `figment::Jail` for isolation. Each scenario \\"
+                .to_string(),
+            "executes asynchronously with `tokio`.".to_string(),
+        ];
+        let expected = vec![
+            "Scenarios live under `tests/features/`. Step implementations in `tests` share \\"
+                .to_string(),
+            "a common `World` struct that uses `figment::Jail` for isolation. Each scenario"
+                .to_string(),
+            "\\ executes asynchronously with `tokio`.".to_string(),
+        ];
+        assert_eq!(wrap_text(&input, 80), expected);
+    }
 }


### PR DESCRIPTION
## Summary
- add a test verifying that lines ending with a backslash keep the break

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6878d697bdc08322b47f796aba2337df

## Summary by Sourcery

Tests:
- Add wrap_text_respects_backslash_linebreaks to verify that lines ending with a backslash keep the break and reposition the backslash appropriately in the output