### PR TITLE
Bump crate version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "mdtablefix"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdtablefix"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.89"
 


### PR DESCRIPTION
## Summary
- bump crate version to 0.1.2

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adaf3fc0ec83228ef834c348d988c0

## Summary by Sourcery

Bump mdtablefix crate version to 0.1.2 for release

Chores:
- Update Cargo.toml version to 0.1.2
- Regenerate Cargo.lock to match updated version