### PR TITLE
Fix duplicate punctuation after inline code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,9 @@
   documentation should omit examples where the example serves only to reiterate
   the test logic.
 - **Keep file size managable.** No single code file may be longer than 400
-  lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be
-  moved to external data files.
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -290,6 +290,7 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
                 .last_mut()
                 .expect("checked last line exists")
                 .push_str(&tokens[i]);
+            i += 1;
             continue;
         }
 


### PR DESCRIPTION
## Summary
- avoid repeating punctuation when wrapping list items with inline code
- reformat AGENTS.md

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a85b16d6c8322a23435641d464e3b