### PR TITLE
Add doc comment for reflow helpers

### DIFF
--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1,7 +1,7 @@
-// Helper functions for reflowing markdown tables.
-//
-// These small utilities break down the steps of `reflow_table` so each
-// piece can be understood and tested independently.
+//! Helper functions for table reflow.
+//!
+//! The routines here parse raw rows, calculate cell widths, and format
+//! aligned output for the main [`reflow_table`] function.
 
 use regex::Regex;
 


### PR DESCRIPTION
## Summary
- document the `reflow` module using `//!` comments

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f7bb4d5083228f50919a4132da1f

## Summary by Sourcery

Documentation:
- Add //!-style documentation comments to the src/reflow.rs module to describe its reflow helper functions.