### PR TITLE
Fix import path and run fmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,10 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden, as it
-  introduces unacceptable risk and unpredictability. Tilde requirements (`~`)
-  should only be used where a dependency must be locked to patch-level updates
-  for a specific, documented reason.
+  open-ended inequality (`>=`) version requirements is strictly forbidden, as
+  it introduces unacceptable risk and unpredictability. Tilde requirements
+  (`~`) should only be used where a dependency must be locked to patch-level
+  updates for a specific, documented reason.
 
 ### Error Handling
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -112,10 +112,10 @@ fn is_bold_tag(tag: &str) -> bool {
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.
 fn contains_strong(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data
-        && is_bold_tag(name.local.as_ref())
-    {
-        return true;
+    if let NodeData::Element { name, .. } = &handle.data {
+        if is_bold_tag(name.local.as_ref()) {
+            return true;
+        }
     }
     let children = handle.children.borrow();
     children.iter().any(contains_strong)

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -13,6 +13,8 @@ mod tokenize;
 /// Re-export this so callers of [`crate::textproc`] can implement custom
 /// transformations without depending on internal modules.
 pub use tokenize::Token;
+/// Convenience re-export of [`tokenize::tokenize_markdown`].
+#[doc(inline)]
 pub use tokenize::tokenize_markdown;
 
 static FENCE_RE: std::sync::LazyLock<Regex> =

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ macro_rules! lines_vec {
 ///
 /// Example:
 /// ```
-/// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
+/// let input: Vec<String> = include_lines!("data/bold_header_input.txt");
 /// ```
 #[expect(unused_macros, reason = "macros are optional helpers across modules")]
 macro_rules! include_lines {


### PR DESCRIPTION
## Summary
- re-export `tokenize_markdown` with inline docs
- run `fmt` after updating the code

## Testing
- `make lint`
- `make check-fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d273069a8832299abb344bd7a85d5