### PR TITLE
Reset list numbers after breaks and headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--footnotes] [--in-pla
   numbering. The renumbering logic correctly handles nested lists by tracking
   indentation (tabs are interpreted as four spaces) and restarts numbering
   after a list is interrupted by other content, such as a paragraph at a lower
-  indentation level.
+  indentation level, a thematic break, or a heading.
 
 - Use `--breaks` to standardise thematic breaks to a line of 70 underscores
   (configurable via the `THEMATIC_BREAK_LEN` constant).

--- a/src/breaks.rs
+++ b/src/breaks.rs
@@ -8,8 +8,9 @@ use crate::wrap::is_fence;
 
 pub const THEMATIC_BREAK_LEN: usize = 70;
 
-static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$").unwrap()
+pub(crate) static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$")
+        .expect("valid thematic break regex")
 });
 
 static THEMATIC_BREAK_LINE: std::sync::LazyLock<String> =

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -2,24 +2,21 @@
 
 use regex::Regex;
 
-use crate::wrap::is_fence;
+use crate::{breaks::THEMATIC_BREAK_RE, wrap::is_fence};
 
 /// Characters that mark formatted text at the start of a line.
 const FORMATTING_CHARS: [char; 3] = ['*', '_', '`'];
 
 // Lines starting with optional indentation followed by '#' characters denote
 // Markdown ATX headings. A space or end of line must follow the hashes.
-static HEADING_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^[ ]{0,3}#{1,6}(?:\s|$)").unwrap());
-
-// Matches Markdown thematic breaks using '*', '-' or '_' characters.
-static BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$").unwrap()
+static HEADING_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^[ ]{0,3}#{1,6}(?:\s|$)").expect("valid heading regex")
 });
 
 fn parse_numbered(line: &str) -> Option<(&str, &str, &str)> {
-    static NUMBERED_RE: std::sync::LazyLock<Regex> =
-        std::sync::LazyLock::new(|| Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").unwrap());
+    static NUMBERED_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").expect("valid list number regex")
+    });
     let cap = NUMBERED_RE.captures(line)?;
     let indent = cap.get(1)?.as_str();
     let sep = cap.get(3)?.as_str();
@@ -123,7 +120,7 @@ pub fn renumber_lists(lines: &[String]) -> Vec<String> {
         let indent_str = &line[..indent_end];
         let indent = indent_len(indent_str);
 
-        if HEADING_RE.is_match(line) || BREAK_RE.is_match(line.trim_end()) {
+        if HEADING_RE.is_match(line) || THEMATIC_BREAK_RE.is_match(line.trim_end()) {
             counters.clear();
             out.push(line.clone());
             prev_blank = false;

--- a/tests/data/renumber_break_heading_restart_expected.txt
+++ b/tests/data/renumber_break_heading_restart_expected.txt
@@ -1,0 +1,9 @@
+1. Start
+2. Continue
+
+---
+
+## Heading
+
+1. Next
+

--- a/tests/data/renumber_break_heading_restart_input.txt
+++ b/tests/data/renumber_break_heading_restart_input.txt
@@ -1,0 +1,9 @@
+1. Start
+2. Continue
+
+---
+
+## Heading
+
+3. Next
+

--- a/tests/data/renumber_break_restart_expected.txt
+++ b/tests/data/renumber_break_restart_expected.txt
@@ -1,0 +1,7 @@
+1. Start
+2. Continue
+
+---
+
+1. Next
+

--- a/tests/data/renumber_break_restart_input.txt
+++ b/tests/data/renumber_break_restart_input.txt
@@ -1,0 +1,7 @@
+1. Start
+2. Continue
+
+---
+
+3. Next
+

--- a/tests/data/renumber_heading_restart_expected.txt
+++ b/tests/data/renumber_heading_restart_expected.txt
@@ -1,0 +1,7 @@
+1. Start
+2. Continue
+
+## Heading
+
+1. Next
+

--- a/tests/data/renumber_heading_restart_input.txt
+++ b/tests/data/renumber_heading_restart_input.txt
@@ -1,0 +1,7 @@
+1. Start
+2. Continue
+
+## Heading
+
+3. Next
+

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -42,9 +42,9 @@ fn no_restart_for_indented_paragraph() {
 }
 
 #[test]
-fn no_restart_for_non_plain_line() {
+fn restart_after_top_heading() {
     let input = lines_vec!("1. One", "", "# Heading", "3. Next");
-    let expected = lines_vec!("1. One", "", "# Heading", "2. Next");
+    let expected = lines_vec!("1. One", "", "# Heading", "1. Next");
     assert_eq!(renumber_lists(&input), expected);
 }
 
@@ -111,6 +111,18 @@ fn test_cli_renumber_option() {
     case::restart_after_formatting(
         include_lines!("data/renumber_formatting_paragraph_input.txt"),
         include_lines!("data/renumber_formatting_paragraph_expected.txt")
+    ),
+    case::restart_after_break(
+        include_lines!("data/renumber_break_restart_input.txt"),
+        include_lines!("data/renumber_break_restart_expected.txt")
+    ),
+    case::restart_after_heading(
+        include_lines!("data/renumber_heading_restart_input.txt"),
+        include_lines!("data/renumber_heading_restart_expected.txt")
+    ),
+    case::restart_after_break_and_heading(
+        include_lines!("data/renumber_break_heading_restart_input.txt"),
+        include_lines!("data/renumber_break_heading_restart_expected.txt")
     )
 )]
 fn test_renumber_cases(input: Vec<String>, expected: Vec<String>) {


### PR DESCRIPTION
## Summary
- reset counters when encountering headings and thematic breaks
- cover the new behaviour in list integration tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cb8e8fe8483229002165161799248

## Summary by Sourcery

Reset list numbering to restart after Markdown headings and thematic breaks and cover the new behavior with integration tests

New Features:
- Restart ordered list counters when encountering top-level headings
- Restart ordered list counters when encountering thematic breaks

Enhancements:
- Expose THEMATIC_BREAK_RE as pub(crate) and add expect messages for regex initialization

Documentation:
- Update README to document restarting numbering after headings and thematic breaks

Tests:
- Add list renumbering integration tests for restarts after headings, breaks, and their combination