### PR TITLE
Document concurrency behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes
 - If no files are specified, input is read from stdin and output is written to
   stdout.
 
+## Concurrency
+
+When multiple file paths are supplied the tool processes them in parallel using
+the [`rayon`](https://docs.rs/rayon) crate. Results are buffered so they can be
+printed in the original order. This coordination uses extra memory and can
+outweigh the speed gains when each file is small.
+
 ### Example: Table Reflowing
 
 Before:

--- a/docs/parallel-processing-roadmap.md
+++ b/docs/parallel-processing-roadmap.md
@@ -18,6 +18,6 @@ serial output order.
 - [ ] **Extend tests for parallel execution**
   - Use `rstest` to verify that processing many files yields correct results.
   - Add tests exercising error handling when some paths are invalid.
-- [ ] **Update documentation**
+- [x] **Update documentation**
   - Document the new flags or behaviour in `README.md` and module docs.
   - Note any concurrency caveats or performance implications.

--- a/docs/rayon-concurrency.md
+++ b/docs/rayon-concurrency.md
@@ -5,3 +5,8 @@
 tool relies on Rayon’s global thread pool so that no manual setup is required.
 The dependency is specified as `^1.0` in `Cargo.toml` to track stable API
 changes within the same major release.
+
+Parallelism is enabled automatically whenever more than one file path is
+provided on the command line. Each worker gathers its output before printing so
+results appear in the original order. This buffering increases memory usage and
+may reduce performance if many tiny files are processed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 //! Command-line interface for the mdtablefix tool.
 //!
 //! This module provides the main entry point and CLI parsing for fixing
-//! markdown table formatting. It supports concurrent processing of multiple
-//! files using Rayon for improved performance.
+//! markdown table formatting. It processes multiple files concurrently using
+//! Rayon. Each worker buffers its output so lines can be printed in the same
+//! order the paths were supplied. For many small files this coordination cost
+//! may outweigh the benefits of parallelism.
 
 use std::{
     borrow::Cow,


### PR DESCRIPTION
## Summary
- detail parallel processing in README
- describe how Rayon handles concurrency
- mark documentation task complete in roadmap
- note memory overhead in `main.rs`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687ec99ba9bc83228a87ec721997a86a