### PR TITLE
Fix renumbering across blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes
   indentation (tabs are interpreted as four spaces) and restarts numbering
   after a list is interrupted by other content, such as a paragraph at a lower
   indentation level, a thematic break, or a heading. Blank lines between items
-  are ignored so numbering continues uninterrupted.
+  are ignored, so numbering continues uninterrupted.
 
 - Use `--breaks` to standardize thematic breaks to a line of 70 underscores
   (configurable via the `THEMATIC_BREAK_LEN` constant).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes
   numbering. The renumbering logic correctly handles nested lists by tracking
   indentation (tabs are interpreted as four spaces) and restarts numbering
   after a list is interrupted by other content, such as a paragraph at a lower
-  indentation level, a thematic break, or a heading.
+  indentation level, a thematic break, or a heading. Blank lines between items
+  are ignored so numbering continues uninterrupted.
 
 - Use `--breaks` to standardize thematic breaks to a line of 70 underscores
   (configurable via the `THEMATIC_BREAK_LEN` constant).

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -95,6 +95,12 @@ pub fn renumber_lists(lines: &[String]) -> Vec<String> {
             continue;
         }
 
+        if line.trim().is_empty() {
+            out.push(line.clone());
+            prev_blank = true;
+            continue;
+        }
+
         if let Some((indent_str, sep, rest)) = parse_numbered(line) {
             let indent = indent_len(indent_str);
             drop_deeper(indent, &mut counters);

--- a/tests/data/renumber_blank_lines_expected.txt
+++ b/tests/data/renumber_blank_lines_expected.txt
@@ -1,0 +1,11 @@
+  1. pyo3::marker - Rust, accessed on July 14, 2025,
+     <https://pyo3.rs/main/doc/pyo3/marker/>
+
+  2. Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
+     2025, <https://pyo3.rs/main/free-threading>
+
+  3. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+     <https://docs.rs/pyo3/0.25.1/pyo3/>
+
+  4. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+     <https://docs.rs/pyo3/latest/pyo3/>

--- a/tests/data/renumber_blank_lines_input.txt
+++ b/tests/data/renumber_blank_lines_input.txt
@@ -1,0 +1,11 @@
+  1. pyo3::marker - Rust, accessed on July 14, 2025,
+     <https://pyo3.rs/main/doc/pyo3/marker/>
+
+  1. Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
+     2025, <https://pyo3.rs/main/free-threading>
+
+  1. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+     <https://docs.rs/pyo3/0.25.1/pyo3/>
+
+  1. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+     <https://docs.rs/pyo3/latest/pyo3/>

--- a/tests/data/renumber_ordered_list_expected.txt
+++ b/tests/data/renumber_ordered_list_expected.txt
@@ -1,0 +1,5 @@
+1. Implement the `FemtoFormatter` trait and `DefaultFormatter` in Rust.
+2. Port `StreamHandler` and `FileHandler` following the producer–consumer model.
+3. Update the roadmap once these components have stable tests.
+4. Expand with rotating and network handlers as described in the roadmap's later
+   phases.

--- a/tests/data/renumber_ordered_list_input.txt
+++ b/tests/data/renumber_ordered_list_input.txt
@@ -1,0 +1,5 @@
+1. Implement the `FemtoFormatter` trait and `DefaultFormatter` in Rust.
+2. Port `StreamHandler` and `FileHandler` following the producer–consumer model.
+3. Update the roadmap once these components have stable tests.
+4. Expand with rotating and network handlers as described in the roadmap's later
+   phases.

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -127,6 +127,10 @@ fn test_cli_renumber_option() {
     case::blank_lines(
         include_lines!("data/renumber_blank_lines_input.txt"),
         include_lines!("data/renumber_blank_lines_expected.txt")
+    ),
+    case::ordered_list(
+        include_lines!("data/renumber_ordered_list_input.txt"),
+        include_lines!("data/renumber_ordered_list_expected.txt")
     )
 )]
 fn test_renumber_cases(input: Vec<String>, expected: Vec<String>) {

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -123,6 +123,10 @@ fn test_cli_renumber_option() {
     case::restart_after_break_and_heading(
         include_lines!("data/renumber_break_heading_restart_input.txt"),
         include_lines!("data/renumber_break_heading_restart_expected.txt")
+    ),
+    case::blank_lines(
+        include_lines!("data/renumber_blank_lines_input.txt"),
+        include_lines!("data/renumber_blank_lines_expected.txt")
     )
 )]
 fn test_renumber_cases(input: Vec<String>, expected: Vec<String>) {


### PR DESCRIPTION
## Summary
- ignore blank lines when renumbering ordered lists
- document that blank lines do not interrupt list numbering
- add regression test demonstrating renumbering with blank lines

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687ea87e7b748322b9eae5cc77a29507

## Summary by Sourcery

Ignore blank lines when renumbering ordered lists to maintain continuous numbering across blank lines, update documentation accordingly, and add regression tests

Bug Fixes:
- Skip blank lines when renumbering ordered lists to preserve correct numbering across blank lines

Documentation:
- Document that blank lines no longer interrupt list numbering

Tests:
- Add regression test and test data for renumbering lists with blank lines