### PR TITLE
Add doc examples for table helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
   examples demonstrating the usage and outcome of the function. Test
   documentation should omit examples where the example serves only to reiterate
   the test logic.
-- **Keep file size managable.** No single code file may be longer than 400
+- **Keep file size manageable.** No single code file may be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by
   feature and constituents colocated with targets. Large blocks of test data
   should be moved to external data files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,10 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
-  (`~`) should only be used where a dependency must be locked to patch-level
-  updates for a specific, documented reason.
+ open-ended inequality (`>=`) version requirements is strictly forbidden, as
+ they introduce unacceptable risk and unpredictability. Tilde requirements
+ (`~`) should only be used where a dependency must be locked to patch-level
+ updates for a specific, documented reason.
 
 ### Error Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators or comprehensions, and declarative code to imperative
-  repetition when readable.
+  logic. Prefer generators or comprehensions, and declarative code to
+  imperative repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining
@@ -25,12 +25,13 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
 - **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test documentation
-  should omit examples where the example serves only to reiterate the test logic.
-- **Keep file size managable.** No single code file may be longer than 400 lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be moved
-  to external data files.
+  examples demonstrating the usage and outcome of the function. Test
+  documentation should omit examples where the example serves only to reiterate
+  the test logic.
+- **Keep file size managable.** No single code file may be longer than 400
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 
@@ -42,8 +43,8 @@
   relevant file(s) in the `docs/` directory to reflect the latest state.
   **Ensure the documentation remains accurate and current.**
 - Documentation must use en-GB-oxendict ("-ize" / "-yse" / "-our") spelling
-  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which
-  is to be left unchanged for community consistency.)
+  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which is to be
+  left unchanged for community consistency.)
 
 ## Change Quality & Committing
 
@@ -153,19 +154,19 @@ project:
   specified in `Cargo.toml` must use SemVer-compatible caret requirements
   (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring
-  build stability and reproducibility.
+  changes from new major versions. This approach is critical for ensuring build
+  stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden
-  as they introduce unacceptable risk and unpredictability. Tilde requirements
+  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
 ### Error Handling
 
 - **Prefer semantic error enums**. Derive `std::error::Error` (via the
-  `thiserror` crate) for any condition the caller might inspect, retry, or
-  map to an HTTP status.
+  `thiserror` crate) for any condition the caller might inspect, retry, or map
+  to an HTTP status.
 - **Use an *opaque* error only at the app boundary**. Use `eyre::Report` for
   human-readable logs; these should not be exposed in public APIs.
 - **Never export the opaque type from a library**. Convert to domain enums at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
   the test logic.
 - **Keep file size manageable.** No single code file may be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by
-  feature and constituents colocated with targets. Large blocks of test data
+  feature and constituents co-located with targets. Large blocks of test data
   should be moved to external data files.
 
 ## Documentation Maintenance
@@ -157,10 +157,10 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
- open-ended inequality (`>=`) version requirements is strictly forbidden, as
- they introduce unacceptable risk and unpredictability. Tilde requirements
- (`~`) should only be used where a dependency must be locked to patch-level
- updates for a specific, documented reason.
+ open-ended inequality (`>=`) version requirements is strictly forbidden, as it
+ introduces unacceptable risk and unpredictability. Tilde requirements (`~`)
+ should only be used where a dependency must be locked to patch-level updates
+ for a specific, documented reason.
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ alongside regular Markdown tables.
 
 See
 [HTML table support for more details](docs/architecture.md#html-table-support-in-mdtablefix)
-.
+ .
 
 ## Module structure
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ alongside regular Markdown tables.
 
 See
 [HTML table support for more details](docs/architecture.md#html-table-support-in-mdtablefix)
- .
+.
 
 ## Module structure
 

--- a/src/breaks.rs
+++ b/src/breaks.rs
@@ -16,6 +16,30 @@ pub(crate) static THEMATIC_BREAK_RE: std::sync::LazyLock<Regex> = std::sync::Laz
 static THEMATIC_BREAK_LINE: std::sync::LazyLock<String> =
     std::sync::LazyLock::new(|| "_".repeat(THEMATIC_BREAK_LEN));
 
+/// Normalize thematic breaks outside fenced code blocks.
+///
+/// Consecutive hyphens, asterisks or underscores are replaced with a
+/// standardised line of underscores. Fenced code blocks are ignored so
+/// that breaks within them remain untouched.
+///
+/// # Examples
+///
+/// ```
+/// use std::borrow::Cow;
+///
+/// use mdtablefix::{THEMATIC_BREAK_LEN, format_breaks};
+///
+/// let lines = vec!["foo".to_string(), "***".to_string(), "bar".to_string()];
+/// let out = format_breaks(&lines);
+/// assert_eq!(
+///     out,
+///     vec![
+///         Cow::Borrowed("foo"),
+///         Cow::Owned("_".repeat(THEMATIC_BREAK_LEN)),
+///         Cow::Borrowed("bar"),
+///     ]
+/// );
+/// ```
 #[must_use]
 pub fn format_breaks(lines: &[String]) -> Vec<Cow<'_, str>> {
     let mut out = Vec::with_capacity(lines.len());

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,6 +11,24 @@ fn next_is_pipe(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> bool {
 }
 
 #[must_use]
+/// Split a Markdown table row into individual cell strings.
+///
+/// Escaped pipe characters (`\|`) are treated as literals and whitespace
+/// inside each cell is trimmed.
+///
+/// # Examples
+///
+/// ```
+/// use mdtablefix::split_cells;
+/// assert_eq!(
+///     split_cells("| A | B |"),
+///     vec!["A".to_string(), "B".to_string()]
+/// );
+/// assert_eq!(
+///     split_cells("a | b \\| c | d"),
+///     vec!["a".to_string(), "b | c".to_string(), "d".to_string()]
+/// );
+/// ```
 pub fn split_cells(line: &str) -> Vec<String> {
     let mut s = line.trim();
     if let Some(stripped) = s.strip_prefix('|') {
@@ -162,6 +180,25 @@ fn calculate_and_format(
     crate::reflow::insert_separator(out, sep_cells, &widths, indent)
 }
 
+/// Reflow a Markdown table so columns align uniformly.
+///
+/// Invalid tables are returned unchanged.
+///
+/// # Examples
+///
+/// ```
+/// use mdtablefix::reflow_table;
+/// let lines = vec![
+///     "| A | B |    |".to_string(),
+///     "| 1 | 2 |  | 3 | 4 |".to_string(),
+/// ];
+/// let expected = vec![
+///     "| A | B |".to_string(),
+///     "| 1 | 2 |".to_string(),
+///     "| 3 | 4 |".to_string(),
+/// ];
+/// assert_eq!(reflow_table(&lines), expected);
+/// ```
 #[must_use]
 pub fn reflow_table(lines: &[String]) -> Vec<String> {
     if lines.is_empty() {


### PR DESCRIPTION
## Summary
- document `format_breaks` with a simple Rustdoc example
- add examples to `split_cells` and `reflow_table`
- run `make fmt`, `make lint` and `make test`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f6653184832283bebd7d9927a75f

## Summary by Sourcery

Add usage examples to the Rustdoc comments for table helper functions and refine project documentation formatting.

Documentation:
- Add Rustdoc examples for split_cells, reflow_table, and format_breaks to illustrate their usage
- Refine line wrapping and spacing in AGENTS.md and README.md for consistent documentation formatting

Chores:
- Apply code formatting and lint fixes by running make fmt, make lint, and make test