### PR TITLE
Refactor regex construction

### DIFF
--- a/src/breaks.rs
+++ b/src/breaks.rs
@@ -1,6 +1,6 @@
 //! Thematic break formatting utilities.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::LazyLock};
 
 use regex::Regex;
 
@@ -8,13 +8,12 @@ use crate::wrap::is_fence;
 
 pub const THEMATIC_BREAK_LEN: usize = 70;
 
-pub(crate) static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$")
-        .expect("valid thematic break regex")
-});
+pub(crate) static THEMATIC_BREAK_RE: LazyLock<Regex> = lazy_regex!(
+    r"^[ ]{0,3}((?:[ \t]*\*){3,}|(?:[ \t]*-){3,}|(?:[ \t]*_){3,})[ \t]*$",
+    "valid thematic break regex",
+);
 
-static THEMATIC_BREAK_LINE: std::sync::LazyLock<String> =
-    std::sync::LazyLock::new(|| "_".repeat(THEMATIC_BREAK_LEN));
+static THEMATIC_BREAK_LINE: LazyLock<String> = LazyLock::new(|| "_".repeat(THEMATIC_BREAK_LEN));
 
 #[must_use]
 pub fn format_breaks(lines: &[String]) -> Vec<Cow<'_, str>> {

--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -5,12 +5,13 @@
 //! complete triple remain. Fenced code blocks and inline code spans are left
 //! untouched.
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use crate::wrap::{Token, tokenize_markdown};
 
-static DOT_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"\.{3,}").expect("valid dot regex"));
+static DOT_RE: LazyLock<Regex> = lazy_regex!(r"\.{3,}", "valid dot regex");
 
 /// Replace `...` with `…` outside code spans and fences.
 #[must_use]

--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use crate::wrap::{Token, tokenize_markdown};
 
 static DOT_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"\.{3,}").unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r"\.{3,}").expect("valid dot regex"));
 
 /// Replace `...` with `…` outside code spans and fences.
 #[must_use]

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -8,14 +8,15 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-static FENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(\s*)(`{3,}|~{3,})([A-Za-z0-9_+.,-]*)\s*$").expect("valid fence regex")
-});
+static FENCE_RE: LazyLock<Regex> = lazy_regex!(
+    r"^(\s*)(`{3,}|~{3,})([A-Za-z0-9_+.,-]*)\s*$",
+    "valid fence regex"
+);
 
-static ORPHAN_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-](?:,[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-])*$")
-        .expect("valid language regex")
-});
+static ORPHAN_LANG_RE: LazyLock<Regex> = lazy_regex!(
+    r"^[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-](?:,[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-])*$",
+    "valid language regex"
+);
 
 /// Normalise a potential language specifier.
 ///

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -8,11 +8,13 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-static FENCE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*)(`{3,}|~{3,})([A-Za-z0-9_+.,-]*)\s*$").unwrap());
+static FENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(\s*)(`{3,}|~{3,})([A-Za-z0-9_+.,-]*)\s*$").expect("valid fence regex")
+});
 
 static ORPHAN_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-](?:,[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-])*$").unwrap()
+    Regex::new(r"^[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-](?:,[A-Za-z0-9_+.-]*[A-Za-z0-9_+\-])*$")
+        .expect("valid language regex")
 });
 
 /// Normalise a potential language specifier.

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -4,17 +4,19 @@
 //! footnote links and rewrites the trailing numeric list into a footnote
 //! block. Only the final contiguous list of footnotes is processed.
 
+use std::sync::LazyLock;
+
 use regex::{Captures, Regex};
 
-static INLINE_FN_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"(?P<pre>^|[^0-9])(?P<punc>[.!?);:])(?P<style>[*_]*)(?P<num>\d+)(?P<boundary>\s|$)")
-        .expect("valid inline footnote regex")
-});
+static INLINE_FN_RE: LazyLock<Regex> = lazy_regex!(
+    r"(?P<pre>^|[^0-9])(?P<punc>[.!?);:])(?P<style>[*_]*)(?P<num>\d+)(?P<boundary>\s|$)",
+    "valid inline footnote regex",
+);
 
-static FOOTNOTE_LINE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^(?P<indent>\s*)(?P<num>\d+)\.\s+(?P<rest>.*)$")
-        .expect("valid footnote line regex")
-});
+static FOOTNOTE_LINE_RE: LazyLock<Regex> = lazy_regex!(
+    r"^(?P<indent>\s*)(?P<num>\d+)\.\s+(?P<rest>.*)$",
+    "valid footnote line regex",
+);
 
 use crate::wrap::{Token, tokenize_markdown};
 

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -8,11 +8,12 @@ use regex::{Captures, Regex};
 
 static INLINE_FN_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"(?P<pre>^|[^0-9])(?P<punc>[.!?);:])(?P<style>[*_]*)(?P<num>\d+)(?P<boundary>\s|$)")
