### PR TITLE
Respect flags in in-place mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +446,7 @@ dependencies = [
  "libc",
  "markup5ever_rcdom",
  "once_cell",
+ "predicates",
  "rayon",
  "regex",
  "rstest",
@@ -455,6 +465,21 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -555,7 +580,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rstest = "0.18"
 assert_cmd = "2"
 tempfile = "3"
 libc = "0.2.174"
+predicates = "3"
 
 [lints.clippy]
 pedantic = "warn"

--- a/tests/breaks.rs
+++ b/tests/breaks.rs
@@ -62,15 +62,11 @@ fn test_format_breaks_mixed_chars_excessive_length() {
 /// underscore-based thematic break.
 #[test]
 fn test_cli_breaks_option() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--breaks")
         .write_stdin("---\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        format!("{}\n", "_".repeat(THEMATIC_BREAK_LEN))
-    );
+        .assert()
+        .success()
+        .stdout(format!("{}\n", "_".repeat(THEMATIC_BREAK_LEN)));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,7 +6,10 @@
 //! - Error handling for invalid argument combinations
 //! - Processing of Markdown files through the CLI interface
 
-use std::{fs::File, io::Write};
+use std::{
+    fs::{self, File},
+    io::Write,
+};
 
 use tempfile::tempdir;
 
@@ -66,14 +69,13 @@ fn test_cli_process_file(broken_table: Vec<String>) {
 /// Verifies that the CLI correctly processes input containing "..." and outputs "…".
 #[test]
 fn test_cli_ellipsis_option() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--ellipsis")
         .write_stdin("foo...\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "foo…\n");
+        .assert()
+        .success()
+        .stdout("foo…\n");
 }
 
 /// Tests that the `--ellipsis` option preserves dots within inline code spans.
@@ -81,17 +83,13 @@ fn test_cli_ellipsis_option() {
 /// Verifies that triple dots inside backtick-delimited code spans are not converted to ellipsis.
 #[test]
 fn test_cli_ellipsis_code_span() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--ellipsis")
         .write_stdin("before `dots...` after\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "before `dots...` after\n"
-    );
+        .assert()
+        .success()
+        .stdout("before `dots...` after\n");
 }
 
 /// Tests that the `--ellipsis` option does not alter fenced code blocks.
@@ -99,17 +97,13 @@ fn test_cli_ellipsis_code_span() {
 /// Ensures that sequences like "..." inside a fenced code block remain unchanged.
 #[test]
 fn test_cli_ellipsis_fenced_block() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--ellipsis")
         .write_stdin("```\nlet x = ...;\n```\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```\nlet x = ...;\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```\nlet x = ...;\n```\n");
 }
 
 /// Tests ellipsis replacement for sequences longer than three characters.
@@ -117,14 +111,13 @@ fn test_cli_ellipsis_fenced_block() {
 /// Confirms that only the first three dots are replaced with an ellipsis.
 #[test]
 fn test_cli_ellipsis_long_sequence() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--ellipsis")
         .write_stdin("wait....\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "wait….\n");
+        .assert()
+        .success()
+        .stdout("wait….\n");
 }
 
 /// Tests that the `--ellipsis` option handles multiple ellipsis sequences in one line.
@@ -132,80 +125,60 @@ fn test_cli_ellipsis_long_sequence() {
 /// Verifies that all occurrences of "..." are replaced with "…".
 #[test]
 fn test_cli_ellipsis_multiple_sequences() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--ellipsis")
         .write_stdin("First... then second... done.\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "First… then second… done.\n"
-    );
+        .assert()
+        .success()
+        .stdout("First… then second… done.\n");
 }
 
 /// Tests that the `--fences` option normalizes backtick fences.
 #[test]
 fn test_cli_fences_option() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin("````rust\nfn main() {}\n````\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```rust\nfn main() {}\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```rust\nfn main() {}\n```\n");
 }
 
 #[test]
 fn test_cli_fences_option_tilde() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin("~~~~rust\nfn main() {}\n~~~~\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```rust\nfn main() {}\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```rust\nfn main() {}\n```\n");
 }
 
 /// Ensures fence normalization runs before other processing.
 #[test]
 fn test_cli_fences_before_ellipsis() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .args(["--fences", "--ellipsis"])
         .write_stdin("````\nlet x = ...;\n````\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```\nlet x = ...;\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```\nlet x = ...;\n```\n");
 }
 
 /// Ensures orphan specifiers are attached when `--fences` is used.
 #[test]
 fn test_cli_fences_orphan_specifier() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin("Rust\n```\nfn main() {}\n```\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```rust\nfn main() {}\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```rust\nfn main() {}\n```\n");
 }
 
 /// Combines fence normalization with renumbering to verify processing order.
