### PR TITLE
Refactor wrap_text case handling

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -25,29 +25,31 @@ struct PrefixHandler {
     rest_group: usize,
 }
 
-fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
+impl PrefixHandler {
+    fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
 
-fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
+    fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
 
-fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
+    fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
+}
 
 static HANDLERS: &[PrefixHandler] = &[
     PrefixHandler {
         re: &BULLET_RE,
         is_bq: false,
-        build_prefix: build_bullet_prefix,
+        build_prefix: PrefixHandler::build_bullet_prefix,
         rest_group: 2,
     },
     PrefixHandler {
         re: &FOOTNOTE_RE,
         is_bq: false,
-        build_prefix: build_footnote_prefix,
+        build_prefix: PrefixHandler::build_footnote_prefix,
         rest_group: 3,
     },
     PrefixHandler {
         re: &BLOCKQUOTE_RE,
         is_bq: true,
-        build_prefix: build_blockquote_prefix,
+        build_prefix: PrefixHandler::build_blockquote_prefix,
         rest_group: 2,
     },
 ];


### PR DESCRIPTION
## Summary
- extract block detection helpers
- delegate list item, footnote and blockquote processing to new helper functions
- keep `wrap_text` main loop focused on high level flow

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f66a0744832287eda00ac83afb5a

## Summary by Sourcery

Refactor wrap_text to improve readability and maintainability by extracting block detection and handling logic into dedicated helper functions and simplifying the main loop.

Enhancements:
- Extract is_list_item, is_footnote, and is_blockquote helpers to encapsulate regex captures for bullets, footnotes, and blockquotes
- Introduce handle_list_item, handle_footnote, and handle_blockquote functions to centralize prefixed line processing
- Simplify wrap_text main loop by delegating list item, footnote, and blockquote handling to the new helper functions