### PR TITLE
Document tokenize_markdown

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ The function combines several helpers documented in `docs/`:
     [HTML table support](#html-table-support-in-mdtablefix).
 - `wrap::wrap_text` applies optional line wrapping. It relies on the
   `unicode-width` crate for accurate character widths.
+- `wrap::tokenize_markdown` emits `Token` values for custom processing.
 
 The function maintains a small state machine that tracks whether it is inside a
 Markdown table, an HTML table, or a fenced code block. The state determines how
@@ -263,14 +264,16 @@ classDiagram
     io ..> process : uses process_stream, process_stream_no_wrap
 ```
 
-The `lib` module re-exports the public API from the other modules. The
-`ellipsis` module performs text normalization, while `footnotes` converts bare
-references. The `textproc` module contains shared token-processing helpers used
-by both the `ellipsis` and `footnotes` modules. Tokenization is handled by
-`wrap::tokenize_markdown`, replacing the small state machine that previously
-resided in `process_tokens`. The `process` module provides streaming helpers
-that combine the lower-level functions. The `io` module handles filesystem
-operations, delegating the text processing to `process`.
+The `lib` module re-exports the public API from the other modules. The `wrap`
+module exposes the `Token` enum and `tokenize_markdown` function for custom
+processing. The `ellipsis` module performs text normalization, while
+`footnotes` converts bare references. The `textproc` module contains shared
+token-processing helpers used by both the `ellipsis` and `footnotes` modules.
+Tokenization is handled by `wrap::tokenize_markdown`, replacing the small state
+machine that previously resided in `process_tokens`. The `process` module
+provides streaming helpers that combine the lower-level functions. The `io`
+module handles filesystem operations, delegating the text processing to
+`process`.
 
 The helper `html_table_to_markdown` is retained for backward compatibility but
 is deprecated. New code should call `convert_html_tables` instead.

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -4,6 +4,9 @@
 //! spans, fenced code blocks, and other prefixes. Width calculations rely on
 //! `UnicodeWidthStr::width` from the `unicode-width` crate as described in
 //! `docs/architecture.md#unicode-width-handling`.
+//!
+//! The [`Token`] enum and [`tokenize_markdown`] function are public so callers
+//! can perform custom token-based processing.
 
 use regex::{Captures, Regex};
 


### PR DESCRIPTION
## Summary
- document `tokenize_markdown` in crate-level docs for `wrap`
- mention tokenizer export in the architecture docs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688cfd7e21488322a959d2690aa1ee92

## Summary by Sourcery

Document and expose the tokenize_markdown function and Token enum in the wrap module by updating crate-level and architecture documentation

Enhancements:
- Expose the Token enum and tokenize_markdown function from the wrap module for external use

Documentation:
- Add documentation for wrap::tokenize_markdown in the architecture guide
- Document tokenize_markdown in the crate-level wrap module docs