### PR TITLE
Preserve markdownlint directives when wrapping

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -372,6 +372,15 @@ pub fn wrap_text(lines: &[String], width: usize) -> Vec<String> {
             continue;
         }
 
+        let trimmed = line.trim();
+        if trimmed.starts_with("<!-- markdownlint-") && trimmed.ends_with("-->") {
+            flush_paragraph(&mut out, &buf, &indent, width);
+            buf.clear();
+            indent.clear();
+            out.push(line.clone());
+            continue;
+        }
+
         if line.trim().is_empty() {
             flush_paragraph(&mut out, &buf, &indent, width);
             buf.clear();

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -474,3 +474,36 @@ fn test_wrap_paragraph_with_nested_link() {
         "link with nested parentheses should remain intact",
     );
 }
+
+/// Ensures that markdownlint directives remain on their own line when wrapping.
+#[test]
+fn test_markdownlint_directive_not_broken() {
+    let input = lines_vec![
+        "[roadmap](./roadmap.md) and expands on the design ideas described in",
+        "<!-- markdownlint-disable-next-line MD013 -->",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+/// Regular comments should be reflowed like ordinary text when wrapping.
+#[test]
+fn test_regular_comment_wraps_normally() {
+    let input = lines_vec![
+        "Intro text that preludes a lengthy comment.",
+        concat!(
+            "<!-- This comment contains many words and should be wrapped across ",
+            "multiple lines to ensure that regular comments are formatted ",
+            "correctly. -->"
+        ),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(
+        output,
+        lines_vec![
+            "Intro text that preludes a lengthy comment. <!-- This comment contains many",
+            "words and should be wrapped across multiple lines to ensure that regular",
+            "comments are formatted correctly. -->",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- update wrap logic to keep `markdownlint` directives on a single line
- cover directive behaviour with integration tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68888eec3afc8322a17eab06cba6d228

## Summary by Sourcery

Preserve markdownlint directives on a single line during text wrapping and add tests to verify directive and comment wrapping behaviors

Enhancements:
- Special-case markdownlint directives in wrap_text to avoid breaking them across lines

Tests:
- Add test to ensure markdownlint directives remain unbroken when wrapping
- Add test to verify regular HTML comments wrap normally across lines