### PR TITLE
Refactor footnotes and document option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes
   other processing.
 
 - Use `--footnotes` to convert bare numeric references and the final numbered
-  list into GitHub-flavoured footnote links.
+  list into GitHub-flavoured footnote links. See [Footnote
+  conversion](docs/footnote-conversion.md) for details.
 
 - Use `--in-place` to modify files in-place.
 

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -17,27 +17,13 @@ static FOOTNOTE_LINE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|
 
 use crate::wrap::{Token, tokenize_markdown};
 
-/// Extract captured footnote components from a regex match.
-fn parse_inline_caps<'a>(caps: &'a Captures<'a>) -> (&'a str, &'a str, &'a str, &'a str, &'a str) {
-    (
-        &caps["pre"],
-        &caps["punc"],
-        &caps["style"],
-        &caps["num"],
-        &caps["boundary"],
-    )
-}
-
-/// Build a Markdown footnote from its captured parts.
-fn build_inline_footnote(pre: &str, punc: &str, style: &str, num: &str, boundary: &str) -> String {
-    format!("{pre}{punc}{style}[^{num}]{boundary}")
-}
-
 fn convert_inline(text: &str) -> String {
     INLINE_FN_RE
         .replace_all(text, |caps: &Captures| {
-            let (pre, punc, style, num, boundary) = parse_inline_caps(caps);
-            build_inline_footnote(pre, punc, style, num, boundary)
+            format!(
+                "{}{}{}[^{}]{}",
+                &caps["pre"], &caps["punc"], &caps["style"], &caps["num"], &caps["boundary"],
+            )
         })
         .into_owned()
 }

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -1,4 +1,12 @@
 //! Integration tests for footnote conversion.
+//!
+//! These tests exercise the public API using real Markdown examples from
+//! `tests/data`. They ensure that bare numeric references are transformed into
+//! GitHub-flavoured footnotes and that the final numbered list is rewritten as
+//! a footnote block. The helper macros `include_lines!` and `lines_vec!`,
+//! exported by the `prelude` module, build `Vec<String>` values for input and
+//! expected output. The unit tests cover lower level edge cases; here we focus
+//! on integration behaviour.
 
 use mdtablefix::convert_footnotes;
 
@@ -80,4 +88,10 @@ fn test_whitespace_input() {
     let input = lines_vec!("   ", "\t");
     let output = convert_footnotes(&input);
     assert_eq!(output, input);
+}
+
+#[test]
+fn macros_exported_from_prelude() {
+    let _: Vec<String> = lines_vec!("one", "two");
+    let _: Vec<String> = include_lines!("data/footnotes_input.txt");
 }


### PR DESCRIPTION
## Summary
- document footnotes option and add usage example
- add reference docs for footnote conversion
- refactor footnote conversion helpers
- rename variables in `convert_block`
- expand unit tests for footnote edge cases
- improve integration test docs and verify macro exports
- add API docs for `process_stream_opts`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cb5d1f5e88322beb126919eaab665

## Summary by Sourcery

Refactor and document the footnote conversion feature by reorganizing conversion helpers, updating variable names, and enhancing documentation and examples, while also expanding test coverage for various edge cases and exported macros.

Enhancements:
- Refactor footnote conversion helpers and rename variables in convert_block for clarity

Documentation:
- Add dedicated footnote conversion documentation with usage examples
- Update README to reference the new footnote conversion guide
- Document the `footnotes` parameter in the process_stream_opts API

Tests:
- Add unit tests for multiple inline references, non-numeric identifiers, empty input, and mixed code content
- Add integration test to verify macros are correctly exported from the prelude