### PR TITLE
Update CLI docs and concurrency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes
 
 ## Concurrency
 
-When multiple file paths are supplied the tool processes them in parallel using
-the [`rayon`](https://docs.rs/rayon) crate. Results are buffered so they can be
-printed in the original order. This coordination uses extra memory and can
-outweigh the speed gains when each file is small.
+When multiple file paths are supplied, the tool processes them in parallel
+using the [`rayon`](https://docs.rs/rayon) crate. Results are buffered, so they
+can be printed in the original order. This coordination uses extra memory and
+can outweigh the speed gains when each file is small.
 
 ### Example: Table Reflowing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
-//! Command-line interface for the mdtablefix tool.
+//! Command-line interface for the `mdtablefix` tool.
 //!
-//! This module provides the main entry point and CLI parsing for fixing
-//! markdown table formatting. It processes multiple files concurrently using
-//! Rayon. Each worker buffers its output so lines can be printed in the same
-//! order the paths were supplied. For many small files this coordination cost
-//! may outweigh the benefits of parallelism.
+//! This module provides the main entry point for the command-line parsing in
+//! the `mdtablefix` crate. It fixes Markdown table formatting and processes
+//! multiple files concurrently using Rayon. Each worker buffers its output so
+//! lines can be printed in the same order the paths were supplied. For many
+//! small files, this coordination cost may outweigh the benefits of
+//! parallelism.
 
 use std::{
     borrow::Cow,


### PR DESCRIPTION
## Summary
- improve CLI module documentation
- fix concurrency paragraph grammar

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_687ed2a7673c83229681795a564a8e14