### PR TITLE
Add streaming token processing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,9 +266,9 @@ classDiagram
 The `lib` module re-exports the public API from the other modules. The
 `ellipsis` module performs text normalization, while `footnotes` converts bare
 references. The `textproc` module contains shared token-processing helpers used
-by both. The `process` module provides streaming helpers that combine the
-lower-level functions. The `io` module handles filesystem operations,
-delegating the text processing to `process`.
+by both the `ellipsis` and `footnotes` modules. The `process` module provides
+streaming helpers that combine the lower-level functions. The `io` module
+handles filesystem operations, delegating the text processing to `process`.
 
 The helper `html_table_to_markdown` is retained for backward compatibility but
 is deprecated. New code should call `convert_html_tables` instead.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,10 @@ classDiagram
         <<module>>
         +convert_footnotes()
     }
+    class textproc {
+        <<module>>
+        +process_tokens()
+    }
     class process {
         <<module>>
         +process_stream()
@@ -248,21 +252,23 @@ classDiagram
     table ..> reflow : uses parse_rows, etc.
     lists ..> wrap : uses is_fence
     breaks ..> wrap : uses is_fence
-    ellipsis ..> wrap : uses tokenize_markdown
+    ellipsis ..> textproc : uses process_tokens
     process ..> html : uses convert_html_tables
     process ..> table : uses reflow_table
     process ..> wrap : uses wrap_text, is_fence
     process ..> fences : uses compress_fences, attach_orphan_specifiers
     process ..> ellipsis : uses replace_ellipsis
     process ..> footnotes : uses convert_footnotes
+    footnotes ..> textproc : uses process_tokens
     io ..> process : uses process_stream, process_stream_no_wrap
 ```
 
 The `lib` module re-exports the public API from the other modules. The
-`ellipsis` module performs text normalization. The `process` module provides
-streaming helpers that combine the lower-level functions, including ellipsis
-replacement and footnote conversion. The `io` module handles filesystem
-operations, delegating the text processing to `process`.
+`ellipsis` module performs text normalization, while `footnotes` converts bare
+references. The `textproc` module contains shared token-processing helpers used
+by both. The `process` module provides streaming helpers that combine the
+lower-level functions. The `io` module handles filesystem operations,
+delegating the text processing to `process`.
 
 The helper `html_table_to_markdown` is retained for backward compatibility but
 is deprecated. New code should call `convert_html_tables` instead.

--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -9,41 +9,35 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::wrap::{Token, tokenize_markdown};
+use crate::textproc::{Token, process_tokens};
 
 static DOT_RE: LazyLock<Regex> = lazy_regex!(r"\.{3,}", "ellipsis pattern regex should compile");
 
 /// Replace `...` with `…` outside code spans and fences.
 #[must_use]
 pub fn replace_ellipsis(lines: &[String]) -> Vec<String> {
-    if lines.is_empty() {
-        return Vec::new();
-    }
-    let joined = lines.join("\n");
-    let mut out = String::new();
-    for token in tokenize_markdown(&joined) {
-        match token {
-            Token::Text(t) => {
-                let replaced = DOT_RE.replace_all(t, |caps: &regex::Captures<'_>| {
-                    let len = caps[0].len();
-                    let ellipses = "…".repeat(len / 3);
-                    let leftover = ".".repeat(len % 3);
-                    format!("{ellipses}{leftover}")
-                });
-                out.push_str(&replaced);
+    process_tokens(lines, |token, out| match token {
+        Token::Text(t) => {
+            if !DOT_RE.is_match(t) {
+                out.push_str(t);
+                return;
             }
-            Token::Code(c) => {
-                out.push('`');
-                out.push_str(c);
-                out.push('`');
-            }
-            Token::Fence(f) => {
-                out.push_str(f);
-            }
-            Token::Newline => out.push('\n'),
+            let replaced = DOT_RE.replace_all(t, |caps: &regex::Captures<'_>| {
+                let len = caps[0].len();
+                let ellipses = "…".repeat(len / 3);
+                let leftover = ".".repeat(len % 3);
+                format!("{ellipses}{leftover}")
+            });
+            out.push_str(&replaced);
         }
