### PR TITLE
Fix link wrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,9 @@
   documentation should omit examples where the example serves only to reiterate
   the test logic.
 - **Keep file size managable.** No single code file may be longer than 400
-  lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be
-  moved to external data files.
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -318,5 +318,5 @@ sentences like:
 [link](path).
 ```
 
-on a single line rather than splitting the punctuation onto the next line when
+on a single line, rather than splitting the punctuation onto the next line when
 wrapping occurs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,3 +307,16 @@ multibyte characters from causing unexpected wraps or truncation.
 
 Whenever wrapping logic examines the length of a token, it relies on
 `UnicodeWidthStr::width` to measure visible columns rather than byte length.
+
+## Link punctuation handling
+
+Trailing punctuation immediately following a Markdown link or image is
+tokenised separately and grouped with the link when wrapping. This keeps
+sentences like:
+
+```markdown
+[link](path).
+```
+
+on a single line rather than splitting the punctuation onto the next line when
+wrapping occurs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -311,7 +311,7 @@ Whenever wrapping logic examines the length of a token, it relies on
 ## Link punctuation handling
 
 Trailing punctuation immediately following a Markdown link or image is
-tokenised separately and grouped with the link when wrapping. This keeps
+tokenized separately and grouped with the link when wrapping. This keeps
 sentences like:
 
 ```markdown

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -290,6 +290,7 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
                 .last_mut()
                 .expect("checked last line exists")
                 .push_str(&tokens[i]);
+            i += 1;
             continue;
         }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -278,9 +278,10 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
                 j += 1;
             }
         }
+
         if current.is_empty()
-            && token.len() == 1
-            && ".?!,:;".contains(token.as_str())
+            && tokens[i].len() == 1
+            && ".?!,:;".contains(tokens[i].as_str())
             && lines
                 .last()
                 .is_some_and(|l: &String| l.trim_end().ends_with('`'))
@@ -288,7 +289,7 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
             lines
                 .last_mut()
                 .expect("checked last line exists")
-                .push_str(&token);
+                .push_str(&tokens[i]);
             continue;
         }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -106,6 +106,10 @@ fn parse_link_or_image(chars: &[char], mut i: usize) -> (String, usize) {
                 }
                 i += 1;
             }
+            // treat trailing punctuation as part of the link token
+            if i < chars.len() && matches!(chars[i], '.' | ',' | '!' | '?' | ':' | ';') {
+                i += 1;
+            }
             let tok: String = chars[start..i].iter().collect();
             return (tok, i);
         }

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -487,6 +487,45 @@ fn test_wrap_link_with_trailing_punctuation() {
     assert_eq!(output, input);
 }
 
+/// Test links followed by various punctuation marks remain on a single line.
+#[rstest]
+#[case(".")]
+#[case(",")]
+#[case(";")]
+#[case(":")]
+#[case("!")]
+#[case("?")]
+#[case("...")]
+fn test_wrap_link_with_various_trailing_punctuation(#[case] punct: &str) {
+    let input = lines_vec![format!("[link](https://example.com){}", punct)];
+    let output = process_stream(&input);
+    assert_eq!(output, input, "Failed for punctuation: {punct}");
+}
+
+/// Test a link at line end without trailing punctuation.
+#[test]
+fn test_wrap_link_at_line_end() {
+    let input = lines_vec!["Check out [link](https://example.com)"];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+/// Test links containing punctuation within the link text.
+#[test]
+fn test_wrap_link_with_punctuation_in_text() {
+    let input = lines_vec!["[foo, bar!](https://example.com)"];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+/// Test links containing punctuation inside the URL.
+#[test]
+fn test_wrap_link_with_punctuation_in_url() {
+    let input = lines_vec!["[link](https://example.com/foo,bar)"];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
 /// Regression test for wrapping list items that end with a full stop.
 ///
 /// The period following the inline code span should remain on the same line

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -475,6 +475,18 @@ fn test_wrap_paragraph_with_nested_link() {
     );
 }
 
+/// Ensures punctuation immediately following a link remains attached when
+/// wrapping lines.
+#[test]
+fn test_wrap_link_with_trailing_punctuation() {
+    let input = lines_vec![
+        "[`rust-multithreaded-logging-framework-for-python-design.md`](./\
+         rust-multithreaded-logging-framework-for-python-design.md).",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
 /// Regression test for wrapping list items that end with a full stop.
 ///
 /// The period following the inline code span should remain on the same line


### PR DESCRIPTION
## Summary
- keep punctuation attached to links when wrapping text
- add regression test to cover the behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68880336f7b48322baf57d4482cc75eb

## Summary by Sourcery

Include trailing punctuation in link tokens during wrapping and add a regression test to verify the behavior

Bug Fixes:
- Treat punctuation immediately following a link as part of the link token so it stays attached during text wrapping

Tests:
- Add regression test to ensure trailing punctuation remains attached to links when wrapping lines