### PR TITLE
Fix unstable syntax in HTML parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,10 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden, as it
-  introduces unacceptable risk and unpredictability. Tilde requirements (`~`)
-  should only be used where a dependency must be locked to patch-level updates
-  for a specific, documented reason.
+  open-ended inequality (`>=`) version requirements is strictly forbidden, as
+  it introduces unacceptable risk and unpredictability. Tilde requirements
+  (`~`) should only be used where a dependency must be locked to patch-level
+  updates for a specific, documented reason.
 
 ### Error Handling
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -84,7 +84,9 @@ fn is_element(handle: &Handle, tag: &str) -> bool {
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
+fn is_table_cell(handle: &Handle) -> bool {
+    is_element(handle, "td") || is_element(handle, "th")
+}
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {
@@ -112,10 +114,10 @@ fn is_bold_tag(tag: &str) -> bool {
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.
 fn contains_strong(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data
-        && is_bold_tag(name.local.as_ref())
-    {
-        return true;
+    if let NodeData::Element { name, .. } = &handle.data {
+        if is_bold_tag(name.local.as_ref()) {
+            return true;
+        }
     }
     let children = handle.children.borrow();
     children.iter().any(contains_strong)

--- a/src/io.rs
+++ b/src/io.rs
@@ -30,7 +30,9 @@ where
 ///
 /// # Errors
 /// Returns an error if reading or writing the file fails.
-pub fn rewrite(path: &Path) -> std::io::Result<()> { rewrite_with(path, process_stream) }
+pub fn rewrite(path: &Path) -> std::io::Result<()> {
+    rewrite_with(path, process_stream)
+}
 
 /// Rewrite a file in place without wrapping text.
 ///

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,6 +13,8 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
+/// Convenience re-export of [`tokenize::tokenize_markdown`].
+#[doc(inline)]
 pub use tokenize::tokenize_markdown;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -51,11 +51,17 @@ struct PrefixHandler {
 }
 
 impl PrefixHandler {
-    fn build_bullet_prefix(cap: &Captures) -> String { cap[1].to_string() }
+    fn build_bullet_prefix(cap: &Captures) -> String {
+        cap[1].to_string()
+    }
 
-    fn build_footnote_prefix(cap: &Captures) -> String { format!("{}{}", &cap[1], &cap[2]) }
+    fn build_footnote_prefix(cap: &Captures) -> String {
+        format!("{}{}", &cap[1], &cap[2])
+    }
 
-    fn build_blockquote_prefix(cap: &Captures) -> String { cap[1].to_string() }
+    fn build_blockquote_prefix(cap: &Captures) -> String {
+        cap[1].to_string()
+    }
 }
 
 static HANDLERS: &[PrefixHandler] = &[
@@ -188,7 +194,9 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
 }
 
 #[doc(hidden)]
-pub fn is_fence(line: &str) -> bool { FENCE_RE.is_match(line) }
+pub fn is_fence(line: &str) -> bool {
+    FENCE_RE.is_match(line)
+}
 
 pub(crate) fn is_markdownlint_directive(line: &str) -> bool {
     MARKDOWNLINT_DIRECTIVE_RE.is_match(line)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ macro_rules! lines_vec {
 ///
 /// Example:
 /// ```
-/// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
+/// let input: Vec<String> = include_lines!("data/bold_header_input.txt");
 /// ```
 #[expect(unused_macros, reason = "macros are optional helpers across modules")]
 macro_rules! include_lines {


### PR DESCRIPTION
## Summary
- fix `contains_strong` to avoid unstable let chains
- run fmt after applying the fix

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d273069a8832299abb344bd7a85d5

## Summary by Sourcery

Remove unstable Rust syntax in the HTML parser, standardize utility functions to block syntax, and apply formatting fixes across code and docs

Bug Fixes:
- Refactor contains_strong to eliminate unstable let-chains

Enhancements:
- Expand one-liner utility functions (build_bullet_prefix, build_footnote_prefix, build_blockquote_prefix, is_fence, is_table_cell, rewrite) into full block syntax

Documentation:
- Reflow AGENTS.md to improve line wrapping and readability

Tests:
- Remove trailing whitespace from test include_lines macro snippet

Chores:
- Apply rustfmt to reformat code and documentation