### PR TITLE
Refactor footnotes and document footnote flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ cargo install --path .
 
 ## Command-line usage
 
-
 ```bash
 mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes] [--in-place] [FILE...]
 ```
@@ -111,8 +110,8 @@ A brief intermission for pizza.
 
 ## Library usage
 
-The crate exposes helper functions for embedding the table-reflow logic in
-Rust projects:
+The crate exposes helper functions for embedding the table-reflow logic in Rust
+projects:
 
 ```rust
 use mdtablefix::{process_stream_opts, rewrite, Options};
@@ -124,6 +123,7 @@ fn main() -> std::io::Result<()> {
         wrap: true,
         ellipsis: true,
         fences: true,
+        footnotes: true,
         ..Default::default()
     };
     let fixed = process_stream_opts(&lines, opts);
@@ -135,7 +135,8 @@ fn main() -> std::io::Result<()> {
 
 - `process_stream_opts(lines: &[String], opts: Options) -> Vec<String>`
   rewrites tables in memory. The options enable paragraph wrapping, ellipsis
-  substitution, fence normalization and footnote conversion.
+  substitution, fence normalization and footnote conversion when `footnotes` is
+  set to `true`.
 
 - `rewrite(path: &Path) -> std::io::Result<()>` modifies a Markdown file on
   disk in-place.

--- a/docs/footnote-conversion.md
+++ b/docs/footnote-conversion.md
@@ -2,7 +2,9 @@
 
 `mdtablefix` can optionally convert bare numeric references into
 GitHub-flavoured Markdown footnotes. The `convert_footnotes` function performs
-this operation and is exposed via the higher-level `process_stream_opts` helper.
+this operation and is exposed via the higher-level `process_stream_opts`
+helper. Set `Options { footnotes: true, ..Default::default() }` when calling
+`process_stream_opts` to enable the conversion logic.
 
 Inline references that appear after punctuation are rewritten as footnote links.
 

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -17,13 +17,29 @@ static FOOTNOTE_LINE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|
 
 use crate::wrap::{Token, tokenize_markdown};
 
+/// Extract the components of an inline footnote reference.
+#[inline]
+fn capture_parts<'a>(caps: &'a Captures<'a>) -> (&'a str, &'a str, &'a str, &'a str, &'a str) {
+    (
+        &caps["pre"],
+        &caps["punc"],
+        &caps["style"],
+        &caps["num"],
+        &caps["boundary"],
+    )
+}
+
+/// Construct a footnote link from the captured components.
+#[inline]
+fn build_footnote(pre: &str, punc: &str, style: &str, num: &str, boundary: &str) -> String {
+    format!("{pre}{punc}{style}[^{num}]{boundary}")
+}
+
 fn convert_inline(text: &str) -> String {
     INLINE_FN_RE
         .replace_all(text, |caps: &Captures| {
-            format!(
-                "{}{}{}[^{}]{}",
-                &caps["pre"], &caps["punc"], &caps["style"], &caps["num"], &caps["boundary"]
-            )
+            let (pre, punc, style, num, boundary) = capture_parts(caps);
+            build_footnote(pre, punc, style, num, boundary)
         })
         .into_owned()
 }
@@ -61,13 +77,13 @@ where
 }
 
 fn convert_block(lines: &mut [String]) {
-    let (start, end) = trimmed_range(lines, |l| FOOTNOTE_LINE_RE.is_match(l));
+    let (footnote_start, trimmed_end) = trimmed_range(lines, |l| FOOTNOTE_LINE_RE.is_match(l));
 
-    if start >= end || lines[start].trim_start().starts_with("[^") {
+    if footnote_start >= trimmed_end || lines[footnote_start].trim_start().starts_with("[^") {
         return;
     }
 
-    for line in &mut lines[start..end] {
+    for line in &mut lines[footnote_start..trimmed_end] {
         *line = FOOTNOTE_LINE_RE
             .replace(line, "${indent}[^${num}] ${rest}")
             .to_string();
@@ -131,5 +147,41 @@ mod tests {
     fn idempotent_on_existing_block() {
         let input = vec![" [^1] First".to_string()];
         assert_eq!(convert_footnotes(&input), input);
+    }
+
+    #[test]
+    fn multiple_inline_notes_in_one_line() {
+        let input = vec!["First.1 Then?2".to_string()];
+        let expected = vec!["First.[^1] Then?[^2]".to_string()];
+        assert_eq!(convert_footnotes(&input), expected);
+    }
+
+    #[test]
+    fn ignores_non_numeric_footnote_block() {
+        let input = vec!["Text.".to_string(), " a. note".to_string()];
+        assert_eq!(convert_footnotes(&input), input);
+    }
+
+    #[test]
+    fn empty_input_returns_empty_vec() {
+        let input: Vec<String> = Vec::new();
+        assert!(convert_footnotes(&input).is_empty());
+    }
+
+    #[test]
+    fn converts_only_final_contiguous_block() {
+        let input = vec![
+            "Intro.".to_string(),
+            "1. not a footnote".to_string(),
+            "More text.".to_string(),
+            "2. final".to_string(),
+        ];
+        let expected = vec![
+            "Intro.".to_string(),
+            "1. not a footnote".to_string(),
+            "More text.".to_string(),
+            "[^2] final".to_string(),
+        ];
+        assert_eq!(convert_footnotes(&input), expected);
     }
 }

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -150,6 +150,13 @@ mod tests {
     }
 
     #[test]
+    fn converts_block_after_existing_line() {
+        let input = vec!["[^1] Old".to_string(), " 2. New".to_string()];
+        let expected = vec!["[^1] Old".to_string(), " [^2] New".to_string()];
+        assert_eq!(convert_footnotes(&input), expected);
+    }
+
+    #[test]
     fn multiple_inline_notes_in_one_line() {
         let input = vec!["First.1 Then?2".to_string()];
         let expected = vec!["First.[^1] Then?[^2]".to_string()];

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -1,9 +1,25 @@
 //! Integration tests for footnote conversion.
+//!
+//! These tests feed entire documents through `convert_footnotes` to validate
+//! the complete conversion pipeline. Sample inputs are loaded from data files
+//! using the helper macros `include_lines!` and `lines_vec!` exported by the
+//! `tests::prelude` module. The goal is to ensure inline references are
+//! rewritten and trailing numeric lists become footnote definitions without
+//! affecting other content.
+//!
+//! The presence of the macros here also confirms they are re-exported
+//! correctly for use across integration tests.
 
 use mdtablefix::convert_footnotes;
 
 #[macro_use]
 mod prelude;
+
+#[test]
+fn macros_available() {
+    let _: Vec<String> = lines_vec!("a", "b");
+    let _: Vec<String> = include_lines!("data/footnotes_input.txt");
+}
 
 #[test]
 fn test_convert_bare_footnotes() {


### PR DESCRIPTION
## Summary
- simplify inline footnote handling with helpers
- clarify variable naming in convert_block
- extend `convert_footnotes` unit tests
- document helper macros in footnote integration tests
- describe footnote option usage in docs and README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687d7e6c5ee48322beb353597af98426

## Summary by Sourcery

Refactor inline and block footnote conversion logic, extend tests for various footnote scenarios, and document the footnotes option in README and docs.

Enhancements:
- Extract inline footnote capture and build logic into helper functions for cleaner conversion
- Rename variables in convert_block for better clarity of footnote start and end indices

Documentation:
- Update README and documentation to describe enabling footnote conversion via the footnotes option in Options

Tests:
- Add unit tests for multiple inline notes, ignoring non-numeric and empty inputs, and final contiguous footnote blocks
- Add integration test to verify helper macros availability for footnote tests