### PR TITLE
Fix fence specifier indentation

### DIFF
--- a/src/fences.rs
+++ b/src/fences.rs
@@ -70,9 +70,7 @@ pub fn attach_orphan_specifiers(lines: &[String]) -> Vec<String> {
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
     let mut in_fence = false;
     for line in lines {
-        let trimmed = line.trim_end();
-
-        if let Some(cap) = FENCE_RE.captures(trimmed) {
+        if let Some(cap) = FENCE_RE.captures(line) {
             if in_fence {
                 in_fence = false;
                 out.push(line.clone());

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -166,3 +166,17 @@ fn attaches_orphan_specifier_preserves_indent() {
     let out = attach_orphan_specifiers(&compress_fences(&input));
     assert_eq!(out, lines_vec!["  ```rust", "  fn main() {}", "  ```"]);
 }
+
+#[test]
+fn attaches_orphan_specifier_preserves_tab_indent() {
+    let input = lines_vec!["\tRust", "", "\t```", "\tfn main() {}", "\t```"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, lines_vec!["\t```rust", "\tfn main() {}", "\t```"]);
+}
+
+#[test]
+fn attaches_orphan_specifier_mixed_indent() {
+    let input = lines_vec![" \tRust", "", " \t```", " \tfn main() {}", " \t```"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, lines_vec![" \t```rust", " \tfn main() {}", " \t```"]);
+}


### PR DESCRIPTION
## Summary
- fix indentation handling in `attach_orphan_specifiers`
- add regression test for indent preservation

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e7575ce088322867b301b3bf5ec2c

## Summary by Sourcery

Fix indentation handling when attaching orphan specifiers in fenced code blocks and add a regression test to ensure indent preservation

Bug Fixes:
- Use trim_end instead of trim to preserve leading indentation when attaching specifiers

Tests:
- Add a regression test to verify that orphan specifiers retain indentation when attached