### PR TITLE
Verify release tag matches version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,14 @@ jobs:
 #            ext: ""
     steps:
       - uses: actions/checkout@v4
+      - name: Verify tag matches Cargo.toml
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          cargo_version=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f2)
+          if [ "$tag" != "$cargo_version" ]; then
+            echo "Tag version $tag does not match Cargo.toml version $cargo_version"
+            exit 1
+          fi
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Cache cross binary

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -12,6 +12,10 @@ binaries for:
 - Windows (x86_64 and aarch64)
 - OpenBSD (x86_64 and aarch64)
 
+Releases start from tags named `v<major>.<minor>.<patch>`. The workflow checks
+that the tag's version, without the leading `v`, matches the `Cargo.toml`
+`version` field and aborts if they differ.
+
 Each binary is named using the pattern `mdtablefix-<os>-<arch>` with an `.exe`
 suffix on Windows.
 


### PR DESCRIPTION
## Summary
- fail release workflow when tag version doesn't match Cargo.toml
- document the tag/version check in the release process

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a373a67d0c832280a4f50c3e6ac629

## Summary by Sourcery

Enforce consistent versioning between Git tags and Cargo.toml during releases

New Features:
- Add a workflow step to abort releases when the Git tag version doesn’t match Cargo.toml

Documentation:
- Document the tag/version verification in the release process guide