### PR TITLE
Add test for wrapping angle bracket URLs

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -674,6 +674,10 @@ fn test_wrap_footnote_with_inline_code() {
     common::assert_wrapped_list_item(&output, "  [^code_note]: ", 2);
 }
 
+/// Tests that footnotes with angle-bracketed URLs are wrapped correctly.
+///
+/// Verifies that when a footnote line contains a URL enclosed in angle brackets,
+/// the URL is moved to a new indented line beneath the footnote text.
 #[test]
 fn test_wrap_angle_bracket_url() {
     let input = lines_vec![concat!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -674,6 +674,20 @@ fn test_wrap_footnote_with_inline_code() {
     common::assert_wrapped_list_item(&output, "  [^code_note]: ", 2);
 }
 
+#[test]
+fn test_wrap_angle_bracket_url() {
+    let input = lines_vec![concat!(
+        "[^5]: Given When Then - Martin Fowler, accessed on 14 July 2025, ",
+        "<https://martinfowler.com/bliki/GivenWhenThen.html>"
+    )];
+    let expected = lines_vec![
+        "[^5]: Given When Then - Martin Fowler, accessed on 14 July 2025,",
+        "      <https://martinfowler.com/bliki/GivenWhenThen.html>",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
 /// Checks that a sequence of footnotes is not altered by wrapping.
 ///
 /// This regression test ensures that the footnote collection remains


### PR DESCRIPTION
## Summary
- add regression test ensuring angle-bracket URLs are wrapped on one line

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687a1609f8308322809736c7429cae25

## Summary by Sourcery

Tests:
- Add test_wrap_angle_bracket_url integration test to verify that angle-bracket URLs in footnotes wrap correctly