### PR TITLE
Refactor markdownlint test imports

### DIFF
--- a/tests/markdownlint.rs
+++ b/tests/markdownlint.rs
@@ -4,10 +4,9 @@
 //! `<!-- markdownlint-disable-next-line -->` remain on their own line
 //! after processing. Regular comments should still be wrapped normally.
 
-use mdtablefix::process_stream;
-
 #[macro_use]
 mod prelude;
+use mdtablefix::process_stream;
 use prelude::*;
 
 /// The disable-next-line directive must remain intact after wrapping.


### PR DESCRIPTION
## Summary
- reorder test imports in `tests/markdownlint.rs` for clarity

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68896ea71f208322a9a0dceb100f1011

## Summary by Sourcery

Enhancements:
- Reorder test imports in tests/markdownlint.rs for clarity