### PR TITLE
Fix link wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # mdtablefix
 
-`mdtablefix` unb0rks and reflows Markdown tables so that each column has a uniform width. When the `--wrap` option is used, it also wraps paragraphs and list items to 80 columns.
+`mdtablefix` unb0rks and reflows Markdown tables so that each column has a
+uniform width. When the `--wrap` option is used, it also wraps paragraphs and
+list items to 80 columns.
 
-Hyphenated words are treated as indivisible during wrapping, so `very-long-word` will move to the next line intact rather than split at the hyphen. The tool ignores fenced code blocks and respects escaped pipes (`\|`), making it safe to use on Markdown with mixed content.
+Hyphenated words are treated as indivisible during wrapping, so
+`very-long-word` will move to the next line intact rather than split at the
+hyphen. The tool ignores fenced code blocks and respects escaped pipes (`\|`),
+making it safe to use on Markdown with mixed content.
 
 ## Installation
 
@@ -10,7 +15,7 @@ Install via Cargo:
 
 Bash
 
-```
+```bash
 cargo install mdtablefix
 ```
 
@@ -18,7 +23,7 @@ Or clone the repository and build from source:
 
 Bash
 
-```
+```bash
 cargo install --path .
 ```
 
@@ -26,23 +31,32 @@ cargo install --path .
 
 Bash
 