-    }
-    out.split('\n').map(str::to_string).collect()
+        Token::Code(c) => {
+            out.push('`');
+            out.push_str(c);
+            out.push('`');
+        }
+        Token::Fence(f) => out.push_str(f),
+        Token::Newline => out.push('\n'),
+    })
 }
 
 #[cfg(test)]

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -18,7 +18,7 @@ static FOOTNOTE_LINE_RE: LazyLock<Regex> = lazy_regex!(
     "footnote line pattern should compile",
 );
 
-use crate::wrap::{Token, tokenize_markdown};
+use crate::textproc::{Token, process_tokens};
 
 /// Extract the components of an inline footnote reference.
 #[inline]
@@ -96,24 +96,16 @@ fn convert_block(lines: &mut [String]) {
 /// Convert bare numeric footnote references to Markdown footnote syntax.
 #[must_use]
 pub fn convert_footnotes(lines: &[String]) -> Vec<String> {
-    if lines.is_empty() {
-        return Vec::new();
-    }
-    let joined = lines.join("\n");
-    let mut out = String::new();
-    for token in tokenize_markdown(&joined) {
-        match token {
-            Token::Text(t) => out.push_str(&convert_inline(t)),
-            Token::Code(c) => {
-                out.push('`');
-                out.push_str(c);
-                out.push('`');
-            }
-            Token::Fence(f) => out.push_str(f),
-            Token::Newline => out.push('\n'),
+    let mut lines = process_tokens(lines, |token, out| match token {
+        Token::Text(t) => out.push_str(&convert_inline(t)),
+        Token::Code(c) => {
+            out.push('`');
+            out.push_str(c);
+            out.push('`');
         }
-    }
-    let mut lines: Vec<String> = out.split('\n').map(str::to_string).collect();
+        Token::Fence(f) => out.push_str(f),
+        Token::Newline => out.push('\n'),
+    });
     convert_block(&mut lines);
     lines
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! - `ellipsis` for normalizing textual ellipses.
 //! - `fences` for issues with code block fences
 //! - `footnotes` for converting bare footnote links.
+//! - `textproc` for token-based transformations.
 //! - `process` for stream processing.
 //! - `io` for file helpers.
 
@@ -29,7 +30,7 @@ pub mod lists;
 pub mod process;
 mod reflow;
 pub mod table;
-mod textproc;
+pub mod textproc;
 pub mod wrap;
 
 #[deprecated(note = "this function is legacy; use `convert_html_tables` instead")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod lists;
 pub mod process;
 mod reflow;
 pub mod table;
+mod textproc;
 pub mod wrap;
 
 #[deprecated(note = "this function is legacy; use `convert_html_tables` instead")]

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -1,0 +1,199 @@
+//! Provides helpers for token-based transformations of Markdown lines.
+//!
+//! This module reuses the tokenizer from the [`wrap`] module and offers
+//! a streaming API for rewriting Markdown. Each helper tokenizes lines
+//! on the fly, feeds the resulting tokens to caller-provided logic, and
+//! then reconstructs the lines. Trailing blank lines roundtrip
+//! correctly.
+
+pub use crate::wrap::Token;
+use crate::wrap::is_fence;
+
+/// Apply a transformation to a sequence of [`Token`]s.
+///
+/// The `lines` slice is tokenized in order, preserving fence context.
+/// Each token is passed to `f` along with the output accumulator. The
+/// final string is split on newline characters and returned as a
+/// vector of lines.
+///
+/// # Examples
+///
+/// ```ignore
+/// use mdtablefix::{
+///     textproc::process_tokens,
+///     wrap::Token,
+/// };
+///
+/// let lines = vec!["code".to_string()];
+/// let out = process_tokens(&lines, |tok, out| match tok {
+///     Token::Text(t) => out.push_str(t),
+///     Token::Code(c) => {
+///         out.push('`');
+///         out.push_str(c);
+///         out.push('`');
+///     }
+///     Token::Fence(f) => out.push_str(f),
+///     Token::Newline => out.push('\n'),
+/// });
+/// assert_eq!(out, lines);
+/// ```
+#[must_use]
+pub(crate) fn process_tokens<F>(lines: &[String], mut f: F) -> Vec<String>
+where
+    F: FnMut(Token<'_>, &mut String),
+{
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let trailing_blanks = lines.iter().rev().take_while(|l| l.is_empty()).count();
+    if trailing_blanks == lines.len() {
+        return vec![String::new(); lines.len()];
+    }
+
+    let mut out = String::new();
+    let mut in_fence = false;
+    let last_idx = lines.len() - 1;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.as_str();
+        if is_fence(trimmed) {
+            f(Token::Fence(trimmed), &mut out);
+            if i < last_idx {
+                f(Token::Newline, &mut out);
+            }
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            f(Token::Fence(trimmed), &mut out);
+            if i < last_idx {
+                f(Token::Newline, &mut out);
+            }
+            continue;
+        }
+        let mut rest = trimmed;
+        while let Some(pos) = rest.find('`') {
+            if pos > 0 {
+                f(Token::Text(&rest[..pos]), &mut out);
+            }
+            if let Some(end) = rest[pos + 1..].find('`') {
+                f(Token::Code(&rest[pos + 1..pos + 1 + end]), &mut out);
+                rest = &rest[pos + end + 2..];
+            } else {
+                f(Token::Text(&rest[pos..]), &mut out);
+                rest = "";
+                break;
+            }
+        }
+        if !rest.is_empty() {
+            f(Token::Text(rest), &mut out);
+        }
+        if i < last_idx {
+            f(Token::Newline, &mut out);
+        }
+    }
+
+    if out.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result: Vec<String> = out.split('\n').map(str::to_string).collect();
+    let out_blanks = result.iter().rev().take_while(|l| l.is_empty()).count();
+    for _ in out_blanks..trailing_blanks {
+        result.push(String::new());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_transformation_returns_input() {
+        let lines = vec!["a `b`".to_string()];
+        let out = process_tokens(&lines, |tok, buf| match tok {
+            Token::Text(t) => buf.push_str(t),
+            Token::Code(c) => {
+                buf.push('`');
+                buf.push_str(c);
+                buf.push('`');
+            }
+            Token::Fence(f) => buf.push_str(f),
+            Token::Newline => buf.push('\n'),
+        });
+        assert_eq!(out, lines);
+    }
+
+    #[test]
+    fn empty_input_returns_empty_vector() {
+        let lines: Vec<String> = Vec::new();
+        let out = process_tokens(&lines, |_tok, _out| unreachable!());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn transformation_can_remove_all_content() {
+        let lines = vec!["data".to_string()];
+        let out = process_tokens(&lines, |_tok, _out| {});
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn preserves_trailing_blank_lines() {
+        let lines = vec!["a".to_string(), String::new(), String::new()];
+        let out = process_tokens(&lines, |tok, buf| match tok {
+            Token::Text(t) => buf.push_str(t),
+            Token::Code(c) => {
+                buf.push('`');
+                buf.push_str(c);
+                buf.push('`');
+            }
+            Token::Fence(f) => buf.push_str(f),
+            Token::Newline => buf.push('\n'),
+        });
+        assert_eq!(out, lines);
+    }
+
+    #[test]
+    fn blanks_only_are_preserved() {
+        let lines = vec![String::new(), String::new()];
+        let out = process_tokens(&lines, |_tok, _buf| {});
+        assert_eq!(out, lines);
+    }
+
+    #[test]
+    fn token_stream_handles_fences() {
+        let lines = vec![
+            "```rust".to_string(),
+            "fn main() {".to_string(),
+            "    println!(\"hi\");".to_string(),
+            "```".to_string(),
+        ];
+        let mut tokens = Vec::new();
+        let _ = process_tokens(&lines, |tok, _| tokens.push(format!("{tok:?}")));
+        let expected = vec![
+            "Fence(\"```rust\")".to_string(),
+            "Newline".to_string(),
+            "Fence(\"fn main() {\")".to_string(),
+            "Newline".to_string(),
+            "Fence(\"    println!(\\\"hi\\\");\")".to_string(),
+            "Newline".to_string(),
+            "Fence(\"```\")".to_string(),
+        ];
+        assert_eq!(tokens, expected);
+    }
+
+    #[test]
+    fn malformed_fence_sequence_returns_tokens() {
+        let lines = vec!["```".to_string(), "code".to_string()];
+        let mut tokens = Vec::new();
+        let _ = process_tokens(&lines, |tok, _| tokens.push(format!("{tok:?}")));
+        let expected = vec![
+            "Fence(\"```\")".to_string(),
+            "Newline".to_string(),
+            "Fence(\"code\")".to_string(),
+        ];
+        assert_eq!(tokens, expected);
+    }
+}

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -37,6 +37,18 @@ static MARKDOWNLINT_DIRECTIVE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLo
     )
     .expect("valid markdownlint regex")
 });
+/// Markdown token emitted by token-processing helpers.
+#[derive(Debug, PartialEq)]
+pub enum Token<'a> {
+    /// Line within a fenced code block, including the fence itself.
+    Fence(&'a str),
+    /// Inline code span without surrounding backticks.
+    Code(&'a str),
+    /// Plain text outside code regions.
+    Text(&'a str),
+    /// Line break separating tokens.
+    Newline,
+}
 
 struct PrefixHandler {
     re: &'static std::sync::LazyLock<Regex>,
@@ -51,6 +63,77 @@ impl PrefixHandler {
     fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
 
     fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
+fn tokenize_inline(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c.is_whitespace() {
+            let start = i;
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            tokens.push(chars[start..i].iter().collect());
+        } else if c == '`' {
+            let start = i;
+            let mut delim_len = 0;
+            while i < chars.len() && chars[i] == '`' {
+                i += 1;
+                delim_len += 1;
+            }
+            let mut end = i;
+            while end < chars.len() {
+                if chars[end] == '`' {
+                    let mut j = end;
+                    let mut count = 0;
+                    while j < chars.len() && chars[j] == '`' {
+                        j += 1;
+                        count += 1;
+                    }
+                    if count == delim_len {
+                        end = j;
+                        break;
+                    }
+                }
+                end += 1;
+            }
+            if end >= chars.len() {
+                tokens.push(chars[start..start + delim_len].iter().collect());
+                i = start + delim_len;
+            } else {
+                tokens.push(chars[start..end].iter().collect());
+                i = end;
+            }
+        } else if c == '[' || (c == '!' && i + 1 < chars.len() && chars[i + 1] == '[') {
+            let (tok, new_i) = parse_link_or_image(&chars, i);
+            tokens.push(tok);
+            i = new_i;
+        } else {
+            let start = i;
+            while i < chars.len() && !chars[i].is_whitespace() && chars[i] != '`' {
+                i += 1;
+            }
+            tokens.push(chars[start..i].iter().collect());
+        }
+    }
+    tokens
+}
+
+/// Determine if the current line should break at the last whitespace.
+///
+/// Returns `true` if `current_width` exceeds `width` and a whitespace split
+/// position is available.
+///
+/// # Examples
+///
+/// ```ignore
+/// use mdtablefix::wrap::should_break_line;
+/// assert!(should_break_line(10, 12, Some(3)));
+/// assert!(!should_break_line(10, 8, Some(3)));
+/// ```
+fn should_break_line(width: usize, current_width: usize, last_split: Option<usize>) -> bool {
+    current_width > width && last_split.is_some()
 }
 
 static HANDLERS: &[PrefixHandler] = &[


### PR DESCRIPTION
## Summary
- rewrite `process_tokens` to stream lines and preserve fence context
- adjust documentation for the `textproc` and `wrap` modules
- remove the unused `tokenize_markdown` helper
- update architecture diagram
- add a test for blank-only input

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6888f6ff67208322b8d20d3c1e042e70

## Summary by Sourcery

Provide a shared streaming token-processing helper in a new textproc module, migrate existing Markdown transforms (ellipsis and footnotes) to use it, remove the old tokenizer, and update documentation accordingly.

New Features:
- Introduce textproc::process_tokens API for streaming Markdown token transformations.

Enhancements:
- Refactor ellipsis and footnote conversion to use process_tokens instead of tokenize_markdown.
- Remove the unused tokenize_markdown function and adjust wrap module documentation.

Documentation:
- Update architecture diagram and module docs to reference the new textproc module and streaming API.

Tests:
- Add tests for process_tokens covering blank-only input, fence handling, and identity transformations.