### PR TITLE
Add version flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ cargo install --path .
 ## Command-line usage
 
 ```bash
-mdtablefix [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes] [--in-place] [FILE...]
+mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes] [--in-place] [FILE...]
 ```
 
 - When one or more file paths are provided, the corrected tables are printed to
   stdout.
+
+- Use `--version` to print the current version and exit.
 
 - Use `--wrap` to reflow paragraphs and list items to 80 columns.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use mdtablefix::{Options, format_breaks, process_stream_opts, renumber_lists};
 use rayon::prelude::*;
 
 #[derive(Parser)]
-#[command(about = "Reflow broken markdown tables")]
+#[command(version, about = "Reflow broken markdown tables")]
 struct Cli {
     /// Rewrite files in place
     #[arg(long = "in-place", requires = "files")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -27,6 +27,17 @@ fn test_cli_in_place_requires_file() {
         .failure();
 }
 
+/// Verifies that the `--version` flag prints the crate version and exits.
+#[test]
+fn test_cli_version_flag() {
+    Command::cargo_bin("mdtablefix")
+        .expect("Failed to create cargo command for mdtablefix")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(format!("mdtablefix {}\n", env!("CARGO_PKG_VERSION")));
+}
+
 /// Tests that the CLI processes a file containing a broken Markdown table and outputs the corrected
 /// table to stdout.
 ///


### PR DESCRIPTION
## Summary
- expose a `--version` flag to print the crate version and exit
- document the version flag in command-line usage
- test the new flag via CLI integration test

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899c005361c832287bcd5032028cc4a