-```
+```bash
 mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--in-place] [FILE...]
 ```
 
-- When one or more file paths are provided, the corrected tables are printed to stdout.
+- When one or more file paths are provided, the corrected tables are printed to
+  stdout.
 
 - Use `--wrap` to reflow paragraphs and list items to 80 columns.
 
-- Use `--renumber` to rewrite ordered lists with consistent sequential numbering. The renumbering logic correctly handles nested lists by tracking indentation (tabs are interpreted as four spaces) and restarts numbering after a list is interrupted by other content, such as a paragraph at a lower indentation level.
+- Use `--renumber` to rewrite ordered lists with consistent sequential
+  numbering. The renumbering logic correctly handles nested lists by tracking
+  indentation (tabs are interpreted as four spaces) and restarts numbering
+  after a list is interrupted by other content, such as a paragraph at a lower
+  indentation level.
 
-- Use `--breaks` to standardise thematic breaks to a line of 70 underscores (configurable via the `THEMATIC_BREAK_LEN` constant).
+- Use `--breaks` to standardise thematic breaks to a line of 70 underscores
+  (configurable via the `THEMATIC_BREAK_LEN` constant).
 
-- Use `--ellipsis` to replace groups of three dots (`...`) with the ellipsis character (`…`). Longer runs are processed left-to-right, so any leftover dots are preserved.
+- Use `--ellipsis` to replace groups of three dots (`...`) with the ellipsis
+  character (`…`). Longer runs are processed left-to-right, so any leftover
+  dots are preserved.
 
 - Use `--in-place` to modify files in-place.
 
-- If no files are specified, input is read from stdin and output is written to stdout.
+- If no files are specified, input is read from stdin and output is written to
+  stdout.
 
 ### Example: Table Reflowing
 
@@ -50,7 +64,7 @@ Before:
 
 Markdown
 
-```
+```markdown
 |Character|Catchphrase|Pizza count| |---|---|---| |Speedy Cerviche|Here
 come the Samurai Pizza Cats!|lots| |Guido Anchovy|Slice and dice!|tons|
 |Polly Esther|Cat fight!|many|
@@ -60,7 +74,7 @@ After running `mdtablefix`:
 
 Markdown
 
-```
+```markdown
 | Character       | Catchphrase                       | Pizza count |
 | --------------- | --------------------------------- | ----------- |
 | Speedy Cerviche | Here come the Samurai Pizza Cats! | lots        |
@@ -74,7 +88,7 @@ Before:
 
 Markdown
 
-```
+```markdown
 1. The Big Cheese's evil plans.
 4. Jerry Atric's schemes.
 
@@ -90,7 +104,7 @@ After running `mdtablefix --renumber`:
 
 Markdown
 
-```
+```markdown
 1. The Big Cheese's evil plans.
 2. Jerry Atric's schemes.
 
@@ -104,11 +118,12 @@ A brief intermission for pizza.
 
 ## Library usage
 
-The crate provides helper functions for embedding the table reflow logic in your own Rust project:
+The crate provides helper functions for embedding the table reflow logic in
+your own Rust project:
 
 Rust
 
-```
+```rust
 use mdtablefix::{process_stream_opts, rewrite};
 use std::path::Path;
 
@@ -125,26 +140,36 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-- `process_stream_opts(lines: &[String], wrap: bool, ellipsis: bool) -> Vec<String>` rewrites tables in memory, with optional paragraph wrapping and ellipsis substitution.
+- `process_stream_opts(lines: &[String], wrap: bool, ellipsis: bool) ->
+  Vec<String>` rewrites tables in memory, with optional paragraph wrapping and
+  ellipsis substitution.
 
-- `rewrite(path: &Path) -> std::io::Result<()>` modifies a Markdown file on disk in-place.
+- `rewrite(path: &Path) -> std::io::Result<()>` modifies a Markdown file on
+  disk in-place.
 
 ## HTML table support
 
-`mdtablefix` recognises basic HTML `<table>` elements embedded in Markdown. These are converted to Markdown in a preprocessing stage using `convert_html_tables`, prior to reflow.
+`mdtablefix` recognises basic HTML `<table>` elements embedded in Markdown.
+These are converted to Markdown in a preprocessing stage using
+`convert_html_tables`, prior to reflow.
 
-Only simple tables composed of `<tr>`, `<th>`, and `<td>` tags are supported. Tag case and attributes are ignored. After conversion, they are reformatted alongside regular Markdown tables.
+Only simple tables composed of `<tr>`, `<th>`, and `<td>` tags are supported.
+Tag case and attributes are ignored. After conversion, they are reformatted
+alongside regular Markdown tables.
 
 See [HTML table support for more details](docs/html-table-support.md).
 
 ## Module structure
 
-For an overview of how the crate's internal modules relate to each other, see [Module relationships](docs/module-relationships.md).
+For an overview of how the crate's internal modules relate to each other, see
+[Module relationships](docs/module-relationships.md).
 
 ## Testing
 
-The test suite is structured using the `rstest` crate. See [Rust testing with rstest fixtures](docs/rust-testing-with-rstest-fixtures.md) for details.
+The test suite is structured using the `rstest` crate. See [Rust testing with
+rstest fixtures](docs/rust-testing-with-rstest-fixtures.md) for details.
 
 ## License
 
-This project is licensed under the ISC License. See the [LICENSE](LICENSE) file for full details.
+This project is licensed under the ISC License. See the [LICENSE](LICENSE) file
+for full details.

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -72,6 +72,36 @@ fn tokenize_inline(text: &str) -> Vec<String> {
                 tokens.push(chars[start..end].iter().collect());
                 i = end;
             }
+        } else if c == '[' || (c == '!' && i + 1 < chars.len() && chars[i + 1] == '[') {
+            let start = i;
+            if c == '!' {
+                i += 1;
+            }
+            if i < chars.len() && chars[i] == '[' {
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    i += 1;
+                }
+                if i < chars.len() && chars[i] == ']' {
+                    i += 1;
+                    if i < chars.len() && chars[i] == '(' {
+                        i += 1;
+                        let mut depth = 1;
+                        while i < chars.len() && depth > 0 {
+                            if chars[i] == '(' {
+                                depth += 1;
+                            } else if chars[i] == ')' {
+                                depth -= 1;
+                            }
+                            i += 1;
+                        }
+                        tokens.push(chars[start..i].iter().collect());
+                        continue;
+                    }
+                }
+            }
+            i = start + 1;
+            tokens.push(chars[start..i].iter().collect());
         } else {
             let start = i;
             while i < chars.len() && !chars[i].is_whitespace() && chars[i] != '`' {

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -424,3 +424,21 @@ fn test_cli_wrap_option() {
     );
     assert!(text.lines().all(|l| l.len() <= 80));
 }
+
+/// Ensures that links are not split across lines when wrapping paragraphs.
+#[test]
+fn test_wrap_paragraph_with_link() {
+    let input = lines_vec![concat!(
+        "**Wireframe** is an experimental Rust library that simplifies building",
+        " servers and clients for custom binary protocols. The design borrows ",
+        "heavily from [Actix Web](https://actix.rs/) to provide a familiar, ",
+        "declarative API for routing, extractors, and middleware."
+    )];
+    let output = process_stream(&input);
+    assert!(
+        output
+            .iter()
+            .any(|line| line.contains("[Actix Web](https://actix.rs/)")),
+        "link should not be broken across lines"
+    );
+}


### PR DESCRIPTION
## Summary
- treat Markdown links as indivisible tokens during wrapping
- ensure README code blocks specify languages
- verify link wrapping behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687b82f6823c83229077f87bc83e5260