@@ -221,63 +194,47 @@ fn test_cli_fences_with_renumber() {
         "1. first\n",
         "3. second\n",
     );
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .args(["--fences", "--renumber"])
         .write_stdin(input)
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```rust\nfn main() {}\n```\n\n1. first\n2. second\n",
-    );
+        .assert()
+        .success()
+        .stdout("```rust\nfn main() {}\n```\n\n1. first\n2. second\n");
 }
 
 #[test]
 fn test_cli_fences_preserve_existing_language() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin("ruby\n```rust\nfn main() {}\n```\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "ruby\n```rust\nfn main() {}\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("ruby\n```rust\nfn main() {}\n```\n");
 }
 
 #[test]
 fn test_cli_fences_orphan_specifier_symbols() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin("C++\n```\nfn main() {}\n```\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "```c++\nfn main() {}\n```\n"
-    );
+        .assert()
+        .success()
+        .stdout("```c++\nfn main() {}\n```\n");
 }
 
 #[test]
 fn test_cli_no_attach_without_preceding_blank_line() {
     let input = concat!("text\n", "Rust\n", "```\n", "fn main() {}\n", "```\n");
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--fences")
         .write_stdin(input)
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "text\nRust\n```\nfn main() {}\n```\n",
-    );
+        .assert()
+        .success()
+        .stdout("text\nRust\n```\nfn main() {}\n```\n");
 }
 
 /// Tests the CLI `--footnotes` option to convert bare footnote links.
@@ -285,15 +242,45 @@ fn test_cli_no_attach_without_preceding_blank_line() {
 fn test_cli_footnotes_option() {
     let input = include_str!("data/footnotes_input.txt");
     let expected = include_str!("data/footnotes_expected.txt");
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--footnotes")
         .write_stdin(input)
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    assert_eq!(
-        output.stdout,
-        format!("{}\n", expected.trim_end()).as_bytes()
-    );
+        .assert()
+        .success()
+        .stdout(format!("{}\n", expected.trim_end()));
+}
+
+/// Ensures `--fences` rewrites files when combined with `--in-place`.
+#[test]
+fn test_cli_in_place_fences() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("sample.md");
+    fs::write(&file_path, "Rust\n```\nfn main() {}\n```\n").expect("failed to write test file");
+    Command::cargo_bin("mdtablefix")
+        .expect("Failed to create cargo command for mdtablefix")
+        .args(["--in-place", "--fences", file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, "```rust\nfn main() {}\n```\n");
+}
+
+/// Ensures `--footnotes` rewrites files when combined with `--in-place`.
+#[test]
+fn test_cli_in_place_footnotes() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("sample.md");
+    let input = include_str!("data/footnotes_input.txt");
+    let expected = include_str!("data/footnotes_expected.txt");
+    fs::write(&file_path, input).expect("failed to write test file");
+    Command::cargo_bin("mdtablefix")
+        .expect("Failed to create cargo command for mdtablefix")
+        .args(["--in-place", "--footnotes", file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, format!("{}\n", expected.trim_end()));
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
 //! Utility helpers shared across integration tests.
 #![allow(unfulfilled_lint_expectations)]
 
-use assert_cmd::Command;
+use assert_cmd::{Command, assert::Assert};
 use rstest::fixture;
 
 /// Build a `Vec<String>` from a list of string slices.
@@ -103,12 +103,11 @@ pub fn broken_table() -> Vec<String> {
 
 /// Run the `mdtablefix` binary with the provided arguments.
 ///
-/// Returns the captured `Output` from the command execution.
+/// Returns an [`Assert`] handle for chaining output and status checks.
 #[expect(dead_code, reason = "used selectively across integration tests")]
-pub fn run_cli_with_args(args: &[&str]) -> std::process::Output {
+pub fn run_cli_with_args(args: &[&str]) -> Assert {
     Command::cargo_bin("mdtablefix")
         .expect("failed to create command")
         .args(args)
-        .output()
-        .expect("failed to run command")
+        .assert()
 }

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -66,15 +66,13 @@ fn restart_after_formatting_paragraph() {
 /// Ensures that list numbering is corrected when the flag is supplied.
 #[test]
 fn test_cli_renumber_option() {
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--renumber")
         .write_stdin("1. a\n4. b\n")
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    let text = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(text, "1. a\n2. b\n");
+        .assert()
+        .success()
+        .stdout("1. a\n2. b\n");
 }
 
 #[rstest(

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -9,11 +9,7 @@ mod prelude;
 use prelude::*;
 
 #[rstest]
-fn test_cli_parallel_empty_file_list() {
-    let output = run_cli_with_args(&[]);
-    assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "\n");
-}
+fn test_cli_parallel_empty_file_list() { run_cli_with_args(&[]).success().stdout("\n"); }
 
 #[rstest]
 fn test_cli_parallel_multiple_files() {
@@ -38,9 +34,7 @@ fn test_cli_parallel_multiple_files() {
     }
 
     let args: Vec<&str> = files.iter().map(|p| p.to_str().unwrap()).collect();
-    let output = run_cli_with_args(&args);
-    assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    run_cli_with_args(&args).success().stdout(expected);
 }
 
 #[rstest]
@@ -60,16 +54,14 @@ fn test_cli_parallel_missing_file_error() {
     let expected = mdtablefix::reflow_table(&table).join("\n") + "\n";
     let missing = dir.path().join("missing.md");
 
-    let output = Command::cargo_bin("mdtablefix")
+    Command::cargo_bin("mdtablefix")
         .expect("failed to create command")
         .arg(&good)
         .arg(&missing)
-        .output()
-        .expect("failed to run command");
-
-    assert!(!output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
-    assert!(String::from_utf8_lossy(&output.stderr).contains("missing.md"));
+        .assert()
+        .failure()
+        .stdout(expected)
+        .stderr(predicates::str::contains("missing.md"));
 }
 
 #[rstest]
@@ -86,8 +78,7 @@ fn test_cli_parallel_missing_file_in_place(broken_table: Vec<String>) {
 
     let good_str = good.to_str().unwrap();
     let missing_str = missing.to_str().unwrap();
-    let output = run_cli_with_args(&["--in-place", good_str, missing_str]);
-
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("missing.md"));
+    run_cli_with_args(&["--in-place", good_str, missing_str])
+        .failure()
+        .stderr(predicates::str::contains("missing.md"));
 }

--- a/tests/prelude/mod.rs
+++ b/tests/prelude/mod.rs
@@ -2,7 +2,9 @@
 #![allow(unfulfilled_lint_expectations)]
 
 #[expect(unused_imports, reason = "re-exporting common test utilities")]
-pub use assert_cmd::Command;
+pub use assert_cmd::{Command, prelude::*};
+#[expect(unused_imports, reason = "re-exporting common test utilities")]
+pub use predicates::prelude::*;
 #[expect(unused_imports, reason = "re-exporting common test utilities")]
 pub use rstest::{fixture, rstest};
 

--- a/tests/wrap/cli.rs
+++ b/tests/wrap/cli.rs
@@ -11,14 +11,13 @@ fn test_cli_wrap_option() {
     let input = "This line is deliberately made much longer than eighty columns so that the \
                  wrapping algorithm is forced to insert a soft line-break somewhere in the middle \
                  of the paragraph when the --wrap flag is supplied.";
-    let output = Command::cargo_bin("mdtablefix")
+    let assert = Command::cargo_bin("mdtablefix")
         .expect("Failed to create cargo command for mdtablefix")
         .arg("--wrap")
         .write_stdin(format!("{input}\n"))
-        .output()
-        .expect("Failed to execute mdtablefix command");
-    assert!(output.status.success());
-    let text = String::from_utf8_lossy(&output.stdout);
+        .assert()
+        .success();
+    let text = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(text.lines().count() > 1, "expected wrapped output on multiple lines");
     assert!(text.lines().all(|l| l.len() <= 80));
 }


### PR DESCRIPTION
## Summary
- ensure `--fences` and `--footnotes` are honoured when using `--in-place`
- verify in-place rewriting applies fence and footnote transformations
- use `assert_cmd` assertions across CLI tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68a38af507e48322b0fc055e2c86b208

## Summary by Sourcery

Respect formatting flags in in-place mode and streamline CLI tests using assert_cmd’s assertion chaining

New Features:
- Honor --fences and --footnotes flags in in-place mode to apply corresponding transformations when rewriting files

Enhancements:
- Refactor handle_file to unify file read/write logic and ensure trailing newline on in-place rewrites
- Migrate CLI tests to assert_cmd’s .assert() API for concise status and output assertions

Build:
- Add predicates crate dependency and update test prelude to re-export assert_cmd and predicates utilities

Tests:
- Add integration tests for in-place fence normalization and footnote rewrites
- Update existing CLI and parallel tests to use chained assertions and predicates