### PR TITLE
Fix empty backtick edge case

### DIFF
--- a/src/wrap/tokenize.rs
+++ b/src/wrap/tokenize.rs
@@ -123,24 +123,20 @@ fn next_token(s: &str) -> Option<(Token<'_>, usize)> {
     if s.is_empty() {
         return None;
     }
-    if let Some(pos) = s.find('`') {
-        if pos > 0 {
+    let delim_len = s.chars().take_while(|&c| c == '`').count();
+    if delim_len == 0 {
+        if let Some(pos) = s.find('`') {
             return Some((Token::Text(&s[..pos]), pos));
         }
-        let delim_len = s.chars().take_while(|&c| c == '`').count();
-        if delim_len == 0 {
-            let first_len = s.chars().next().unwrap().len_utf8();
-            let next = s[first_len..].find('`').map_or(s.len(), |i| first_len + i);
-            return Some((Token::Text(&s[..next]), next));
-        }
-        let closing = &s[..delim_len];
-        if let Some(end) = s[delim_len..].find(closing) {
-            let code = &s[delim_len..delim_len + end];
-            return Some((Token::Code(code), delim_len + end + delim_len));
-        }
-        return Some((Token::Text(&s[..delim_len]), delim_len));
+        return Some((Token::Text(s), s.len()));
     }
-    Some((Token::Text(s), s.len()))
+
+    let closing = &s[..delim_len];
+    if let Some(end) = s[delim_len..].find(closing) {
+        let code = &s[delim_len..delim_len + end];
+        return Some((Token::Code(code), delim_len + end + delim_len));
+    }
+    Some((Token::Text(closing), delim_len))
 }
 
 fn tokenize_inline<'a, F>(mut rest: &'a str, mut emit: F)

--- a/src/wrap/tokenize.rs
+++ b/src/wrap/tokenize.rs
@@ -129,7 +129,9 @@ fn next_token(s: &str) -> Option<(Token<'_>, usize)> {
         }
         let delim_len = s.chars().take_while(|&c| c == '`').count();
         if delim_len == 0 {
-            return Some((Token::Text(&s[..1]), 1));
+            let first_len = s.chars().next().unwrap().len_utf8();
+            let next = s[first_len..].find('`').map_or(s.len(), |i| first_len + i);
+            return Some((Token::Text(&s[..next]), next));
         }
         let closing = &s[..delim_len];
         if let Some(end) = s[delim_len..].find(closing) {

--- a/src/wrap/tokenize.rs
+++ b/src/wrap/tokenize.rs
@@ -129,13 +129,14 @@ fn next_token(s: &str) -> Option<(Token<'_>, usize)> {
         }
         let delim_len = s.chars().take_while(|&c| c == '`').count();
         if delim_len == 0 {
-            return Some((Token::Text(s), s.len()));
+            return Some((Token::Text(&s[..1]), 1));
         }
         let closing = &s[..delim_len];
         if let Some(end) = s[delim_len..].find(closing) {
             let code = &s[delim_len..delim_len + end];
             return Some((Token::Code(code), delim_len + end + delim_len));
         }
+        return Some((Token::Text(&s[..delim_len]), delim_len));
     }
     Some((Token::Text(s), s.len()))
 }

--- a/tests/wrap/tokenize_markdown.rs
+++ b/tests/wrap/tokenize_markdown.rs
@@ -50,3 +50,17 @@ fn incorrect_fence_length_is_text() {
         ]
     );
 }
+#[test]
+fn unmatched_inline_code_is_text() {
+    let source = "bad `code span";
+    let tokens = wrap::tokenize_markdown(source);
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Text("bad "),
+            Token::Text("`"),
+            Token::Text("code span"),
+        ]
+    );
+}
+

--- a/tests/wrap/tokenize_markdown.rs
+++ b/tests/wrap/tokenize_markdown.rs
@@ -64,3 +64,16 @@ fn unmatched_inline_code_is_text() {
     );
 }
 
+#[test]
+fn multiple_unmatched_backticks_are_text() {
+    let source = "``bad code";
+    let tokens = wrap::tokenize_markdown(source);
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Text("``"),
+            Token::Text("bad code"),
+        ]
+    );
+}
+


### PR DESCRIPTION
## Summary
- handle cases with empty inline code delimiters
- add regression test for unmatched inline code

## Testing
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make fmt`
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make lint`
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make test`
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688d32f6a54483229b3f0e212a78abb2

## Summary by Sourcery

Treat unmatched or empty backtick delimiters as plain text when tokenizing markdown and add a regression test to cover this scenario

Bug Fixes:
- Return single backtick as text when no backtick delimiters are present instead of consuming the entire string
- Treat unmatched inline code delimiters as text tokens rather than code spans

Tests:
- Add regression test for unmatched inline code delimiters to ensure they are tokenized as text