### PR TITLE
Add list restart test for formatted paragraphs

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -28,6 +28,7 @@ fn drop_deeper(indent: usize, counters: &mut Vec<(usize, usize)>) {
 
 fn is_plain_paragraph_line(line: &str) -> bool {
     line.trim_start()
+        .trim_start_matches(|c: char| ['*', '_', '`'].contains(&c))
         .chars()
         .next()
         .is_some_and(char::is_alphanumeric)

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -4,6 +4,9 @@ use regex::Regex;
 
 use crate::wrap::is_fence;
 
+/// Characters that mark formatted text at the start of a line.
+const FORMATTING_CHARS: [char; 3] = ['*', '_', '`'];
+
 fn parse_numbered(line: &str) -> Option<(&str, &str, &str)> {
     static NUMBERED_RE: std::sync::LazyLock<Regex> =
         std::sync::LazyLock::new(|| Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").unwrap());
@@ -28,7 +31,7 @@ fn drop_deeper(indent: usize, counters: &mut Vec<(usize, usize)>) {
 
 fn is_plain_paragraph_line(line: &str) -> bool {
     line.trim_start()
-        .trim_start_matches(|c: char| ['*', '_', '`'].contains(&c))
+        .trim_start_matches(|c: char| FORMATTING_CHARS.contains(&c))
         .chars()
         .next()
         .is_some_and(char::is_alphanumeric)

--- a/tests/data/renumber_formatting_paragraph_expected.txt
+++ b/tests/data/renumber_formatting_paragraph_expected.txt
@@ -1,0 +1,30 @@
+When pytest-forked creates child processes, Slipcover's enhanced capabilities
+ensure that:
+
+1. Each forked child process independently collects coverage data for the tests
+   it executes.
+
+2. This data is temporarily stored.
+
+3. Upon completion of all tests, the main Slipcover process aggregates the
+   coverage data from all child processes into a single, unified dataset.
+
+4. The final coverage report is generated from this aggregated data.
+
+**Practical Guide to Using Slipcover with** `pytest-forked`**:**
+<!-- markdownlint-disable MD029 -->
+
+1. **Prerequisites**:
+
+   - Slipcover v1.0.4+
+
+   - Pytest
+
+   - `pytest-forked`
+
+   `bash pip install --upgrade slipcover pytest pytest-forked`
+
+   *Note:* `pytest-forked` *relies on the* `fork()` *system call, making it
+   suitable for Unix-like systems (Linux, macOS).* 
+
+2. Command Invocation:

--- a/tests/data/renumber_formatting_paragraph_input.txt
+++ b/tests/data/renumber_formatting_paragraph_input.txt
@@ -1,0 +1,30 @@
+When pytest-forked creates child processes, Slipcover's enhanced capabilities
+ensure that:
+
+1. Each forked child process independently collects coverage data for the tests
+   it executes.
+
+1. This data is temporarily stored.
+
+1. Upon completion of all tests, the main Slipcover process aggregates the
+   coverage data from all child processes into a single, unified dataset.
+
+1. The final coverage report is generated from this aggregated data.
+
+**Practical Guide to Using Slipcover with** `pytest-forked`**:**
+<!-- markdownlint-disable MD029 -->
+
+1. **Prerequisites**:
+
+   - Slipcover v1.0.4+
+
+   - Pytest
+
+   - `pytest-forked`
+
+   `bash pip install --upgrade slipcover pytest pytest-forked`
+
+   *Note:* `pytest-forked` *relies on the* `fork()` *system call, making it
+   suitable for Unix-like systems (Linux, macOS).* 
+
+1. Command Invocation:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1066,6 +1066,19 @@ fn test_renumber_restart_after_paragraph() {
 }
 
 #[test]
+fn test_renumber_restart_after_formatting_paragraph() {
+    let input: Vec<String> = include_str!("data/renumber_formatting_paragraph_input.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = include_str!("data/renumber_formatting_paragraph_expected.txt")
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
 fn test_format_breaks_basic() {
     let input = vec!["foo", "***", "bar"]
         .into_iter()

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -54,3 +54,10 @@ fn restart_after_nested_paragraph() {
     let expected = lines_vec!("1. One", "    1. Sub", "", "Paragraph", "1. Next");
     assert_eq!(renumber_lists(&input), expected);
 }
+
+#[test]
+fn restart_after_formatting_paragraph() {
+    let input = lines_vec!("1. Start", "", "**Bold intro**", "", "4. Next");
+    let expected = lines_vec!("1. Start", "", "**Bold intro**", "", "1. Next");
+    assert_eq!(renumber_lists(&input), expected);
+}


### PR DESCRIPTION
## Summary
- handle formatted paragraphs as plain paragraphs
- add regression test using sample Slipcover text
- add unit test for formatted paragraph case

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878db4e32f88322a1a466414b729b37

## Summary by Sourcery

Allow list numbering to restart after formatted paragraphs and add corresponding tests

New Features:
- Treat paragraphs starting with formatting markers (*, _, `) as plain paragraphs for list renumbering

Tests:
- Add integration and unit tests for restarting list numbering after formatted paragraphs
- Include regression test using sample Slipcover text for formatted paragraph case