### PR TITLE
Sets RUSTFLAGS to empty when installing cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
           path: ~/.cargo/bin/cross
           key: cross-v0.2.5-${{ runner.os }}
       - name: Install cross
+        env:
+          RUSTFLAGS: ""
         run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
       - name: Cache cargo registry
         uses: actions/cache@v4


### PR DESCRIPTION
Ensures the environment variable RUSTFLAGS is unset during cross installation to avoid issues from inherited or conflicting flag values.

## Summary by Sourcery

CI:
- Unset RUSTFLAGS in the "Install cross" step of the release workflow to avoid interference from inherited flags.