### PR TITLE
Document markdown tokenization

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -186,16 +186,16 @@ fn tokenize_inline(text: &str) -> Vec<String> {
     tokens
 }
 
-/// Tokenize the input string by splitting on whitespace and backtick
-/// delimiters.
+/// Tokenize a Markdown snippet using backtick-delimited code spans.
 ///
-/// Consecutive whitespace characters are emitted as a single [`Token::Text`].
-/// Runs of backticks denote code spans; the parser searches ahead for a
-/// matching delimiter of the same length, allowing nested backticks when the
-/// outer span uses more characters. If no matching delimiter is found, the
-/// backticks are treated as literal text. The function employs a small
-/// state machine to track fenced blocks, ensuring that lines within fences are
-/// passed through unchanged.
+/// The function scans the input line by line. Lines matching [`FENCE_RE`]
+/// produce [`Token::Fence`] tokens and toggle fenced mode. Lines inside a
+/// fence are yielded verbatim. Outside fenced regions the scanner searches for
+/// backtick sequences. Text before a backtick becomes [`Token::Text`]. When a
+/// matching sequence of equal length follows, the enclosed portion forms a
+/// [`Token::Code`] span. If no closing sequence is found the backticks and the
+/// remaining text are returned as [`Token::Text`]. Whitespace is preserved
+/// exactly as it appears.
 ///
 /// ```rust,ignore
 /// use mdtablefix::wrap::{Token, tokenize_markdown};

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -186,14 +186,16 @@ fn tokenize_inline(text: &str) -> Vec<String> {
     tokens
 }
 
-/// Split the input string into [`Token`]s by analysing whitespace and
-/// backtick delimiters.
+/// Tokenize the input string by splitting on whitespace and backtick
+/// delimiters.
 ///
-/// The tokenizer groups consecutive whitespace into a single
-/// [`Token::Text`] and recognises backtick sequences as inline code spans.
-/// When a run of backticks is encountered the parser searches forward for an
-/// identical delimiter, allowing nested backticks when the span uses a longer
-/// fence. Unmatched delimiter sequences are treated as literal text.
+/// Consecutive whitespace characters are emitted as a single [`Token::Text`].
+/// Runs of backticks denote code spans; the parser searches ahead for a
+/// matching delimiter of the same length, allowing nested backticks when the
+/// outer span uses more characters. If no matching delimiter is found, the
+/// backticks are treated as literal text. The function employs a small
+/// state machine to track fenced blocks, ensuring that lines within fences are
+/// passed through unchanged.
 ///
 /// ```rust,ignore
 /// use mdtablefix::wrap::{Token, tokenize_markdown};


### PR DESCRIPTION
## Summary
- document tokenization logic in `tokenize_markdown`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688a8aaf45548322b0d8d06d738127aa

## Summary by Sourcery

Improve and expand the documentation for markdown tokenization in the wrap module

Documentation:
- Clarify that consecutive whitespace emits a single text token
- Describe how backtick runs denote code spans and support nested backticks by matching delimiter lengths
- Explain the state machine used to preserve fenced block content unchanged