### PR TITLE
Deprecate html table helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,7 @@ classDiagram
     class html {
         <<module>>
         +convert_html_tables()
-        +html_table_to_markdown()
+        +html_table_to_markdown() %% deprecated
     }
     class table {
         <<module>>
@@ -263,6 +263,9 @@ The `lib` module re-exports the public API from the other modules. The
 streaming helpers that combine the lower-level functions, including ellipsis
 replacement and footnote conversion. The `io` module handles filesystem
 operations, delegating the text processing to `process`.
+
+The helper `html_table_to_markdown` is retained for backward compatibility but
+is deprecated. New code should call `convert_html_tables` instead.
 
 ## Concurrency with `rayon`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod reflow;
 pub mod table;
 pub mod wrap;
 
-#[doc(hidden)]
+#[deprecated(note = "this function is legacy; use `convert_html_tables` instead")]
 #[must_use]
 pub fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
     html::html_table_to_markdown(lines)


### PR DESCRIPTION
## Summary
- mark `html_table_to_markdown` as deprecated
- label the function as deprecated in architecture docs
- document the alternative

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1)*
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a8ab769508322bf81c00d6a74ddc1