### PR TITLE
Add helper to reemit original tokens

### DIFF
--- a/src/ellipsis.rs
+++ b/src/ellipsis.rs
@@ -9,14 +9,14 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::textproc::{Token, process_tokens};
+use crate::textproc::{Token, process_tokens, push_original_token};
 
 static DOT_RE: LazyLock<Regex> = lazy_regex!(r"\.{3,}", "ellipsis pattern regex should compile");
 
 /// Replace `...` with `…` outside code spans and fences.
 #[must_use]
 pub fn replace_ellipsis(lines: &[String]) -> Vec<String> {
-    process_tokens(lines, |token, out| match token {
+    process_tokens(lines, |tok, out| match tok {
         Token::Text(t) => {
             if !DOT_RE.is_match(t) {
                 out.push_str(t);
@@ -30,13 +30,7 @@ pub fn replace_ellipsis(lines: &[String]) -> Vec<String> {
             });
             out.push_str(&replaced);
         }
-        Token::Code(c) => {
-            out.push('`');
-            out.push_str(c);
-            out.push('`');
-        }
-        Token::Fence(f) => out.push_str(f),
-        Token::Newline => out.push('\n'),
+        _ => push_original_token(&tok, out),
     })
 }
 

--- a/src/footnotes.rs
+++ b/src/footnotes.rs
@@ -18,7 +18,7 @@ static FOOTNOTE_LINE_RE: LazyLock<Regex> = lazy_regex!(
     "footnote line pattern should compile",
 );
 
-use crate::textproc::{Token, process_tokens};
+use crate::textproc::{Token, process_tokens, push_original_token};
 
 /// Extract the components of an inline footnote reference.
 #[inline]
@@ -96,15 +96,9 @@ fn convert_block(lines: &mut [String]) {
 /// Convert bare numeric footnote references to Markdown footnote syntax.
 #[must_use]
 pub fn convert_footnotes(lines: &[String]) -> Vec<String> {
-    let mut lines = process_tokens(lines, |token, out| match token {
+    let mut lines = process_tokens(lines, |tok, out| match tok {
         Token::Text(t) => out.push_str(&convert_inline(t)),
-        Token::Code(c) => {
-            out.push('`');
-            out.push_str(c);
-            out.push('`');
-        }
-        Token::Fence(f) => out.push_str(f),
-        Token::Newline => out.push('\n'),
+        _ => push_original_token(&tok, out),
     });
     convert_block(&mut lines);
     lines


### PR DESCRIPTION
## Summary
- add `push_original_token` helper to write tokens back unchanged
- reuse helper in `replace_ellipsis` and `convert_footnotes`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893db40a43883228b1df1f3b86e2ed1

## Summary by Sourcery

Introduce a helper to reconstruct original tokens and refactor existing transformations to leverage it, reducing duplication and ensuring consistent token output.

New Features:
- Add push_original_token helper to reemit original tokens without modification

Enhancements:
- Refactor replace_ellipsis and convert_footnotes to use the new helper instead of manual token reconstruction

Tests:
- Add unit tests to verify that push_original_token correctly round-trips all Token variants