### PR TITLE
Add token processing helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -252,7 +252,6 @@ classDiagram
     table ..> reflow : uses parse_rows, etc.
     lists ..> wrap : uses is_fence
     breaks ..> wrap : uses is_fence
-    ellipsis ..> wrap : uses tokenize_markdown
     ellipsis ..> textproc : uses process_tokens
     process ..> html : uses convert_html_tables
     process ..> table : uses reflow_table

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,10 @@ classDiagram
         <<module>>
         +convert_footnotes()
     }
+    class textproc {
+        <<module>>
+        +process_tokens()
+    }
     class process {
         <<module>>
         +process_stream()
@@ -249,20 +253,23 @@ classDiagram
     lists ..> wrap : uses is_fence
     breaks ..> wrap : uses is_fence
     ellipsis ..> wrap : uses tokenize_markdown
+    ellipsis ..> textproc : uses process_tokens
     process ..> html : uses convert_html_tables
     process ..> table : uses reflow_table
     process ..> wrap : uses wrap_text, is_fence
     process ..> fences : uses compress_fences, attach_orphan_specifiers
     process ..> ellipsis : uses replace_ellipsis
     process ..> footnotes : uses convert_footnotes
+    footnotes ..> textproc : uses process_tokens
     io ..> process : uses process_stream, process_stream_no_wrap
 ```
 
 The `lib` module re-exports the public API from the other modules. The
-`ellipsis` module performs text normalization. The `process` module provides
-streaming helpers that combine the lower-level functions, including ellipsis
-replacement and footnote conversion. The `io` module handles filesystem
-operations, delegating the text processing to `process`.
+`ellipsis` module performs text normalization, while `footnotes` converts bare
+references. The `textproc` module contains shared token-processing helpers used
+by both. The `process` module provides streaming helpers that combine the
+lower-level functions. The `io` module handles filesystem operations,
+delegating the text processing to `process`.
 
 ## Concurrency with `rayon`
 

--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -9,41 +9,31 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::wrap::{Token, tokenize_markdown};
+use crate::{textproc::process_tokens, wrap::Token};
 
 static DOT_RE: LazyLock<Regex> = lazy_regex!(r"\.{3,}", "ellipsis pattern regex should compile");
 
 /// Replace `...` with `…` outside code spans and fences.
 #[must_use]
 pub fn replace_ellipsis(lines: &[String]) -> Vec<String> {
-    if lines.is_empty() {
-        return Vec::new();
-    }
-    let joined = lines.join("\n");
-    let mut out = String::new();
-    for token in tokenize_markdown(&joined) {
-        match token {
-            Token::Text(t) => {
-                let replaced = DOT_RE.replace_all(t, |caps: &regex::Captures<'_>| {
-                    let len = caps[0].len();
-                    let ellipses = "…".repeat(len / 3);
-                    let leftover = ".".repeat(len % 3);
-                    format!("{ellipses}{leftover}")
-                });
-                out.push_str(&replaced);
-            }
-            Token::Code(c) => {
-                out.push('`');
-                out.push_str(c);
-                out.push('`');
-            }
-            Token::Fence(f) => {
-                out.push_str(f);
-            }
-            Token::Newline => out.push('\n'),
+    process_tokens(lines, |token, out| match token {
+        Token::Text(t) => {
+            let replaced = DOT_RE.replace_all(t, |caps: &regex::Captures<'_>| {
+                let len = caps[0].len();
+                let ellipses = "…".repeat(len / 3);
+                let leftover = ".".repeat(len % 3);
+                format!("{ellipses}{leftover}")
+            });
+            out.push_str(&replaced);
         }
-    }
-    out.split('\n').map(str::to_string).collect()
+        Token::Code(c) => {
+            out.push('`');
+            out.push_str(c);
+            out.push('`');
+        }
+        Token::Fence(f) => out.push_str(f),
+        Token::Newline => out.push('\n'),
+    })
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod lists;
 pub mod process;
 mod reflow;
 pub mod table;
+mod textproc;
 pub mod wrap;
 
 #[doc(hidden)]

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -1,0 +1,73 @@
+//! Token-level transformation utilities.
+//!
+//! This module provides helpers for processing Markdown input by
+//! reusing the tokenizer from the [`wrap`] module. Each helper joins
+//! incoming lines, tokenizes them, and feeds the tokens to caller
+//! provided logic before splitting the output back into lines.
+
+use crate::wrap::{Token, tokenize_markdown};
+
+/// Apply a transformation to a sequence of [`Token`]s.
+///
+/// The `lines` slice is joined with newlines and tokenized. Each token
+/// is passed to `f` along with the output accumulator. The final
+/// string is split on newline characters and returned as a vector of
+/// lines.
+///
+/// # Examples
+///
+/// ```
+/// use mdtablefix::{
+///     textproc::process_tokens,
+///     wrap::{Token, tokenize_markdown},
+/// };
+///
+/// let lines = vec!["code".to_string()];
+/// let out = process_tokens(&lines, |tok, out| match tok {
+///     Token::Text(t) => out.push_str(t),
+///     Token::Code(c) => {
+///         out.push('`');
+///         out.push_str(c);
+///         out.push('`');
+///     }
+///     Token::Fence(f) => out.push_str(f),
+///     Token::Newline => out.push('\n'),
+/// });
+/// assert_eq!(out, lines);
+/// ```
+#[must_use]
+pub(crate) fn process_tokens<F>(lines: &[String], mut f: F) -> Vec<String>
+where
+    F: FnMut(Token<'_>, &mut String),
+{
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    let joined = lines.join("\n");
+    let mut out = String::new();
+    for token in tokenize_markdown(&joined) {
+        f(token, &mut out);
+    }
+    out.split('\n').map(str::to_string).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_transformation_returns_input() {
+        let lines = vec!["a `b`".to_string()];
+        let out = process_tokens(&lines, |tok, buf| match tok {
+            Token::Text(t) => buf.push_str(t),
+            Token::Code(c) => {
+                buf.push('`');
+                buf.push_str(c);
+                buf.push('`');
+            }
+            Token::Fence(f) => buf.push_str(f),
+            Token::Newline => buf.push('\n'),
+        });
+        assert_eq!(out, lines);
+    }
+}

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -49,6 +49,9 @@ where
     for token in tokenize_markdown(&joined) {
         f(token, &mut out);
     }
+    if out.is_empty() {
+        return Vec::new();
+    }
     let mut result: Vec<String> = out.split('\n').map(str::to_string).collect();
     let out_blanks = result.iter().rev().take_while(|l| l.is_empty()).count();
     for _ in out_blanks..trailing_blanks {
@@ -81,6 +84,13 @@ mod tests {
     fn empty_input_returns_empty_vector() {
         let lines: Vec<String> = Vec::new();
         let out = process_tokens(&lines, |_tok, _out| unreachable!());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn transformation_can_remove_all_content() {
+        let lines = vec!["data".to_string()];
+        let out = process_tokens(&lines, |_tok, _out| {});
         assert!(out.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- share token-processing logic in `process_tokens`
- use `process_tokens` in ellipsis and footnote modules
- cover the new helper with a unit test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f6ff67208322b8d20d3c1e042e70

## Summary by Sourcery

Centralize markdown token processing by introducing a reusable helper and refactor existing modules to leverage it

Enhancements:
- Extract common tokenization and output-assembly logic into a new process_tokens helper in a textproc module
- Refactor ellipsis and footnotes modules to replace manual token loops with process_tokens

Tests:
- Add unit test for process_tokens to verify identity transformation