### PR TITLE
Switch to stable Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,16 @@ jobs:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+
+  msrv:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
+        with:
+          toolchain: 1.89.0
+      - name: Build
+        run: cargo +1.89.0 build --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,3 @@ jobs:
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
-  msrv:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
-        with:
-          toolchain: 1.89.0
-      - name: Build
-        run: cargo build --locked --all-targets
-      - name: Test
-        run: cargo test --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Format
@@ -43,10 +43,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
         with:
           toolchain: 1.89.0
       - name: Build
-        run: cargo +1.89.0 build --locked --all-targets
+        run: cargo build --locked --all-targets
+      - name: Test
+        run: cargo test --locked --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mdtablefix"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.89"
 
 [dependencies]
 anyhow = "1"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -37,7 +37,7 @@ its main branch. Each binary is placed in an `artifacts/<os>-<arch>` directory
 using the naming pattern `mdtablefix-<os>-<arch>[.exe]`. An SHA-256 checksum is
 written alongside each binary for download verification.
 
-After every build completes, the artifact is uploaded so that the GitHub
+After every build completes, the artefact is uploaded so that the GitHub
 Actions interface provides it immediately. Once the matrix has finished, the
-`release` job downloads all artifacts and uploads them to the GitHub release
+`release` job downloads all artefacts and uploads them to the GitHub release
 using `gh release upload`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,7 +3,8 @@
 This project publishes prebuilt binaries for multiple operating systems and
 architectures.
 
-The project targets Rust `1.89.0` as set in `rust-toolchain.toml`.
+The project targets the stable Rust `1.89.0` toolchain, as specified in
+`rust-toolchain.toml`.
 
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,6 +6,10 @@ architectures.
 The project targets the stable Rust `1.89.0` toolchain, as specified in
 `rust-toolchain.toml`.
 
+This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml`
+(`rust-version = "1.89"`) and enforced by the `msrv` job in
+`.github/workflows/ci.yml`.
+
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,6 +3,8 @@
 This project publishes prebuilt binaries for multiple operating systems and
 architectures.
 
+The project targets Rust `1.89.0` as set in `rust-toolchain.toml`.
+
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -7,8 +7,8 @@ The project targets the stable Rust `1.89.0` toolchain, as specified in
 `rust-toolchain.toml`.
 
 This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml`
-(`rust-version = "1.89"`) and enforced by the `msrv` job in
-`.github/workflows/ci.yml`.
+(`rust-version = "1.89"`). The `build-test` job in `.github/workflows/ci.yml`
+uses this toolchain to guard against regressions.
 
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.89.0"
 components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-06-26"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]

--- a/src/html.rs
+++ b/src/html.rs
@@ -84,7 +84,9 @@ fn is_element(handle: &Handle, tag: &str) -> bool {
 }
 
 /// Returns `true` if `handle` represents a `<td>` or `<th>` element.
-fn is_table_cell(handle: &Handle) -> bool { is_element(handle, "td") || is_element(handle, "th") }
+fn is_table_cell(handle: &Handle) -> bool {
+    is_element(handle, "td") || is_element(handle, "th")
+}
 
 /// Walks the DOM tree collecting `<table>` nodes under `handle`.
 fn collect_tables(handle: &Handle, tables: &mut Vec<Handle>) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -30,7 +30,9 @@ where
 ///
 /// # Errors
 /// Returns an error if reading or writing the file fails.
-pub fn rewrite(path: &Path) -> std::io::Result<()> { rewrite_with(path, process_stream) }
+pub fn rewrite(path: &Path) -> std::io::Result<()> {
+    rewrite_with(path, process_stream)
+}
 
 /// Rewrite a file in place without wrapping text.
 ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ macro_rules! lines_vec {
 ///
 /// Example:
 /// ```
-/// let input: Vec<String> = include_lines!("data/bold_header_input.txt"); 
+/// let input: Vec<String> = include_lines!("data/bold_header_input.txt");
 /// ```
 #[expect(unused_macros, reason = "macros are optional helpers across modules")]
 macro_rules! include_lines {

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -9,7 +9,9 @@ mod prelude;
 use prelude::*;
 
 #[rstest]
-fn test_cli_parallel_empty_file_list() { run_cli_with_args(&[]).success().stdout("\n"); }
+fn test_cli_parallel_empty_file_list() {
+    run_cli_with_args(&[]).success().stdout("\n");
+}
 
 #[rstest]
 fn test_cli_parallel_multiple_files() {


### PR DESCRIPTION
## Summary
- pin toolchain to stable Rust 1.89.0 to avoid nightly-only dependency issues
- document the Rust version used for releases

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d6a786888322aaeffb2923251716

## Summary by Sourcery

Pin the project to the Rust stable 1.89.0 toolchain and update documentation accordingly

Enhancements:
- Switch rust-toolchain.toml channel from nightly to stable 1.89.0
- Add Rust 1.89.0 version note to the release-process documentation