-        .unwrap()
+        .expect("valid inline footnote regex")
 });
 
 static FOOTNOTE_LINE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^(?P<indent>\s*)(?P<num>\d+)\.\s+(?P<rest>.*)$").unwrap()
+    Regex::new(r"^(?P<indent>\s*)(?P<num>\d+)\.\s+(?P<rest>.*)$")
+        .expect("valid footnote line regex")
 });
 
 use crate::wrap::{Token, tokenize_markdown};

--- a/src/html.rs
+++ b/src/html.rs
@@ -16,9 +16,10 @@ use crate::wrap::is_fence;
 
 /// Matches the start of an HTML `<table>` tag, ignoring case.
 static TABLE_START_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^<table(?:\s|>|$)").unwrap());
+    LazyLock::new(|| Regex::new(r"(?i)^<table(?:\s|>|$)").expect("valid table start regex"));
 /// Matches the end of an HTML `</table>` tag, ignoring case.
-static TABLE_END_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)</table>").unwrap());
+static TABLE_END_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)</table>").expect("valid table end regex"));
 
 /// Extracts the text content of a DOM node, collapsing consecutive
 /// whitespace to single spaces.

--- a/src/html.rs
+++ b/src/html.rs
@@ -16,10 +16,9 @@ use crate::wrap::is_fence;
 
 /// Matches the start of an HTML `<table>` tag, ignoring case.
 static TABLE_START_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^<table(?:\s|>|$)").expect("valid table start regex"));
+    lazy_regex!(r"(?i)^<table(?:\s|>|$)", "valid table start regex");
 /// Matches the end of an HTML `</table>` tag, ignoring case.
-static TABLE_END_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)</table>").expect("valid table end regex"));
+static TABLE_END_RE: LazyLock<Regex> = lazy_regex!(r"(?i)</table>", "valid table end regex");
 
 /// Extracts the text content of a DOM node, collapsing consecutive
 /// whitespace to single spaces.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 //! - `process` for stream processing.
 //! - `io` for file helpers.
 
+#[macro_use]
+mod macros;
+
 pub mod breaks;
 pub mod ellipsis;
 pub mod fences;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,5 +1,7 @@
 //! Ordered list renumbering utilities.
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use crate::{breaks::THEMATIC_BREAK_RE, wrap::is_fence};
@@ -9,14 +11,11 @@ const FORMATTING_CHARS: [char; 3] = ['*', '_', '`'];
 
 // Lines starting with optional indentation followed by '#' characters denote
 // Markdown ATX headings. A space or end of line must follow the hashes.
-static HEADING_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^[ ]{0,3}#{1,6}(?:\s|$)").expect("valid heading regex")
-});
+static HEADING_RE: LazyLock<Regex> = lazy_regex!(r"^[ ]{0,3}#{1,6}(?:\s|$)", "valid heading regex");
 
 fn parse_numbered(line: &str) -> Option<(&str, &str, &str)> {
-    static NUMBERED_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-        Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").expect("valid list number regex")
-    });
+    static NUMBERED_RE: LazyLock<Regex> =
+        lazy_regex!(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)", "valid list number regex",);
     let cap = NUMBERED_RE.captures(line)?;
     let indent = cap.get(1)?.as_str();
     let sep = cap.get(3)?.as_str();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,19 @@
