### PR TITLE
Improve fence specifier handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ alongside regular Markdown tables.
 
 See
 [HTML&nbsp;table&nbsp;support&nbsp;for&nbsp;more&nbsp;details](docs/architecture.md#html-table-support-in-mdtablefix)
-.
+ .
 
 ## Module structure
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Tag case and attributes are ignored. After conversion, they are reformatted
 alongside regular Markdown tables.
 
 See
-[HTML&nbsp;table&nbsp;support&nbsp;for&nbsp;more&nbsp;details](docs/architecture.md#html-table-support-in-mdtablefix)
- .
+[HTML table support for more details](docs/architecture.md#html-table-support-in-mdtablefix)
+.
 
 ## Module structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,9 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String>
 The function combines several helpers documented in `docs/`:
 
 - `fences::compress_fences` and `attach_orphan_specifiers` normalize code block
-  delimiters.
+  delimiters. `attach_orphan_specifiers` keeps indentation from the language
+  line when the fence lacks it and tolerates spaces between comma-separated
+  languages.
 - `html::convert_html_tables` transforms basic HTML tables into Markdown so \
     they can be reflowed like regular tables. See \
     [HTML table support](#html-table-support-in-mdtablefix).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,9 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String>
 The function combines several helpers documented in `docs/`:
 
 - `fences::compress_fences` and `attach_orphan_specifiers` normalize code block
-  delimiters. `attach_orphan_specifiers` keeps indentation from the language
-  line when the fence lacks it and tolerates spaces between comma-separated
-  languages.
+  delimiters. The latter keeps indentation from the language line when the
+  fence lacks it. It also tolerates spaces within comma-separated specifiers,
+  e.g. `TOML, Ini` becomes `toml,ini`.
 - `html::convert_html_tables` transforms basic HTML tables into Markdown so \
     they can be reflowed like regular tables. See \
     [HTML table support](#html-table-support-in-mdtablefix).

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -50,7 +50,9 @@ pub fn compress_fences(lines: &[String]) -> Vec<String> {
 ///
 /// After compressing fences, an orphaned specifier may remain as a single word
 /// on the line before a fence. This function removes that line and applies the
-/// specifier to the following opening fence.
+/// specifier to the following opening fence. Indentation from the specifier
+/// line is preserved when the fence itself is unindented. Specifiers containing
+/// spaces are accepted and normalised.
 ///
 /// # Examples
 ///
@@ -86,12 +88,31 @@ pub fn attach_orphan_specifiers(lines: &[String]) -> Vec<String> {
                     idx -= 1;
                 }
                 if idx > 0 {
-                    let candidate = out[idx - 1].trim().to_string();
-                    if ORPHAN_LANG_RE.is_match(&candidate)
+                    let candidate_raw = out[idx - 1].as_str();
+                    let candidate_trimmed = candidate_raw.trim();
+                    let candidate_clean = candidate_trimmed
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    if ORPHAN_LANG_RE.is_match(&candidate_clean)
                         && (idx == 1 || out[idx - 2].trim().is_empty())
                     {
+                        let candidate_indent: String = candidate_raw
+                            .chars()
+                            .take_while(|c| c.is_whitespace())
+                            .collect();
+                        let final_indent = if indent.is_empty() {
+                            candidate_indent.as_str()
+                        } else {
+                            indent
+                        };
                         out.truncate(idx - 1);
-                        out.push(format!("{indent}```{}", candidate.to_lowercase()));
+                        out.push(format!(
+                            "{final_indent}```{}",
+                            candidate_clean.to_lowercase()
+                        ));
                         in_fence = true;
                         continue;
                     }

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -22,7 +22,7 @@ static ORPHAN_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust,ignore
 /// use mdtablefix::fences::normalize_specifier;
 /// let (spec, indent) = normalize_specifier("  TOML, Ini");
 /// assert_eq!(spec, "toml,ini");

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -180,3 +180,17 @@ fn attaches_orphan_specifier_mixed_indent() {
     let out = attach_orphan_specifiers(&compress_fences(&input));
     assert_eq!(out, lines_vec![" \t```rust", " \tfn main() {}", " \t```"]);
 }
+
+#[test]
+fn attaches_orphan_specifier_uses_candidate_indent_when_fence_unindented() {
+    let input = lines_vec!["  Rust", "", "```", "fn main() {}", "```"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, lines_vec!["  ```rust", "fn main() {}", "```"]);
+}
+
+#[test]
+fn attaches_orphan_specifier_allows_spaces() {
+    let input = lines_vec!["TOML, Ini", "```", "a=1", "```"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, lines_vec!["```toml,ini", "a=1", "```"]);
+}

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -189,6 +189,13 @@ fn attaches_orphan_specifier_uses_candidate_indent_when_fence_unindented() {
 }
 
 #[test]
+fn attaches_orphan_specifier_with_mismatched_indent() {
+    let input = lines_vec!["  Rust", "", "\t```", "\tfn main() {}", "\t```"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, lines_vec!["\t```rust", "\tfn main() {}", "\t```"]);
+}
+
+#[test]
 fn attaches_orphan_specifier_allows_spaces() {
     let input = lines_vec!["TOML, Ini", "```", "a=1", "```"];
     let out = attach_orphan_specifiers(&compress_fences(&input));


### PR DESCRIPTION
## Summary
- preserve indentation from orphaned language lines when attaching code fence specifiers
- allow comma separated specifiers with spaces
- document the updated behaviour
- cover the edge cases with tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6883f8be90ac8322999b36de77ba4f56

## Summary by Sourcery

Improve code fence specifier handling by preserving indent from orphaned language lines and supporting comma-separated specifiers with spaces, update documentation, and add tests for edge cases

Enhancements:
- Preserve indentation from orphaned specifier lines when attaching code fence specifiers to unindented fences
- Accept and normalize comma-separated specifiers with spaces in code fences

Documentation:
- Document new indentation preservation and space-tolerant comma-separated specifier behavior in function and architecture docs

Tests:
- Add tests for indentation preservation when fences are unindented and for space-tolerant comma-separated specifiers