### PR TITLE
Update Cross reference in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cross
-          key: cross-v0.2.1-${{ runner.os }}
+          key: cross-v0.2.5-${{ runner.os }}
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.1
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 **/*.rs.bk
+.crush

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions release workflow to use cross v0.2.5 and add a CRUSH.md reference file.

CI:
- Bump cross installer and cache key to v0.2.5 in the release workflow

Documentation:
- Add CRUSH.md with a reference to AGENTS.md