### PR TITLE
Enable concurrent file processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +194,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -406,6 +437,7 @@ dependencies = [
  "libc",
  "markup5ever_rcdom",
  "once_cell",
+ "rayon",
  "regex",
  "rstest",
  "tempfile",
@@ -580,6 +612,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 once_cell = "1"
+rayon = "1.10"
 html5ever = "0.27"
 markup5ever_rcdom = "0.3"
 unicode-width = ">=0.1, <0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 once_cell = "1"
-rayon = "1.10"
+rayon = "1"
 html5ever = "0.27"
 markup5ever_rcdom = "0.3"
 unicode-width = ">=0.1, <0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 once_cell = "1"
-rayon = "1"
+rayon = "^1.0"
 html5ever = "0.27"
 markup5ever_rcdom = "0.3"
 unicode-width = ">=0.1, <0.2"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ cargo install --path .
 
 ## Command-line usage
 
-
 ```bash
 mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes] [--in-place] [FILE...]
 ```
@@ -111,8 +110,8 @@ A brief intermission for pizza.
 
 ## Library usage
 
-The crate exposes helper functions for embedding the table-reflow logic in
-Rust projects:
+The crate exposes helper functions for embedding the table-reflow logic in Rust
+projects:
 
 ```rust
 use mdtablefix::{process_stream_opts, rewrite, Options};
@@ -159,8 +158,9 @@ For an overview of how the crate's internal modules relate to each other, see
 
 ## Testing
 
-The test suite is structured using the `rstest` crate. See [Rust testing with
-rstest fixtures](docs/rust-testing-with-rstest-fixtures.md) for details.
+The test suite is structured using the `rstest` crate. See
+[Rust testing with rstest fixtures](docs/rust-testing-with-rstest-fixtures.md)
+for details.
 
 ## License
 

--- a/docs/parallel-processing-roadmap.md
+++ b/docs/parallel-processing-roadmap.md
@@ -4,15 +4,15 @@ The command-line tool currently processes input files sequentially. The steps
 below outline the work required to allow concurrent processing while preserving
 serial output order.
 
-- [ ] **Adopt `rayon` for concurrency**
+- [x] **Adopt `rayon` for concurrency**
   - Use `rayon` thread pools to spawn work for each file path.
   - Ensure the approach integrates cleanly with existing modules.
-- [ ] **Add chosen crate to `Cargo.toml`**
+- [x] **Add chosen crate to `Cargo.toml`**
   - Pin an explicit version and document the decision in `docs/`.
-- [ ] **Refactor `main.rs` to launch parallel tasks**
+- [x] **Refactor `main.rs` to launch parallel tasks**
   - Spawn a worker for each file path using the concurrency crate.
   - Maintain a list of handles so outputs can be gathered in order.
-- [ ] **Collect results sequentially**
+- [x] **Collect results sequentially**
   - Await or join handles in the same order the files were supplied.
   - Print each processed file or error message before moving to the next.
 - [ ] **Extend tests for parallel execution**

--- a/docs/parallel-processing-roadmap.md
+++ b/docs/parallel-processing-roadmap.md
@@ -11,7 +11,7 @@ serial output order.
   - Pin an explicit version and document the decision in `docs/`.
 - [x] **Refactor `main.rs` to launch parallel tasks**
   - Spawn a worker for each file path using the concurrency crate.
-  - Maintain a list of handles so outputs can be gathered in order.
+  - Maintain a list of handles, so outputs can be gathered in order.
 - [x] **Collect results sequentially**
   - Await or join handles in the same order the files were supplied.
   - Print each processed file or error message before moving to the next.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -1,0 +1,6 @@
+# Concurrency with `rayon`
+
+`mdtablefix` uses the `rayon` crate to process multiple files concurrently.
+`rayon` provides a work-stealing thread pool and simple parallel iterators. The
+version is pinned to `1.10` in `Cargo.toml` to avoid breaking changes from a
+future major release.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -2,5 +2,6 @@
 
 `mdtablefix` uses the `rayon` crate to process multiple files concurrently.
 `rayon` provides a work-stealing thread pool and simple parallel iterators. The
-version is pinned to `1.10` in `Cargo.toml` to avoid breaking changes from a
-future major release.
+tool relies on Rayon’s global thread pool so that no manual setup is required.
+The version is pinned to `1.10` in `Cargo.toml` to avoid breaking changes from
+a future major release.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -3,5 +3,5 @@
 `mdtablefix` uses the `rayon` crate to process multiple files concurrently.
 `rayon` provides a work-stealing thread pool and simple parallel iterators. The
 tool relies on Rayon’s global thread pool so that no manual setup is required.
-The dependency is specified as `>=1, <2` in `Cargo.toml` to track stable API
+The dependency is specified as `^1.0` in `Cargo.toml` to track stable API
 changes within the same major release.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -3,5 +3,5 @@
 `mdtablefix` uses the `rayon` crate to process multiple files concurrently.
 `rayon` provides a work-stealing thread pool and simple parallel iterators. The
 tool relies on Rayon’s global thread pool so that no manual setup is required.
-The version is pinned to `1.10` in `Cargo.toml` to avoid breaking changes from
-a future major release.
+The dependency is specified as `1` in `Cargo.toml` to track stable API changes
+within the same major release.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -3,5 +3,5 @@
 `mdtablefix` uses the `rayon` crate to process multiple files concurrently.
 `rayon` provides a work-stealing thread pool and simple parallel iterators. The
 tool relies on Rayon’s global thread pool so that no manual setup is required.
-The dependency is specified as `1` in `Cargo.toml` to track stable API changes
-within the same major release.
+The dependency is specified as `^1.0` in `Cargo.toml` to track stable API
+changes within the same major release.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -3,5 +3,5 @@
 `mdtablefix` uses the `rayon` crate to process multiple files concurrently.
 `rayon` provides a work-stealing thread pool and simple parallel iterators. The
 tool relies on Rayon’s global thread pool so that no manual setup is required.
-The dependency is specified as `^1.0` in `Cargo.toml` to track stable API
+The dependency is specified as `>=1, <2` in `Cargo.toml` to track stable API
 changes within the same major release.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+//! Command-line interface for the mdtablefix tool.
+//!
+//! This module provides the main entry point and CLI parsing for fixing
+//! markdown table formatting. It supports concurrent processing of multiple
+//! files using Rayon for improved performance.
+
 use std::{
     borrow::Cow,
     fs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn handle_file(path: &Path, in_place: bool, opts: FormatOpts) -> anyhow::Result<
         fs::write(path, format!("{fixed}\n"))?;
         Ok(None)
     } else {
-        Ok(Some(fixed))
+        Ok(Some(format!("{fixed}\n")))
     }
 }
 
@@ -137,7 +137,7 @@ fn main() -> anyhow::Result<()> {
             .collect();
 
         for out in outputs {
-            println!("{out}");
+            print!("{out}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn handle_file(path: &Path, in_place: bool, opts: FormatOpts) -> anyhow::Result<
         fs::write(path, format!("{fixed}\n"))?;
         Ok(None)
     } else {
-        Ok(Some(format!("{fixed}\n")))
+        Ok(Some(fixed))
     }
 }
 
@@ -137,7 +137,7 @@ fn main() -> anyhow::Result<()> {
             .collect();
 
         for out in outputs {
-            print!("{out}");
+            println!("{out}");
         }
     }
 


### PR DESCRIPTION
## Summary
- adopt Rayon to process multiple files concurrently
- document concurrency crate and version
- update roadmap checkboxes

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687d73bed3b08322aef70f7770b2fdd9

## Summary by Sourcery

Enable concurrent file processing by integrating the Rayon crate and refactoring the CLI to execute file operations in parallel while preserving serial output order.

New Features:
- Process multiple input files in parallel using Rayon thread pools

Enhancements:
- Refactor main file-processing logic to use parallel iterators while preserving output order

Build:
- Add and pin rayon 1.10 dependency in Cargo.toml

Documentation:
- Update parallel-processing-roadmap with completed concurrency steps
- Add rayon-concurrency.md documenting the use of Rayon for concurrency