### PR TITLE
Use io rewrite helpers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,16 +79,19 @@ fn process_lines(lines: &[String], opts: FormatOpts) -> Vec<String> {
 }
 
 fn handle_file(path: &Path, in_place: bool, opts: FormatOpts) -> anyhow::Result<Option<String>> {
-    let content =
-        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    let lines: Vec<String> = content.lines().map(str::to_string).collect();
-    let fixed = process_lines(&lines, opts).join("\n");
-
     if in_place {
-        fs::write(path, format!("{fixed}\n"))
-            .with_context(|| format!("writing {}", path.display()))?;
+        if opts.wrap {
+            mdtablefix::rewrite(path).with_context(|| format!("writing {}", path.display()))?;
+        } else {
+            mdtablefix::rewrite_no_wrap(path)
+                .with_context(|| format!("writing {}", path.display()))?;
+        }
         Ok(None)
     } else {
+        let content =
+            fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let lines: Vec<String> = content.lines().map(str::to_string).collect();
+        let fixed = process_lines(&lines, opts).join("\n");
         Ok(Some(fixed))
     }
 }


### PR DESCRIPTION
## Summary
- replace inline file handling with `io::rewrite` and `rewrite_no_wrap`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6888f677dfd88322ac57db5a4edfd52a

## Summary by Sourcery

Use the mdtablefix rewrite helpers to simplify file I/O in handle_file, delegating in-place updates to rewrite and rewrite_no_wrap and preserving manual processing for non-in-place mode.

Enhancements:
- Replace manual file read/write in handle_file with mdtablefix::rewrite and rewrite_no_wrap for in-place formatting
- Relocate manual file reading and line processing to the non-in-place branch to retain existing behavior