### PR TITLE
Use setup-rust action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,8 @@ jobs:
 #            ext: ""
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Cache cross binary
         uses: actions/cache@v4
         with:

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,6 +13,7 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
+pub use tokenize::tokenize_markdown;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r"^\s*(```|~~~).*").unwrap());


### PR DESCRIPTION
## Summary
- switch release workflow to leynos `setup-rust` action
- re-export `tokenize_markdown` in `wrap` module so tests compile

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bf7e0c0a08322ac64f8cccb609575

## Summary by Sourcery

Switch the release workflow to the leynos setup-rust action and re-export tokenize_markdown to restore test compilation

Bug Fixes:
- Re-export tokenize_markdown in wrap module so tests compile

CI:
- Use leynos/setup-rust action in release workflow