### PR TITLE
Use en-GB spelling in release documentation

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -29,7 +29,7 @@ architecture combinations. Each entry includes the target triple used by
 `cross` and a filename extension for Windows. During the build job, `cross`
 compiles a release binary for every matrix row.
 
-`cross` is installed from a specific git tag to avoid unexpected behavior from
+`cross` is installed from a specific git tag to avoid unexpected behaviour from
 its main branch. Each binary is placed in an `artifacts/<os>-<arch>` directory
 using the naming pattern `mdtablefix-<os>-<arch>[.exe]`. An SHA-256 checksum is
 written alongside each binary for download verification.


### PR DESCRIPTION
## Summary
- apply en-GB spelling for `behaviour` in release process docs

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make nixie`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ba629da48322b766f1474b43e1d5

## Summary by Sourcery

Documentation:
- Standardise spelling by changing “behavior” to “behaviour” in release-process.md