### PR TITLE
Add regression test for trailing period in list items

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -201,6 +201,19 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
     let mut last_split: Option<usize> = None;
     for token in tokenize_inline(text) {
         let token_width = UnicodeWidthStr::width(token.as_str());
+        if current.is_empty()
+            && token.len() == 1
+            && ".?!,:;".contains(token.as_str())
+            && lines
+                .last()
+                .is_some_and(|l: &String| l.trim_end().ends_with('`'))
+        {
+            lines
+                .last_mut()
+                .expect("checked last line exists")
+                .push_str(&token);
+            continue;
+        }
         if current_width + token_width <= width {
             current.push_str(&token);
             current_width += token_width;

--- a/tests/data/bullet_colon_expected.txt
+++ b/tests/data/bullet_colon_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`:
+

--- a/tests/data/bullet_colon_input.txt
+++ b/tests/data/bullet_colon_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`:
+

--- a/tests/data/bullet_comma_expected.txt
+++ b/tests/data/bullet_comma_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`,
+

--- a/tests/data/bullet_comma_input.txt
+++ b/tests/data/bullet_comma_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`,
+

--- a/tests/data/bullet_exclamation_mark_expected.txt
+++ b/tests/data/bullet_exclamation_mark_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`!
+

--- a/tests/data/bullet_exclamation_mark_input.txt
+++ b/tests/data/bullet_exclamation_mark_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`!
+

--- a/tests/data/bullet_full_stop_expected.txt
+++ b/tests/data/bullet_full_stop_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`.
+

--- a/tests/data/bullet_full_stop_input.txt
+++ b/tests/data/bullet_full_stop_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`.
+

--- a/tests/data/bullet_question_mark_expected.txt
+++ b/tests/data/bullet_question_mark_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`?
+

--- a/tests/data/bullet_question_mark_input.txt
+++ b/tests/data/bullet_question_mark_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`?
+

--- a/tests/data/bullet_semicolon_expected.txt
+++ b/tests/data/bullet_semicolon_expected.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`;
+

--- a/tests/data/bullet_semicolon_input.txt
+++ b/tests/data/bullet_semicolon_input.txt
@@ -1,0 +1,7 @@
+- **StateScoped Entities:** A best practice for managing entity lifecycles in
+  conjunction with states is the use of `StateScoped(MyState::InGame)`
+  components.10 Entities spawned with such a component are automatically
+  despawned when the application exits the specified state. This greatly
+  simplifies cleanup logic in tests. For example:
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`;
+

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -486,3 +486,63 @@ fn test_wrap_list_item_period_after_code() {
     let output = process_stream(&input);
     assert_eq!(output, expected);
 }
+
+/// Regression test for wrapping list items that end with a question mark.
+///
+/// The question mark following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_question_mark_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_question_mark_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_question_mark_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
+/// Regression test for wrapping list items that end with an exclamation mark.
+///
+/// The exclamation mark following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_exclamation_mark_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_exclamation_mark_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_exclamation_mark_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
+/// Regression test for wrapping list items that end with a comma.
+///
+/// The comma following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_comma_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_comma_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_comma_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
+/// Regression test for wrapping list items that end with a colon.
+///
+/// The colon following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_colon_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_colon_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_colon_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
+/// Regression test for wrapping list items that end with a semicolon.
+///
+/// The semicolon following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_semicolon_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_semicolon_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_semicolon_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -474,3 +474,15 @@ fn test_wrap_paragraph_with_nested_link() {
         "link with nested parentheses should remain intact",
     );
 }
+
+/// Regression test for wrapping list items that end with a full stop.
+///
+/// The period following the inline code span should remain on the same line
+/// as the code block rather than being wrapped onto a new indented line.
+#[test]
+fn test_wrap_list_item_period_after_code() {
+    let input: Vec<String> = include_lines!("data/bullet_full_stop_input.txt");
+    let expected: Vec<String> = include_lines!("data/bullet_full_stop_expected.txt");
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
## Summary
- prevent line wrapping from splitting trailing punctuation after code spans
- cover the regression with a new test

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68889fa6ea8c832282c274fcbddc08f0

## Summary by Sourcery

Prevent line wrapping from splitting trailing punctuation after inline code spans and add a regression test for list items ending with a trailing period

Bug Fixes:
- Avoid splitting trailing punctuation tokens from code spans when wrapping lines

Tests:
- Add regression test and accompanying input/expected data for list items ending with a full stop after inline code