### PR TITLE
Add include_lines macro for test fixtures

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ macro_rules! lines_vec {
 macro_rules! include_lines {
     ($path:literal $(,)?) => {{
         const _TXT: &str = include_str!($path);
-        _TXT.lines().map(|l| l.to_owned()).collect::<Vec<String>>()
+        _TXT.lines().map(str::to_owned).collect()
     }};
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,7 +16,6 @@ macro_rules! lines_vec {
 /// ```
 /// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
 /// ```
-#[macro_export]
 macro_rules! include_lines {
     ($path:literal $(,)?) => {{
         const _TXT: &str = include_str!($path);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,20 @@ macro_rules! lines_vec {
     };
 }
 
+/// Expands to a `Vec<String>` with one element per line of the file.
+///
+/// Example:
+/// ```
+/// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
+/// ```
+#[macro_export]
+macro_rules! include_lines {
+    ($path:literal $(,)?) => {{
+        const _TXT: &str = include_str!($path);
+        _TXT.lines().map(|l| l.to_owned()).collect::<Vec<String>>()
+    }};
+}
+
 /// Assert common wrapping expectations for list items.
 ///
 /// Verifies the number of lines, prefix on the first line, length of all lines,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -465,27 +465,15 @@ fn test_convert_html_table_unclosed_returns_original() {
 
 #[test]
 fn test_convert_html_table_bold_header() {
-    let input: Vec<String> = include_str!("data/bold_header_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/bold_header_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/bold_header_input.txt");
+    let expected: Vec<String> = include_lines!("data/bold_header_expected.txt");
     assert_eq!(convert_html_tables(&input), expected);
 }
 
 #[test]
 fn test_logical_type_table_output_matches() {
-    let input: Vec<String> = include_str!("data/logical_type_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/logical_type_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/logical_type_input.txt");
+    let expected: Vec<String> = include_lines!("data/logical_type_expected.txt");
     assert_eq!(reflow_table(&input), expected);
 }
 
@@ -495,40 +483,22 @@ fn test_logical_type_table_output_matches() {
 /// Loads the input and expected output from external files and asserts that the
 /// `reflow_table` function transforms the input table to match the expected result.
 fn test_option_table_output_matches() {
-    let input: Vec<String> = include_str!("data/option_table_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/option_table_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/option_table_input.txt");
+    let expected: Vec<String> = include_lines!("data/option_table_expected.txt");
     assert_eq!(reflow_table(&input), expected);
 }
 
 #[test]
 fn test_month_seconds_table_output_matches() {
-    let input: Vec<String> = include_str!("data/month_seconds_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/month_seconds_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/month_seconds_input.txt");
+    let expected: Vec<String> = include_lines!("data/month_seconds_expected.txt");
     assert_eq!(reflow_table(&input), expected);
 }
 
 #[test]
 fn test_offset_table_output_matches() {
-    let input: Vec<String> = include_str!("data/offset_table_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/offset_table_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/offset_table_input.txt");
+    let expected: Vec<String> = include_lines!("data/offset_table_expected.txt");
     assert_eq!(reflow_table(&input), expected);
 }
 
@@ -536,14 +506,8 @@ fn test_offset_table_output_matches() {
 /// Tests that `process_stream` correctly processes a complex Markdown table representing logical
 /// types by comparing its output to expected results loaded from a file.
 fn test_process_stream_logical_type_table() {
-    let input: Vec<String> = include_str!("data/logical_type_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/logical_type_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/logical_type_input.txt");
+    let expected: Vec<String> = include_lines!("data/logical_type_expected.txt");
     assert_eq!(process_stream(&input), expected);
 }
 
@@ -554,14 +518,8 @@ fn test_process_stream_logical_type_table() {
 /// Loads input and expected output from test data files, runs `process_stream` on the input, and
 /// asserts equality.
 fn test_process_stream_option_table() {
-    let input: Vec<String> = include_str!("data/option_table_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/option_table_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/option_table_input.txt");
+    let expected: Vec<String> = include_lines!("data/option_table_expected.txt");
     assert_eq!(process_stream(&input), expected);
 }
 
@@ -821,14 +779,8 @@ fn test_preserve_hard_line_breaks() {
 /// columns and detailed content pass through the processing pipeline unchanged,
 /// preventing regressions that might inadvertently alter correct formatting.
 fn test_regression_complex_table() {
-    let input: Vec<String> = include_str!("data/regression_table_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/regression_table_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/regression_table_input.txt");
+    let expected: Vec<String> = include_lines!("data/regression_table_expected.txt");
     assert_eq!(process_stream(&input), expected);
 }
 
@@ -907,14 +859,8 @@ fn test_renumber_table_in_list() {
 
 #[test]
 fn test_renumber_restart_after_paragraph() {
-    let input: Vec<String> = include_str!("data/renumber_paragraph_restart_input.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
-    let expected: Vec<String> = include_str!("data/renumber_paragraph_restart_expected.txt")
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let input: Vec<String> = include_lines!("data/renumber_paragraph_restart_input.txt");
+    let expected: Vec<String> = include_lines!("data/renumber_paragraph_restart_expected.txt");
     assert_eq!(renumber_lists(&input), expected);
 }
 


### PR DESCRIPTION
## Summary
- add `include_lines!` macro to `tests/common`
- load fixture data with `include_lines!` in `integration.rs`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878ddd802ac8322904f1c36d4b5e862

## Summary by Sourcery

Introduce an include_lines! macro to streamline loading test fixtures and refactor existing integration tests to leverage it for cleaner, more concise code.

New Features:
- Add include_lines! macro in tests/common for loading fixture files as Vec<String>

Enhancements:
- Refactor integration tests to use include_lines! instead of manual include_str! with line mapping

Tests:
- Update multiple test functions in integration.rs to simplify fixture loading via include_lines! macro