### PR TITLE
Fix missing footnotes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ fn main() -> std::io::Result<()> {
         wrap: true,
         ellipsis: true,
         fences: true,
+        footnotes: false,
     };
     let fixed = process_stream_opts(&lines, opts);
     println!("{}", fixed.join("\n"));
@@ -133,7 +134,7 @@ fn main() -> std::io::Result<()> {
 
 - `process_stream_opts(lines: &[String], opts: Options) -> Vec<String>`
   rewrites tables in memory. The options enable paragraph wrapping, ellipsis
-  substitution and fence normalization.
+  substitution, fence normalization and footnote conversion.
 
 - `rewrite(path: &Path) -> std::io::Result<()>` modifies a Markdown file on
   disk in-place.

--- a/src/process.rs
+++ b/src/process.rs
@@ -10,6 +10,10 @@ use crate::{
 };
 
 /// Processing options controlling the behaviour of `process_stream_inner`.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "Options map directly to CLI flags"
+)]
 #[derive(Clone, Copy)]
 pub struct Options {
     /// Enable paragraph wrapping
@@ -18,6 +22,8 @@ pub struct Options {
     pub ellipsis: bool,
     /// Normalise code block fences
     pub fences: bool,
+    /// Convert bare numeric references to footnotes
+    pub footnotes: bool,
 }
 
 #[must_use]
@@ -94,7 +100,7 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String> {
     if opts.ellipsis {
         out = replace_ellipsis(&out);
     }
-    if footnotes {
+    if opts.footnotes {
         out = convert_footnotes(&out);
     }
     out
@@ -108,6 +114,7 @@ pub fn process_stream(lines: &[String]) -> Vec<String> {
             wrap: true,
             ellipsis: false,
             fences: false,
+            footnotes: false,
         },
     )
 }
@@ -120,6 +127,7 @@ pub fn process_stream_no_wrap(lines: &[String]) -> Vec<String> {
             wrap: false,
             ellipsis: false,
             fences: false,
+            footnotes: false,
         },
     )
 }


### PR DESCRIPTION
## Summary
- add `footnotes` field to `Options`
- reflow README example and docs for footnotes support
- respect clippy lint for the extended struct

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687cd1c7cff88322956f921dd318555a

## Summary by Sourcery

Enable footnote conversion through a new Option field, integrate it into the processing pipeline, and refresh documentation accordingly.

New Features:
- Add 'footnotes' flag to Options to toggle conversion of numeric references into footnotes

Enhancements:
- Include footnotes in the default Option values for process_stream variants
- Suppress clippy struct_excessive_bools lint on the extended Options struct
- Update README examples and documentation to cover footnotes support