### PR TITLE
Fix missing doc comment for Token re-export

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -8,9 +8,9 @@
 use regex::{Captures, Regex};
 
 mod tokenize;
-/// Token emitted by [`tokenize`] and used by higher-level wrappers.
+/// Token emitted by [`tokenize::segment_inline`] and used by higher-level wrappers.
 ///
-/// This is re-exported so callers of [`textproc`] can implement custom
+/// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
 


### PR DESCRIPTION
## Summary
- document why the `Token` type is re-exported from `wrap`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bb6ed56648322b6ece95a7e200197

## Summary by Sourcery

Documentation:
- Add missing doc comment for Token re-export explaining its use in custom transformations