### PR TITLE
Handle colon-separated footnotes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,10 +96,12 @@ returns the updated stream for writing to disk or further manipulation.
 
 `mdtablefix` can optionally convert bare numeric references into
 GitHub-flavoured Markdown footnotes. A bare numeric reference is a number that
-appears after punctuation with no footnote formatting, for example:
+appears after punctuation or before a colon with no footnote formatting, for
+example:
 
 ```markdown
 An example of a bare numeric reference.1
+The official docs page showcases several types 7:
 ```
 
 `convert_footnotes` performs this operation and is exposed via the higher-level
@@ -108,18 +110,21 @@ An example of a bare numeric reference.1
 `process_stream_opts` to enable the conversion logic. The parameter defaults to
 `false`.
 
-Inline references that appear after punctuation are rewritten as footnote links.
+Inline references that appear after punctuation or before a colon are rewritten
+as footnote links.
 
 Before:
 
 ```markdown
 A useful tip.1
+Core types 7:
 ```
 
 After:
 
 ```markdown
 A useful tip.[^1]
+Core types[^7]:
 ```
 
 Numbers inside inline code or parentheses are ignored.

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -85,6 +85,28 @@ fn test_handles_punctuation_inside_bold() {
 }
 
 #[test]
+fn test_converts_number_followed_by_colon() {
+    let input = lines_vec!(
+        "While a full library tutorial is beyond this guide's scope, a brief look at the",
+        "core API concepts reveals its ergonomic design. The official `docs.rs` page",
+        "provides several end-to-end examples that revolve around a few key types 7:",
+    );
+    let expected = lines_vec!(
+        "While a full library tutorial is beyond this guide's scope, a brief look at the",
+        "core API concepts reveals its ergonomic design. The official `docs.rs` page",
+        "provides several end-to-end examples that revolve around a few key types[^7]:",
+    );
+    assert_eq!(convert_footnotes(&input), expected);
+}
+
+#[test]
+fn test_converts_colon_footnote_definition() {
+    let input = lines_vec!("7: Footnote text");
+    let expected = lines_vec!("[^7] Footnote text");
+    assert_eq!(convert_footnotes(&input), expected);
+}
+
+#[test]
 fn test_empty_input() {
     let input: Vec<String> = Vec::new();
     let output = convert_footnotes(&input);


### PR DESCRIPTION
## Summary
- convert bare `7:` references into `[^7]:` links
- document colon-based footnote support
- cover colon footnotes in tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: RuntimeError: Error running command bun x --bun @mermaid-js/mermaid-cli mmdc -p /tmp/tmpw32pa7sq.json -i /tmp/tmp7i9oe1ec/architecture_1.mmd -o /tmp/tmp7i9oe1ec/architecture_1.svg for file 'docs/architecture.md' (diagram 1): error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68960ac13cc88322bb27b43391f38016