### PR TITLE
Add CLI module documentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
-//! Command-line interface for the `mdtablefix` tool.
+//! Command-line interface for `mdtablefix`.
 //!
-//! This module provides the main entry point for the command-line parsing in
-//! the `mdtablefix` crate. It fixes Markdown table formatting and processes
-//! multiple files concurrently using the `rayon` crate. Each worker buffers
-//! its output so lines can be printed in the same order the paths were
-//! supplied. For many small files, this coordination cost may outweigh the
-//! benefits of parallelism.
+//! Parses command-line arguments and coordinates file processing. When paths
+//! are supplied, each file can be rewritten in place and processing is
+//! parallelised with Rayon. Without paths the tool reads from standard input.
+//! Outputs always appear in the same order the paths were provided.
 
 use std::{
     borrow::Cow,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 //! Command-line interface for `mdtablefix`.
 //!
-//! Parses command-line arguments and coordinates file processing. When paths
-//! are supplied, each file can be rewritten in place and processing is
-//! parallelised with Rayon. Without paths the tool reads from standard input.
-//! Outputs always appear in the same order the paths were provided.
+//! Parses command-line arguments and coordinate file processing. When paths are
+//! supplied, each file can be rewritten in place and processing is
+//! parallelized with Rayon. Without paths the tool reads from standard input.
+//! Output always appears in the same order as the paths are provided.
 
 use std::{
     borrow::Cow,


### PR DESCRIPTION
## Summary
- improve `src/main.rs` module documentation with an inner doc comment

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888fb2044b48322aaeb92936389f9b2

## Summary by Sourcery

Enhance CLI documentation by adding an inner doc comment to the main module for better clarity.

Enhancements:
- Add an inner module documentation comment to src/main.rs to clarify the CLI entrypoint.

Documentation:
- Improve CLI module documentation with an inner doc comment in main.rs.