### PR TITLE
Preserve markdownlint directives when wrapping

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -18,7 +18,8 @@ static FOOTNOTE_RE: std::sync::LazyLock<Regex> =
 static BLOCKQUOTE_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^(\s*(?:>\s*)+)(.*)$").unwrap());
 
-/// Matches markdownlint directives such as `<!-- markdownlint-disable -->`.
+/// Matches markdownlint directives including `disable`, `enable`,
+/// `disable-line` and `disable-next-line` forms.
 static MARKDOWNLINT_DIRECTIVE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"^<!--\s*markdownlint-[^>]*-->$").expect("valid markdownlint regex")
 });

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -408,6 +408,15 @@ pub fn wrap_text(lines: &[String], width: usize) -> Vec<String> {
             continue;
         }
 
+        let trimmed = line.trim();
+        if trimmed.starts_with("<!-- markdownlint-") && trimmed.ends_with("-->") {
+            flush_paragraph(&mut out, &buf, &indent, width);
+            buf.clear();
+            indent.clear();
+            out.push(line.clone());
+            continue;
+        }
+
         if line.trim().is_empty() {
             flush_paragraph(&mut out, &buf, &indent, width);
             buf.clear();

--- a/tests/markdownlint.rs
+++ b/tests/markdownlint.rs
@@ -1,0 +1,56 @@
+//! Tests for markdownlint directive handling during wrapping.
+//!
+//! These tests ensure that comment directives such as
+//! `<!-- markdownlint-disable-next-line -->` remain on their own line
+//! after processing. Regular comments should still be wrapped normally.
+
+use mdtablefix::process_stream;
+
+#[macro_use]
+mod prelude;
+use prelude::*;
+
+/// The disable-next-line directive must remain intact after wrapping.
+#[test]
+fn test_markdownlint_disable_next_line_preserved() {
+    let input = lines_vec![
+        "[roadmap](./roadmap.md) and expands on the design ideas described in",
+        "<!--  markdownlint-disable-next-line  MD013  -->",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+/// Regular comments should still wrap when necessary.
+#[test]
+fn test_regular_comment_wraps_normally() {
+    let input = lines_vec![
+        "Intro text that preludes a lengthy comment.",
+        concat!(
+            "<!-- This comment contains many words and should be wrapped across ",
+            "multiple lines to ensure that regular comments are formatted ",
+            "correctly. -->"
+        ),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(
+        output,
+        lines_vec![
+            "Intro text that preludes a lengthy comment. <!-- This comment contains many",
+            "words and should be wrapped across multiple lines to ensure that regular",
+            "comments are formatted correctly. -->",
+        ]
+    );
+}
+
+/// Other markdownlint directives should also remain on their own lines, even
+/// when indented or combined with multiple rule names.
+#[rstest]
+#[case("<!-- markdownlint-disable-line MD001 MD005 -->")]
+#[case("<!-- markdownlint-enable MD001 -->")]
+#[case("    <!-- markdownlint-disable -->")]
+fn test_markdownlint_directive_variants_preserved(#[case] directive: &str) {
+    let input = lines_vec!["A preceding line.", directive];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -474,36 +474,3 @@ fn test_wrap_paragraph_with_nested_link() {
         "link with nested parentheses should remain intact",
     );
 }
-
-/// Ensures that markdownlint directives remain on their own line when wrapping.
-#[test]
-fn test_markdownlint_directive_not_broken() {
-    let input = lines_vec![
-        "[roadmap](./roadmap.md) and expands on the design ideas described in",
-        "<!--  markdownlint-disable-next-line  MD013  -->",
-    ];
-    let output = process_stream(&input);
-    assert_eq!(output, input);
-}
-
-/// Regular comments should be reflowed like ordinary text when wrapping.
-#[test]
-fn test_regular_comment_wraps_normally() {
-    let input = lines_vec![
-        "Intro text that preludes a lengthy comment.",
-        concat!(
-            "<!-- This comment contains many words and should be wrapped across ",
-            "multiple lines to ensure that regular comments are formatted ",
-            "correctly. -->"
-        ),
-    ];
-    let output = process_stream(&input);
-    assert_eq!(
-        output,
-        lines_vec![
-            "Intro text that preludes a lengthy comment. <!-- This comment contains many",
-            "words and should be wrapped across multiple lines to ensure that regular",
-            "comments are formatted correctly. -->",
-        ]
-    );
-}

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -480,7 +480,7 @@ fn test_wrap_paragraph_with_nested_link() {
 fn test_markdownlint_directive_not_broken() {
     let input = lines_vec![
         "[roadmap](./roadmap.md) and expands on the design ideas described in",
-        "<!-- markdownlint-disable-next-line MD013 -->",
+        "<!--  markdownlint-disable-next-line  MD013  -->",
     ];
     let output = process_stream(&input);
     assert_eq!(output, input);

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -474,3 +474,36 @@ fn test_wrap_paragraph_with_nested_link() {
         "link with nested parentheses should remain intact",
     );
 }
+
+/// Ensures that markdownlint directives remain on their own line when wrapping.
+#[test]
+fn test_markdownlint_directive_not_broken() {
+    let input = lines_vec![
+        "[roadmap](./roadmap.md) and expands on the design ideas described in",
+        "<!-- markdownlint-disable-next-line MD013 -->",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, input);
+}
+
+/// Regular comments should be reflowed like ordinary text when wrapping.
+#[test]
+fn test_regular_comment_wraps_normally() {
+    let input = lines_vec![
+        "Intro text that preludes a lengthy comment.",
+        concat!(
+            "<!-- This comment contains many words and should be wrapped across ",
+            "multiple lines to ensure that regular comments are formatted ",
+            "correctly. -->"
+        ),
+    ];
+    let output = process_stream(&input);
+    assert_eq!(
+        output,
+        lines_vec![
+            "Intro text that preludes a lengthy comment. <!-- This comment contains many",
+            "words and should be wrapped across multiple lines to ensure that regular",
+            "comments are formatted correctly. -->",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- update wrap logic to keep `markdownlint` directives on a single line
- cover directive behaviour with integration tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68888eec3afc8322a17eab06cba6d228

## Summary by Sourcery

Improve text wrapping to keep markdownlint directives on their own line and add tests to verify this behavior and normal comment wrapping

Enhancements:
- Detect and preserve markdownlint directives as standalone lines during wrapping

Tests:
- Add integration test to ensure markdownlint directives remain unwrapped
- Add integration test to verify regular HTML comments wrap as expected