+//! Helper macros used across the crate.
+
+/// Lazily compile a [`Regex`] with a custom panic message.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::LazyLock;
+///
+/// use regex::Regex;
+/// static RE: LazyLock<Regex> = mdtablefix::lazy_regex!(r"\d+", "digits");
+/// assert!(RE.is_match("42"));
+/// ```
+#[macro_export]
+macro_rules! lazy_regex {
+    ($pattern:expr, $msg:expr $(,)?) => {
+        LazyLock::new(|| Regex::new($pattern).expect($msg))
+    };
+}

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use crate::table::{SEP_RE, format_separator_cells, split_cells};
 
 static SENTINEL_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"\|\s*\|\s*").unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r"\|\s*\|\s*").expect("valid sentinel regex"));
 
 pub(crate) fn parse_rows(trimmed: &[String]) -> (Vec<Vec<String>>, bool) {
     let raw = trimmed.join(" ");

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1,14 +1,15 @@
-// Helper functions for reflowing markdown tables.
-//
-// These small utilities break down the steps of `reflow_table` so each
-// piece can be understood and tested independently.
+//! Helper functions for reflowing Markdown tables.
+//!
+//! These small utilities break down the steps of `reflow_table` so each
+//! piece can be understood and tested independently.
+
+use std::sync::LazyLock;
 
 use regex::Regex;
 
 use crate::table::{SEP_RE, format_separator_cells, split_cells};
 
-static SENTINEL_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"\|\s*\|\s*").expect("valid sentinel regex"));
+static SENTINEL_RE: LazyLock<Regex> = lazy_regex!(r"\|\s*\|\s*", "valid sentinel regex");
 
 pub(crate) fn parse_rows(trimmed: &[String]) -> (Vec<Vec<String>>, bool) {
     let raw = trimmed.join(" ");

--- a/src/table.rs
+++ b/src/table.rs
@@ -4,6 +4,8 @@
 //! [`docs/architecture.md`](../../docs/architecture.md).
 //! Provides helpers used by the `reflow` module and `reflow_table` itself.
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 fn next_is_pipe(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> bool {
@@ -89,8 +91,7 @@ fn rows_mismatched(rows: &[Vec<String>], split_within_line: bool) -> bool {
         .any(|row| row.len() != first_len && !row.iter().all(|c| SEP_RE.is_match(c)))
 }
 
-pub(crate) static SEP_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^[\s|:-]+$").expect("valid separator regex"));
+pub(crate) static SEP_RE: LazyLock<Regex> = lazy_regex!(r"^[\s|:-]+$", "valid separator regex");
 
 /// Holds the parsed and validated table data.
 ///

--- a/src/table.rs
+++ b/src/table.rs
@@ -90,7 +90,7 @@ fn rows_mismatched(rows: &[Vec<String>], split_within_line: bool) -> bool {
 }
 
 pub(crate) static SEP_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^[\s|:-]+$").unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r"^[\s|:-]+$").expect("valid separator regex"));
 
 /// Holds the parsed and validated table data.
 ///

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -4,22 +4,20 @@
 //! `docs/architecture.md` and uses the `unicode-width` crate for accurate
 //! display calculations.
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 
-static FENCE_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").expect("valid fence start regex"));
+static FENCE_RE: LazyLock<Regex> = lazy_regex!(r"^\s*(```|~~~).*", "valid fence start regex");
 
-static BULLET_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)").expect("valid list bullet regex")
-});
+static BULLET_RE: LazyLock<Regex> =
+    lazy_regex!(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)", "valid list bullet regex",);
 
-static FOOTNOTE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^(\s*)(\[\^[^]]+\]:\s*)(.*)$").expect("valid footnote regex")
-});
+static FOOTNOTE_RE: LazyLock<Regex> =
+    lazy_regex!(r"^(\s*)(\[\^[^]]+\]:\s*)(.*)$", "valid footnote regex",);
 
-static BLOCKQUOTE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^(\s*(?:>\s*)+)(.*)$").expect("valid blockquote regex")
-});
+static BLOCKQUOTE_RE: LazyLock<Regex> =
+    lazy_regex!(r"^(\s*(?:>\s*)+)(.*)$", "valid blockquote regex",);
 
 /// Markdown token emitted by [`tokenize_markdown`].
 #[derive(Debug, PartialEq)]

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -7,16 +7,19 @@
 use regex::Regex;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").expect("valid fence start regex"));
 
-static BULLET_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)").unwrap());
+static BULLET_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)").expect("valid list bullet regex")
+});
 
-static FOOTNOTE_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^(\s*)(\[\^[^]]+\]:\s*)(.*)$").unwrap());
+static FOOTNOTE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^(\s*)(\[\^[^]]+\]:\s*)(.*)$").expect("valid footnote regex")
+});
 
-static BLOCKQUOTE_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r"^(\s*(?:>\s*)+)(.*)$").unwrap());
+static BLOCKQUOTE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"^(\s*(?:>\s*)+)(.*)$").expect("valid blockquote regex")
+});
 
 /// Markdown token emitted by [`tokenize_markdown`].
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Summary
- use `expect` rather than `unwrap` when constructing regexes
- keep clippy clean

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f708fc6483228ad42b3b2cb97b1f

## Summary by Sourcery

Refactor regex construction by replacing unwrap calls with expect and descriptive panic messages, and harmonize lazy_static regex initializers for improved safety and clippy compliance.

Enhancements:
- Replace unwrap() with expect() and descriptive error messages for all lazy-initialized regexes
- Standardize regex initialization closures across multiple modules for consistency