### PR TITLE
Fix CodeScene token duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,11 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
-      - id: generate-coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@b2f82fdc94c8c9da67833f972a02814c9ef8cf16
+      - uses: leynos/shared-actions/.github/actions/generate-coverage@b2f82fdc94c8c9da67833f972a02814c9ef8cf16
         with:
           output-path: lcov.info
           format: lcov
       - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN != '' }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
         with:


### PR DESCRIPTION
## Summary
- clean up CodeScene step envs
- drop unused step id in CI

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_6888c2113908832284f7b6e2cd1c20e0

## Summary by Sourcery

Clean up CI workflow by removing redundant step id and environment settings for CodeScene coverage upload

CI:
- Remove unused 'id: generate-coverage' from the coverage generation step
- Drop explicit CS_ACCESS_TOKEN environment block from the CodeScene upload step