### PR TITLE
Add ellipsis command-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cargo install --path .
 ## Command-line usage
 
 ```bash
-mdtablefix [--wrap] [--renumber] [--breaks] [--in-place] [FILE...]
+mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--in-place] [FILE...]
 ```
 
 - With file paths provided, the corrected tables are printed to stdout.
@@ -32,6 +32,8 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--in-place] [FILE...]
   `--renumber`.
 - Use `--breaks` to normalize thematic breaks to a line of 70 underscores
   (configurable via the `THEMATIC_BREAK_LEN` constant).
+- Use `--ellipsis` to replace sequences of three dots with the ellipsis
+  character.
 - Use `--in-place` to overwrite files.
 - If no files are supplied, input is read from stdin and results are written
   to stdout.

--- a/docs/module-relationships.md
+++ b/docs/module-relationships.md
@@ -32,6 +32,10 @@ classDiagram
         +format_breaks()
         +THEMATIC_BREAK_LEN
     }
+    class ellipsis {
+        <<module>>
+        +replace_ellipsis()
+    }
     class process {
         <<module>>
         +process_stream()
@@ -47,12 +51,14 @@ classDiagram
     lib --> wrap
     lib --> lists
     lib --> breaks
+    lib --> ellipsis
     lib --> process
     lib --> io
     html ..> wrap : uses is_fence
     table ..> reflow : uses parse_rows, etc.
     lists ..> wrap : uses is_fence
     breaks ..> wrap : uses is_fence
+    ellipsis ..> wrap : uses tokenize_markdown
     process ..> html : uses convert_html_tables
     process ..> table : uses reflow_table
     process ..> wrap : uses wrap_text, is_fence
@@ -60,6 +66,6 @@ classDiagram
 ```
 
 The `lib` module re-exports the public API from the other modules. The
-`process` module provides streaming helpers that combine the lower-level
-functions. The `io` module handles filesystem operations, delegating the text
-processing to `process`.
+`ellipsis` module performs text normalisation. The `process` module provides
+streaming helpers that combine the lower-level functions. The `io` module
+handles filesystem operations, delegating the text processing to `process`.

--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -1,0 +1,67 @@
+//! Replace sequences of three dots with the ellipsis character.
+//!
+//! This module provides a helper for normalising textual ellipses. It respects
+//! fenced code blocks and inline code spans so that code is left untouched.
+
+use crate::wrap::{is_fence, tokenize_markdown};
+
+/// Replace `...` with `…` outside code spans and fences.
+#[must_use]
+pub fn replace_ellipsis(lines: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(lines.len());
+    let mut in_code = false;
+    for line in lines {
+        if is_fence(line) {
+            in_code = !in_code;
+            out.push(line.clone());
+            continue;
+        }
+        if in_code {
+            out.push(line.clone());
+            continue;
+        }
+        let mut replaced = String::new();
+        for token in tokenize_markdown(line) {
+            if token.starts_with('`') {
+                replaced.push_str(&token);
+            } else {
+                replaced.push_str(&token.replace("...", "…"));
+            }
+        }
+        out.push(replaced);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_simple_text() {
+        let input = vec!["wait...".to_string()];
+        let expected = vec!["wait…".to_string()];
+        assert_eq!(replace_ellipsis(&input), expected);
+    }
+
+    #[test]
+    fn ignores_code_spans() {
+        let input = vec!["a `b...` c".to_string()];
+        let expected = input.clone();
+        assert_eq!(replace_ellipsis(&input), expected);
+    }
+
+    #[test]
+    fn ignores_fenced_blocks() {
+        let input = vec!["```".to_string(), "...".to_string(), "```".to_string()];
+        let expected = input.clone();
+        assert_eq!(replace_ellipsis(&input), expected);
+    }
+
+    #[test]
+    fn replaces_long_sequences() {
+        let input = vec![".... ..... ...... .......".to_string()];
+        let expected = vec!["…. ….. …… …….".to_string()];
+        assert_eq!(replace_ellipsis(&input), expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@
 //! - `wrap` for paragraph wrapping.
 //! - `lists` for renumbering ordered lists.
 //! - `breaks` for thematic break formatting.
+//! - `ellipsis` for normalising textual ellipses.
 //! - `process` for stream processing.
 //! - `io` for file helpers.
 
 pub mod breaks;
+pub mod ellipsis;
 mod html;
 pub mod io;
 pub mod lists;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,13 @@ use std::{
 };
 
 use clap::Parser;
-use mdtablefix::{format_breaks, process_stream, process_stream_no_wrap, renumber_lists};
+use mdtablefix::{
+    ellipsis::replace_ellipsis,
+    format_breaks,
+    process_stream,
+    process_stream_no_wrap,
+    renumber_lists,
+};
 
 #[derive(Parser)]
 #[command(about = "Reflow broken markdown tables")]
@@ -21,6 +27,7 @@ struct Cli {
 }
 
 #[derive(clap::Args, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)] // CLI exposes four independent flags
 struct FormatOpts {
     /// Wrap paragraphs and list items to 80 columns
     #[arg(long = "wrap")]
@@ -31,6 +38,9 @@ struct FormatOpts {
     /// Reformat thematic breaks as underscores
     #[arg(long = "breaks")]
     breaks: bool,
+    /// Replace "..." with the ellipsis character
+    #[arg(long = "ellipsis")]
+    ellipsis: bool,
 }
 
 fn process_lines(lines: &[String], opts: FormatOpts) -> Vec<String> {
@@ -47,6 +57,9 @@ fn process_lines(lines: &[String], opts: FormatOpts) -> Vec<String> {
             .into_iter()
             .map(Cow::into_owned)
             .collect();
+    }
+    if opts.ellipsis {
+        out = replace_ellipsis(&out);
     }
     out
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -952,3 +952,15 @@ fn test_cli_breaks_option() {
         format!("{}\n", "_".repeat(THEMATIC_BREAK_LEN))
     );
 }
+
+#[test]
+fn test_cli_ellipsis_option() {
+    let output = Command::cargo_bin("mdtablefix")
+        .unwrap()
+        .arg("--ellipsis")
+        .write_stdin("foo...\n")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "foo…\n");
+}


### PR DESCRIPTION
## Summary
- add `ellipsis` module to replace `...` with the Unicode ellipsis
- expose new `--ellipsis` CLI flag
- update documentation and module diagram
- cover feature with unit and behavioural tests
- test long dot sequences are grouped correctly

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68797c95ec4c832285890f6b5ce9b73a