### PR TITLE
Improve wrap renumber test and Token docs

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -15,8 +15,9 @@ mod tokenize;
 /// Token emitted by [`tokenize::segment_inline`] and used by higher-level
 /// wrappers.
 ///
-/// Re-export these so callers of [`crate::textproc`] can implement custom
-/// transformations without depending on internal modules.
+/// Downstream callers of [`crate::textproc`] use [`Token<'a>`] to inspect
+/// tokenised Markdown without depending on internal modules. The `'a`
+/// lifetime parameter ties each token to the source text slice.
 pub use tokenize::Token;
 #[doc(inline)]
 pub use tokenize::tokenize_markdown;
@@ -164,7 +165,9 @@ fn wrap_preserving_code(text: &str, width: usize) -> Vec<String> {
 }
 
 #[doc(hidden)]
-pub fn is_fence(line: &str) -> bool { FENCE_RE.is_match(line) }
+pub fn is_fence(line: &str) -> bool {
+    FENCE_RE.is_match(line)
+}
 
 pub(crate) fn is_markdownlint_directive(line: &str) -> bool {
     MARKDOWNLINT_DIRECTIVE_RE.is_match(line)

--- a/tests/wrap_renumber.rs
+++ b/tests/wrap_renumber.rs
@@ -1,17 +1,33 @@
 //! Regression test for combined wrapping and renumbering.
 
 use mdtablefix::{process_stream, renumber_lists};
+use std::fs;
 
 #[macro_use]
 mod prelude;
 
+// File paths for the regression fixtures to avoid repetition.
+const INPUT_FILE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/data/wrap_renumber_regression_input.txt",
+);
+const EXPECTED_FILE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/data/wrap_renumber_regression_expected.txt",
+);
+
 #[test]
 fn wrap_then_renumber_preserves_order() {
-    let input: Vec<String> = include_lines!("data/wrap_renumber_regression_input.txt");
-    let expected: Vec<String> = include_lines!("data/wrap_renumber_regression_expected.txt");
+    let input = fs::read_to_string(INPUT_FILE).expect("read regression input");
+    let expected = fs::read_to_string(EXPECTED_FILE).expect("read regression output");
+    let input: Vec<String> = input.lines().map(str::to_owned).collect();
+    let expected: Vec<String> = expected.lines().map(str::to_owned).collect();
 
     let mut out = process_stream(&input);
     out = renumber_lists(&out);
 
-    assert_eq!(out, expected);
+    assert_eq!(
+        out, expected,
+        "processed output differed\nexpected: {expected:?}\nactual: {out:?}",
+    );
 }


### PR DESCRIPTION
## Summary
- clarify `Token` re-export docs and reference its `'a` lifetime
- extract wrap renumber regression fixture paths into constants and add detailed assertion messaging

## Testing
- `make fmt`
- `make lint` *(fails: `let` expressions in this position are unstable)*
- `make test` *(fails: `let` expressions in this position are unstable)*


------
https://chatgpt.com/codex/tasks/task_e_688fdec11498832292bb9ab9edf7620c

## Summary by Sourcery

Enhance the wrap/renumber regression test by centralizing fixture paths, reading files via fs, and improving assertion feedback, and clarify the Token re-export docs with its lifetime parameter

Enhancements:
- Reformat is_fence into a block for clarity

Documentation:
- Clarify the Token re-export documentation to reference its 'a lifetime and downstream usage

Tests:
- Extract regression fixture file paths into constants and read them via fs::read_to_string in wrap_renumber test
- Add detailed assertion message to wrap_renumber test to show expected vs actual outputs