### PR TITLE
Add module relationship diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 uniform width. It can wrap paragraphs and list items to 80 columns when the
 `--wrap` option is used. Hyphenated words are treated as single units during
 wrapping, so `very-long-word` moves to the next line rather than splitting at
-the hyphen. The tool ignores fenced code blocks and respects escaped pipes (`\|
-`), making it safe for mixed content.
+the hyphen. The tool ignores fenced code blocks and respects escaped pipes
+(`\|`), making it safe for mixed content.
 
 ## Installation
 
@@ -87,6 +87,9 @@ Only basic tables composed of `<tr>`, `<th>` and `<td>` tags are detected, and
 attributes or tag casing do not matter. After conversion the regular reflow
 logic aligns them alongside Markdown tables. See [`docs/html-table-support.md`]
 (docs/html-table-support.md) for details.
+
+For an overview of how the crate's modules fit together, see
+[`docs/module-relationships.md`](docs/module-relationships.md).
 
 ## Testing
 

--- a/docs/module-relationships.md
+++ b/docs/module-relationships.md
@@ -1,0 +1,65 @@
+# Module Relationships
+
+This diagram illustrates the connections between the crate's modules.
+
+```mermaid
+classDiagram
+    class lib {
+        <<module>>
+    }
+    class html {
+        <<module>>
+        +convert_html_tables()
+        +html_table_to_markdown()
+    }
+    class table {
+        <<module>>
+        +reflow_table()
+        +split_cells()
+        +SEP_RE
+    }
+    class wrap {
+        <<module>>
+        +wrap_text()
+        +is_fence()
+    }
+    class lists {
+        <<module>>
+        +renumber_lists()
+    }
+    class breaks {
+        <<module>>
+        +format_breaks()
+        +THEMATIC_BREAK_LEN
+    }
+    class process {
+        <<module>>
+        +process_stream()
+        +process_stream_no_wrap()
+    }
+    class io {
+        <<module>>
+        +rewrite()
+        +rewrite_no_wrap()
+    }
+    lib --> html
+    lib --> table
+    lib --> wrap
+    lib --> lists
+    lib --> breaks
+    lib --> process
+    lib --> io
+    html ..> wrap : uses is_fence
+    table ..> reflow : uses parse_rows, etc.
+    lists ..> wrap : uses is_fence
+    breaks ..> wrap : uses is_fence
+    process ..> html : uses convert_html_tables
+    process ..> table : uses reflow_table
+    process ..> wrap : uses wrap_text, is_fence
+    io ..> process : uses process_stream, process_stream_no_wrap
+```
+
+The `lib` module re-exports the public API from the other modules. The
+`process` module provides streaming helpers that combine the lower-level
+functions. The `io` module handles filesystem operations, delegating the text
+processing to `process`.


### PR DESCRIPTION
## Summary
- add a Mermaid diagram describing how the modules interact
- link to the new diagram from the README

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878da33a2f88322bb6693c5c506c2bc