### PR TITLE
Add docs for markdown tokenizer

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -84,7 +84,9 @@ fn is_element(handle: &Handle, tag: &str) -> bool {
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
+fn is_table_cell(handle: &Handle) -> bool {
+    is_element(handle, "td") || is_element(handle, "th")
+}
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {
@@ -112,10 +114,10 @@ fn is_bold_tag(tag: &str) -> bool {
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.
 fn contains_strong(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data
-        && is_bold_tag(name.local.as_ref())
-    {
-        return true;
+    if let NodeData::Element { name, .. } = &handle.data {
+        if is_bold_tag(name.local.as_ref()) {
+            return true;
+        }
     }
     let children = handle.children.borrow();
     children.iter().any(contains_strong)

--- a/src/html.rs
+++ b/src/html.rs
@@ -112,10 +112,10 @@ fn is_bold_tag(tag: &str) -> bool {
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.
 fn contains_strong(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data {
-        if is_bold_tag(name.local.as_ref()) {
-            return true;
-        }
+    if let NodeData::Element { name, .. } = &handle.data
+        && is_bold_tag(name.local.as_ref())
+    {
+        return true;
     }
     let children = handle.children.borrow();
     children.iter().any(contains_strong)

--- a/src/html.rs
+++ b/src/html.rs
@@ -84,9 +84,7 @@ fn is_element(handle: &Handle, tag: &str) -> bool {
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool {
-    is_element(handle, "td") || is_element(handle, "th")
-}
+fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -61,17 +61,11 @@ struct PrefixHandler {
 }
 
 impl PrefixHandler {
-    fn build_bullet_prefix(cap: &Captures) -> String {
-        cap[1].to_string()
-    }
+    fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
 
-    fn build_footnote_prefix(cap: &Captures) -> String {
-        format!("{}{}", &cap[1], &cap[2])
-    }
+    fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
 
-    fn build_blockquote_prefix(cap: &Captures) -> String {
-        cap[1].to_string()
-    }
+    fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
 }
 
 static HANDLERS: &[PrefixHandler] = &[
@@ -204,9 +198,7 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
 }
 
 #[doc(hidden)]
-pub fn is_fence(line: &str) -> bool {
-    FENCE_RE.is_match(line)
-}
+pub fn is_fence(line: &str) -> bool { FENCE_RE.is_match(line) }
 
 pub(crate) fn is_markdownlint_directive(line: &str) -> bool {
     MARKDOWNLINT_DIRECTIVE_RE.is_match(line)

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,6 +13,11 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
+/// Tokenize a Markdown snippet using backtick-delimited code spans.
+///
+/// Re-exporting this helper lets downstream crates parse Markdown without
+/// depending on the private [`tokenize`] module.
+#[doc(inline)]
 pub use tokenize::tokenize_markdown;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =
@@ -51,11 +56,17 @@ struct PrefixHandler {
 }
 
 impl PrefixHandler {
-    fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
+    fn build_bullet_prefix(cap: &Captures) -> String {
+        cap[1].to_string()
+    }
 
-    fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
+    fn build_footnote_prefix(cap: &Captures) -> String {
+        format!("{}{}", &cap[1], &cap[2])
+    }
 
-    fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
+    fn build_blockquote_prefix(cap: &Captures) -> String {
+        cap[1].to_string()
+    }
 }
 
 static HANDLERS: &[PrefixHandler] = &[
@@ -188,7 +199,9 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
 }
 
 #[doc(hidden)]
-pub fn is_fence(line: &str) -> bool { FENCE_RE.is_match(line) }
+pub fn is_fence(line: &str) -> bool {
+    FENCE_RE.is_match(line)
+}
 
 pub(crate) fn is_markdownlint_directive(line: &str) -> bool {
     MARKDOWNLINT_DIRECTIVE_RE.is_match(line)

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -8,7 +8,7 @@
 //! The [`Token`] enum and [`tokenize_markdown`] function are public so callers
 //! can perform custom token-based processing.
 
-use regex::{Captures, Regex};
+use regex::Regex;
 
 mod tokenize;
 /// Token emitted by [`tokenize::segment_inline`] and used by higher-level wrappers.
@@ -52,42 +52,6 @@ static MARKDOWNLINT_DIRECTIVE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLo
     )
     .expect("valid markdownlint regex")
 });
-
-struct PrefixHandler {
-    re: &'static std::sync::LazyLock<Regex>,
-    is_bq: bool,
-    build_prefix: fn(&Captures) -> String,
-    rest_group: usize,
-}
-
-impl PrefixHandler {
-    fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
-
-    fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
-
-    fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
-}
-
-static HANDLERS: &[PrefixHandler] = &[
-    PrefixHandler {
-        re: &BULLET_RE,
-        is_bq: false,
-        build_prefix: PrefixHandler::build_bullet_prefix,
-        rest_group: 2,
-    },
-    PrefixHandler {
-        re: &FOOTNOTE_RE,
-        is_bq: false,
-        build_prefix: PrefixHandler::build_footnote_prefix,
-        rest_group: 3,
-    },
-    PrefixHandler {
-        re: &BLOCKQUOTE_RE,
-        is_bq: true,
-        build_prefix: PrefixHandler::build_blockquote_prefix,
-        rest_group: 2,
-    },
-];
 
 fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
     use unicode_width::UnicodeWidthStr;

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -8,7 +8,7 @@
 //! The [`Token`] enum and [`tokenize_markdown`] function are public so callers
 //! can perform custom token-based processing.
 
-use regex::Regex;
+use regex::{Captures, Regex};
 
 mod tokenize;
 /// Token emitted by [`tokenize::segment_inline`] and used by higher-level wrappers.

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,10 +13,6 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
-/// Tokenize a Markdown snippet using backtick-delimited code spans.
-///
-/// Re-exporting this helper lets downstream crates parse Markdown without
-/// depending on the private [`tokenize`] module.
 #[doc(inline)]
 pub use tokenize::tokenize_markdown;
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,6 +13,7 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
+pub use tokenize::tokenize_markdown;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").unwrap());


### PR DESCRIPTION
## Summary
- expand documentation for tokenizer functions in `wrap::tokenize`
- re-export `tokenize_markdown` from the `wrap` module

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bea9258d8832289b1f52cdd5701ac

## Summary by Sourcery

Add thorough documentation and examples for markdown tokenizer utilities and re-export tokenize_markdown from the wrap module

New Features:
- Re-export tokenize_markdown from the wrap module

Documentation:
- Add doc comments with usage examples for scan_while, collect_range, parse_link_or_image, is_trailing_punctuation, segment_inline, tokenize_inline, and tokenize_markdown