### PR TITLE
Add missing module docs

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1,10 +1,8 @@
-//! Utilities for converting HTML tables embedded in Markdown into
-//! Markdown table syntax.
+//! Convert basic HTML tables embedded in Markdown into Markdown table syntax.
 //!
-//! The conversion is intentionally simple: only `<table>`, `<tr>`,
-//! `<th>`, and `<td>` tags are recognized. Attributes and tag casing
-//! are ignored. The resulting Markdown lines are passed to
-//! `reflow_table` to ensure consistent column widths.
+//! The conversion intentionally recognises only `<table>`, `<tr>`, `<th>` and
+//! `<td>` tags, ignoring attributes and case. Converted rows are then passed to
+//! `reflow_table` for consistent column widths.
 
 use std::sync::LazyLock;
 
@@ -84,7 +82,9 @@ fn is_element(handle: &Handle, tag: &str) -> bool {
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
+fn is_table_cell(handle: &Handle) -> bool {
+    is_element(handle, "td") || is_element(handle, "th")
+}
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {
@@ -112,10 +112,10 @@ fn is_bold_tag(tag: &str) -> bool {
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.
 fn contains_strong(handle: &Handle) -> bool {
-    if let NodeData::Element { name, .. } = &handle.data
-        && is_bold_tag(name.local.as_ref())
-    {
-        return true;
+    if let NodeData::Element { name, .. } = &handle.data {
+        if is_bold_tag(name.local.as_ref()) {
+            return true;
+        }
     }
     let children = handle.children.borrow();
     children.iter().any(contains_strong)

--- a/src/html.rs
+++ b/src/html.rs
@@ -3,6 +3,8 @@
 //! The conversion intentionally recognises only `<table>`, `<tr>`, `<th>` and
 //! `<td>` tags, ignoring attributes and case. Converted rows are then passed to
 //! `reflow_table` for consistent column widths.
+//!
+//! This module is used by the CLI when rewriting Markdown files.
 
 use std::sync::LazyLock;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-//! File helpers for rewriting Markdown documents.
+//! Helper functions for reading, processing, and rewriting Markdown files.
 
 use std::{fs, path::Path};
 
@@ -30,7 +30,9 @@ where
 ///
 /// # Errors
 /// Returns an error if reading or writing the file fails.
-pub fn rewrite(path: &Path) -> std::io::Result<()> { rewrite_with(path, process_stream) }
+pub fn rewrite(path: &Path) -> std::io::Result<()> {
+    rewrite_with(path, process_stream)
+}
 
 /// Rewrite a file in place without wrapping text.
 ///

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,7 @@
 //! Helper functions for reading, processing, and rewriting Markdown files.
+//!
+//! These helpers integrate with the CLI to apply the rewriting logic to each
+//! file.
 
 use std::{fs, path::Path};
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,12 +1,12 @@
-//! Utilities for wrapping Markdown lines.
+//! Helpers for wrapping Markdown lines while tracking prefix context.
 //!
-//! These helpers reflow paragraphs and list items while preserving inline code
-//! spans, fenced code blocks, and other prefixes. Width calculations rely on
+//! This module reflows paragraphs and list items without disturbing inline code
+//! spans, fenced blocks, or list markers. Width calculations rely on
 //! `UnicodeWidthStr::width` from the `unicode-width` crate as described in
 //! `docs/architecture.md#unicode-width-handling`.
 //!
-//! The [`Token`] enum and [`tokenize_markdown`] function are public so callers
-//! can perform custom token-based processing.
+//! The [`Token`] enum and [`tokenize_markdown`] function are re-exported so
+//! callers can perform custom token-based processing.
 
 use regex::Regex;
 
@@ -163,7 +163,9 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
 }
 
 #[doc(hidden)]
-pub fn is_fence(line: &str) -> bool { FENCE_RE.is_match(line) }
+pub fn is_fence(line: &str) -> bool {
+    FENCE_RE.is_match(line)
+}
 
 pub(crate) fn is_markdownlint_directive(line: &str) -> bool {
     MARKDOWNLINT_DIRECTIVE_RE.is_match(line)

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -7,6 +7,8 @@
 //!
 //! The [`Token`] enum and [`tokenize_markdown`] function are re-exported so
 //! callers can perform custom token-based processing.
+//!
+//! Public wrappers form the core of Markdown table formatting used by the CLI.
 
 use regex::Regex;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ macro_rules! lines_vec {
 ///
 /// Example:
 /// ```
-/// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
+/// let input: Vec<String> = include_lines!("data/bold_header_input.txt");
 /// ```
 #[expect(unused_macros, reason = "macros are optional helpers across modules")]
 macro_rules! include_lines {


### PR DESCRIPTION
## Summary
- document wrap module behaviour
- describe HTML table conversion module
- expand file helpers module comment
- adjust logic to avoid unstable syntax

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_688d37c6926c8322938c345d4d1bfe22

## Summary by Sourcery

Update module documentation and standardize helper function formatting by expanding single-line definitions into block syntax and adjust logic to avoid unstable syntax.

Enhancements:
- Expand single-line helper functions into multi-line block syntax across wrap, html, and io modules
- Refactor contains_strong logic to avoid unstable `if let &&` syntax by nesting conditionals

Documentation:
- Add missing documentation for wrap module behavior and HTML table conversion
- Expand file helpers module comments