### PR TITLE
Add FormatOpts to Options conversion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,19 @@ struct FormatOpts {
     footnotes: bool,
 }
 
+impl From<FormatOpts> for Options {
+    fn from(opts: FormatOpts) -> Self {
+        Self {
+            wrap: opts.wrap,
+            ellipsis: opts.ellipsis,
+            fences: opts.fences,
+            footnotes: opts.footnotes,
+        }
+    }
+}
+
 fn process_lines(lines: &[String], opts: FormatOpts) -> Vec<String> {
-    let opts2 = Options {
-        wrap: opts.wrap,
-        ellipsis: opts.ellipsis,
-        fences: opts.fences,
-        footnotes: opts.footnotes,
-    };
-    let mut out = process_stream_opts(lines, opts2);
+    let mut out = process_stream_opts(lines, opts.into());
     if opts.renumber {
         out = renumber_lists(&out);
     }


### PR DESCRIPTION
## Summary
- convert `FormatOpts` into `Options` via `From` impl
- use `opts.into()` when processing lines

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6888f6f26928832284da1cde24834fc8

## Summary by Sourcery

Implement a From<FormatOpts> for Options to simplify conversion and update process_lines to use opts.into()

Enhancements:
- Add From<FormatOpts> for Options to centralize conversion logic
- Replace manual Options construction in process_lines with opts.into()