### PR TITLE
Add code emphasis option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--code-emphasis` flag to fix emphasis markers that adjoin inline code.
+
 ### Fixed
 
 - Preserve trailing spaces on the final line when wrapping Markdown, retaining

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `--code-emphasis` flag to fix emphasis markers that adjoin inline code.
+  Runs after `--footnotes` in the processing pipeline.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - `--code-emphasis` flag to fix emphasis markers that adjoin inline code.
-  Runs after `--footnotes` in the processing pipeline.
+  Runs before wrapping and footnote conversion.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ cargo install --path .
 ## Command-line usage
 
 ```bash
-mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] [--footnotes] [--in-place] [FILE...]
+mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences]
+          [--footnotes] [--code-emphasis] [--in-place] [FILE...]
 ```
 
 - When one or more file paths are provided, the corrected tables are printed to
@@ -58,6 +59,9 @@ mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences] 
 
   A bare numeric reference is a trailing number after punctuation, like
   `An example.1`.
+
+- Use `--code-emphasis` to fix emphasis markers that directly adjoin inline
+  code without spaces, ensuring the code span remains intact.
 
 - Use `--in-place` to modify files in-place.
 

--- a/src/code_emphasis.rs
+++ b/src/code_emphasis.rs
@@ -1,0 +1,113 @@
+//! Fix misplaced emphasis around inline code spans.
+//!
+//! Emphasis markers that directly adjoin backtick-wrapped inline code without
+//! spaces are reordered or stripped so code remains intact within emphasised
+//! text.
+
+use crate::textproc::process_text;
+use crate::wrap::{Token, tokenize_markdown};
+
+fn split_leading_emphasis(s: &str) -> (&str, &str) {
+    let idx = s.find(|c| c != '*' && c != '_').unwrap_or(s.len());
+    s.split_at(idx)
+}
+
+fn split_trailing_emphasis(s: &str) -> (&str, &str) {
+    let idx = s.rfind(|c| c != '*' && c != '_').map_or(0, |i| i + 1);
+    s.split_at(idx)
+}
+
+fn push_code(code: &str, out: &mut String) {
+    out.push('`');
+    out.push_str(code);
+    out.push('`');
+}
+
+/// Merge contiguous code and emphasis spans.
+///
+/// Groups of emphasis markers and inline code with no separating spaces are
+/// normalised so that emphasis markers wrap the entire group or are removed
+/// when they solely surround code.
+#[must_use]
+pub fn fix_code_emphasis(lines: &[String]) -> Vec<String> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    let trailing_blanks = lines.iter().rev().take_while(|l| l.is_empty()).count();
+    if trailing_blanks == lines.len() {
+        return vec![String::new(); lines.len()];
+    }
+    let source = lines.join("\n");
+    let tokens = tokenize_markdown(&source);
+    let mut out = String::new();
+    let mut pending_prefix: Option<String> = None;
+    let mut next_override: Option<String> = None;
+    let mut i = 0;
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::Text(t_raw) => {
+                let t = next_override.take().unwrap_or_else(|| (*t_raw).to_string());
+                if matches!(tokens.get(i + 1), Some(Token::Code(_))) {
+                    let (body, emph) = split_trailing_emphasis(&t);
+                    out.push_str(body);
+                    if !emph.is_empty() {
+                        pending_prefix = Some(emph.to_string());
+                    }
+                } else {
+                    out.push_str(&t);
+                }
+                i += 1;
+            }
+            Token::Code(c) => {
+                let mut prefix = pending_prefix.take().unwrap_or_default();
+                if let Some(Token::Text(t_next)) = tokens.get(i + 1) {
+                    let (emph, rest) = split_leading_emphasis(t_next);
+                    if !emph.is_empty() {
+                        if prefix.is_empty() {
+                            prefix = emph.to_string();
+                        } else {
+                            prefix.clear();
+                        }
+                        next_override = Some(rest.to_string());
+                    }
+                }
+                if !prefix.is_empty() {
+                    out.push_str(&prefix);
+                }
+                push_code(c, &mut out);
+                i += 1;
+            }
+            Token::Fence(f) => {
+                out.push_str(f);
+                i += 1;
+            }
+            Token::Newline => {
+                out.push('\n');
+                i += 1;
+            }
+        }
+    }
+    process_text(&out, trailing_blanks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merges_emphasis_and_code() {
+        let input = vec![
+            "`StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**".to_string(),
+        ];
+        let expected = vec![
+            "**`StepContext` Enhancement (in `crates/rstest-bdd/src/context.rs`)**".to_string(),
+        ];
+        assert_eq!(fix_code_emphasis(&input), expected);
+    }
+
+    #[test]
+    fn ignores_simple_text() {
+        let input = vec!["nothing here".to_string()];
+        assert_eq!(fix_code_emphasis(&input), input);
+    }
+}

--- a/src/code_emphasis.rs
+++ b/src/code_emphasis.rs
@@ -18,15 +18,26 @@ use crate::wrap::{Token, tokenize_markdown};
 /// assert_eq!(split_marks("text"), ("", "text", ""));
 /// ```
 fn split_marks(s: &str) -> (&str, &str, &str) {
-    let start = s.find(|c| c != '*' && c != '_').unwrap_or(0);
-    let end = s.rfind(|c| c != '*' && c != '_').map_or(s.len(), |i| i + 1);
-    (&s[..start], &s[start..end], &s[end..])
+    let first = s.find(|c| c != '*' && c != '_').unwrap_or(s.len());
+    let last = s.rfind(|c| c != '*' && c != '_').map_or(first, |i| i + 1);
+    (&s[..first], &s[first..last], &s[last..])
 }
 
 fn push_code(code: &str, out: &mut String) {
-    out.push('`');
+    let mut max_run = 0;
+    let mut run = 0;
+    for c in code.chars() {
+        if c == '`' {
+            run += 1;
+            max_run = max_run.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    let fence = "`".repeat(max_run + 1);
+    out.push_str(&fence);
     out.push_str(code);
-    out.push('`');
+    out.push_str(&fence);
 }
 
 /// Merge contiguous code and emphasis spans.
@@ -63,20 +74,31 @@ pub fn fix_code_emphasis(lines: &[String]) -> Vec<String> {
             Token::Text(raw) => {
                 if tokens.peek().is_some_and(|t| matches!(t, Token::Code(_))) {
                     let (lead, body, trail) = split_marks(raw);
-                    out.push_str(lead);
-                    out.push_str(body);
-                    pending = trail;
+                    if body.is_empty() && trail.is_empty() {
+                        pending = lead;
+                    } else {
+                        out.push_str(lead);
+                        out.push_str(body);
+                        pending = trail;
+                    }
                 } else {
                     out.push_str(raw);
                 }
             }
             Token::Code(code) => {
                 let mut prefix = pending;
+                let mut suffix = "";
                 pending = "";
                 if let Some(Token::Text(next)) = tokens.peek_mut() {
-                    let (lead, _, _) = split_marks(next);
+                    let (lead, mid, _) = split_marks(next);
                     if !lead.is_empty() {
-                        prefix = if prefix.is_empty() { lead } else { "" };
+                        if prefix.is_empty() {
+                            prefix = lead;
+                        } else if mid.is_empty() {
+                            suffix = lead;
+                        } else {
+                            prefix = "";
+                        }
                         *next = &next[lead.len()..];
                     }
                 }
@@ -84,6 +106,9 @@ pub fn fix_code_emphasis(lines: &[String]) -> Vec<String> {
                     out.push_str(prefix);
                 }
                 push_code(code, &mut out);
+                if !suffix.is_empty() {
+                    out.push_str(suffix);
+                }
             }
             Token::Fence(f) => out.push_str(f),
             Token::Newline => out.push('\n'),
@@ -110,6 +135,18 @@ mod tests {
     #[test]
     fn ignores_simple_text() {
         let input = vec!["nothing here".to_string()];
+        assert_eq!(fix_code_emphasis(&input), input);
+    }
+
+    #[test]
+    fn preserves_emphasised_code_only() {
+        let input = vec!["**`code`**".to_string()];
+        assert_eq!(fix_code_emphasis(&input), input);
+    }
+
+    #[test]
+    fn preserves_inner_backticks_in_code() {
+        let input = vec!["``a`b``".to_string()];
         assert_eq!(fix_code_emphasis(&input), input);
     }
 }

--- a/src/code_emphasis.rs
+++ b/src/code_emphasis.rs
@@ -102,7 +102,7 @@ pub fn fix_code_emphasis(lines: &[String]) -> Vec<String> {
                     out.push_str(raw);
                 }
             }
-            Token::Code { fence, code } => {
+            Token::Code { raw, code, .. } => {
                 if !pending.is_empty()
                     && let Some(Token::Text(next)) = tokens.peek()
                 {
@@ -140,9 +140,7 @@ pub fn fix_code_emphasis(lines: &[String]) -> Vec<String> {
                 if modified {
                     push_code(code, &mut out);
                 } else {
-                    out.push_str(fence);
-                    out.push_str(code);
-                    out.push_str(fence);
+                    out.push_str(raw);
                 }
                 if !suffix.is_empty() {
                     out.push_str(suffix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! - `ellipsis` for normalizing textual ellipses.
 //! - `fences` for issues with code block fences
 //! - `footnotes` for converting bare footnote links.
+//! - `code_emphasis` for fixing misplaced emphasis around code.
 //! - `textproc` for token-based transformations.
 //! - `process` for stream processing.
 //! - `io` for file helpers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! - `ellipsis` for normalizing textual ellipses.
 //! - `fences` for issues with code block fences
 //! - `footnotes` for converting bare footnote links.
-//! - `code_emphasis` for fixing misplaced emphasis around code.
+//! - `code_emphasis` for fixing emphasis adjoining inline code.
 //! - `textproc` for token-based transformations.
 //! - `process` for stream processing.
 //! - `io` for file helpers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ macro_rules! lazy_regex {
 }
 
 pub mod breaks;
+pub mod code_emphasis;
 pub mod ellipsis;
 pub mod fences;
 pub mod footnotes;
@@ -40,6 +41,7 @@ pub fn html_table_to_markdown(lines: &[String]) -> Vec<String> {
 }
 
 pub use breaks::{THEMATIC_BREAK_LEN, format_breaks};
+pub use code_emphasis::fix_code_emphasis;
 pub use ellipsis::replace_ellipsis;
 pub use fences::{attach_orphan_specifiers, compress_fences};
 pub use footnotes::convert_footnotes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ struct Cli {
 #[derive(clap::Args, Clone, Copy)]
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "CLI exposes five independent flags"
+    reason = "CLI exposes independent flags via separate switches"
 )]
 struct FormatOpts {
     /// Wrap paragraphs and list items to 80 columns

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ struct FormatOpts {
     /// Markdown footnote links
     #[arg(long = "footnotes")]
     footnotes: bool,
+    /// Fix emphasis markers adjacent to inline code
+    #[arg(long = "code-emphasis")]
+    code_emphasis: bool,
 }
 
 impl From<FormatOpts> for Options {
@@ -63,6 +66,7 @@ impl From<FormatOpts> for Options {
             ellipsis: opts.ellipsis,
             fences: opts.fences,
             footnotes: opts.footnotes,
+            code_emphasis: opts.code_emphasis,
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -178,6 +178,10 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String> {
 
     flush_buffer(&mut buf, &mut in_table, &mut out);
 
+    if opts.code_emphasis {
+        out = crate::code_emphasis::fix_code_emphasis(&out);
+    }
+
     let mut out = if opts.wrap {
         wrap_text(&out, WRAP_COLS)
     } else {
@@ -188,9 +192,6 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String> {
     }
     if opts.footnotes {
         out = convert_footnotes(&out);
-    }
-    if opts.code_emphasis {
-        out = crate::code_emphasis::fix_code_emphasis(&out);
     }
     out
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -25,6 +25,7 @@ pub(crate) const WRAP_COLS: usize = 80;
 ///     ellipsis: false,
 ///     fences: false,
 ///     footnotes: false,
+///     code_emphasis: false,
 /// };
 /// let out = process_stream_opts(&lines, opts);
 /// assert_eq!(out, vec!["example"]);
@@ -43,6 +44,8 @@ pub struct Options {
     pub fences: bool,
     /// Convert bare numeric references into GitHub-flavoured footnote links (default: `false`).
     pub footnotes: bool,
+    /// Fix emphasis markers adjacent to inline code.
+    pub code_emphasis: bool,
 }
 
 /// Flushes buffered lines to `out`, formatting as a table when required.
@@ -134,6 +137,7 @@ fn handle_table_line(
 ///         ellipsis: false,
 ///         fences: false,
 ///         footnotes: false,
+///         code_emphasis: false,
 ///     },
 /// );
 /// assert!(out.iter().any(|l| l.contains("| a | b |")));
@@ -184,6 +188,9 @@ pub fn process_stream_inner(lines: &[String], opts: Options) -> Vec<String> {
     }
     if opts.footnotes {
         out = convert_footnotes(&out);
+    }
+    if opts.code_emphasis {
+        out = crate::code_emphasis::fix_code_emphasis(&out);
     }
     out
 }
@@ -248,6 +255,7 @@ pub fn process_stream_no_wrap(lines: &[String]) -> Vec<String> {
 ///     ellipsis: false,
 ///     fences: false,
 ///     footnotes: false,
+///     code_emphasis: false,
 /// };
 /// let out = process_stream_opts(&lines, opts);
 /// assert_eq!(out, vec!["text"]);

--- a/src/process.rs
+++ b/src/process.rs
@@ -288,4 +288,17 @@ mod tests {
         let out = process_stream_no_wrap(&input);
         assert_eq!(out, vec!["| a | b |", "| 1 | 2 |"]);
     }
+
+    #[test]
+    fn integrates_code_emphasis_flag() {
+        let input = vec!["`X`** Y (in **`Z`**)**".to_string()];
+        let out = process_stream_inner(
+            &input,
+            Options {
+                code_emphasis: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(out, vec!["**`X` Y (in `Z`)**"]);
+    }
 }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -14,8 +14,8 @@ mod fence;
 mod tokenize;
 
 pub use fence::is_fence;
-/// Token emitted by [`tokenize::segment_inline`] and used by higher-level
-/// wrappers.
+/// Token emitted by the `tokenize::segment_inline` parser and used by
+/// higher-level wrappers.
 ///
 /// Downstream callers inspect [`Token<'a>`] when implementing bespoke
 /// wrapping logic. The `'a` lifetime parameter ties each token to the source

--- a/src/wrap/tokenize.rs
+++ b/src/wrap/tokenize.rs
@@ -37,13 +37,13 @@ fn collect_range(chars: &[char], start: usize, end: usize) -> String {
     chars[start..end].iter().collect()
 }
 
-/// Markdown token emitted by [`segment_inline`].
+/// Markdown token emitted by the `segment_inline` tokenizer.
 #[derive(Debug, PartialEq)]
 pub enum Token<'a> {
     /// Line within a fenced code block, including the fence itself.
     Fence(&'a str),
-    /// Inline code span without surrounding backticks.
-    Code(&'a str),
+    /// Inline code span alongside its original fence.
+    Code { fence: &'a str, code: &'a str },
     /// Plain text outside code regions.
     Text(&'a str),
     /// Line break separating tokens.
@@ -197,7 +197,13 @@ fn next_token(s: &str) -> Option<(Token<'_>, usize)> {
     let closing = &s[..delim_len];
     if let Some(end) = s[delim_len..].find(closing) {
         let code = &s[delim_len..delim_len + end];
-        return Some((Token::Code(code), delim_len + end + delim_len));
+        return Some((
+            Token::Code {
+                fence: closing,
+                code,
+            },
+            delim_len + end + delim_len,
+        ));
     }
     Some((Token::Text(closing), delim_len))
 }
@@ -213,12 +219,12 @@ fn next_token(s: &str) -> Option<(Token<'_>, usize)> {
 /// ```rust,ignore
 /// // Prints:
 /// // Token::Text("run ")
-/// // Token::Code("cmd")
+/// // Token::Code { fence: "`", code: "cmd" }
 /// tokenize_inline("run `cmd`", &mut |t| println!("{:?}", t));
 /// ```
 ///
 /// The callback receives each token as a [`Token<'a>`], such as
-/// `Token::Text(&str)` or `Token::Code(&str)`.
+/// `Token::Text(&str)` or `Token::Code { fence: &str, code: &str }`.
 fn tokenize_inline<'a, F>(mut rest: &'a str, mut emit: F)
 where
     F: FnMut(Token<'a>),
@@ -248,7 +254,7 @@ where
 /// let tokens = tokenize_markdown("Example with `code`");
 /// assert_eq!(
 ///     tokens,
-///     vec![Token::Text("Example with "), Token::Code("code")]
+///     vec![Token::Text("Example with "), Token::Code { fence: "`", code: "code" }]
 /// );
 /// ```
 fn push_newline_if_needed<I>(

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -36,6 +36,40 @@ fn cli_in_place_code_emphasis() {
 }
 
 #[test]
+fn cli_in_place_code_emphasis_empty_file() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("empty.md");
+    fs::write(&file_path, "").expect("failed to write test file");
+    run_cli_with_args(&[
+        "--code-emphasis",
+        "--in-place",
+        file_path.to_str().expect("path is not valid UTF-8"),
+    ])
+    .success()
+    .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, "");
+}
+
+#[test]
+fn cli_in_place_code_emphasis_whitespace_file() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("whitespace.md");
+    let input = "   \n\t  ";
+    let expected = "   \n\t  \n";
+    fs::write(&file_path, input).expect("failed to write test file");
+    run_cli_with_args(&[
+        "--code-emphasis",
+        "--in-place",
+        file_path.to_str().expect("path is not valid UTF-8"),
+    ])
+    .success()
+    .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, expected);
+}
+
+#[test]
 fn cli_code_emphasis_with_wrap_and_renumber() {
     let input = "8. `StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**\n10. Second item\n";
     let expected = "1. **`StepContext` Enhancement (in `crates/rstest-bdd/src/context.rs`)**\n2. Second item\n";

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -2,9 +2,8 @@
 //!
 //! Verifies that emphasis markers adjacent to inline code are normalised.
 
-#[macro_use]
 mod prelude;
-use prelude::*;
+use prelude::{run_cli_with_args, run_cli_with_stdin};
 use std::fs;
 use tempfile::tempdir;
 
@@ -75,6 +74,23 @@ fn cli_in_place_code_emphasis_whitespace_file() {
     .stdout("");
     let out = fs::read_to_string(&file_path).expect("failed to read output file");
     assert_eq!(out, expected);
+}
+
+#[test]
+fn cli_in_place_preserves_inner_backticks() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("inner.md");
+    let input = "```` ``a`b`` ````\n";
+    fs::write(&file_path, input).expect("failed to write test file");
+    run_cli_with_args(&[
+        "--code-emphasis",
+        "--in-place",
+        file_path.to_str().expect("path is not valid UTF-8"),
+    ])
+    .success()
+    .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, input);
 }
 
 #[test]

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -1,0 +1,45 @@
+//! Integration tests for the `--code-emphasis` flag.
+//!
+//! Verifies that emphasis markers adjacent to inline code are normalised.
+
+#[macro_use]
+mod prelude;
+use prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn cli_stdin_code_emphasis() {
+    let input = "`StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**\n";
+    let expected = "**`StepContext` Enhancement (in `crates/rstest-bdd/src/context.rs`)**\n";
+    run_cli_with_stdin(&["--code-emphasis"], input)
+        .success()
+        .stdout(expected);
+}
+
+#[test]
+fn cli_in_place_code_emphasis() {
+    let dir = tempdir().expect("failed to create temporary directory");
+    let file_path = dir.path().join("sample.md");
+    let input = "`StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**\n";
+    let expected = "**`StepContext` Enhancement (in `crates/rstest-bdd/src/context.rs`)**\n";
+    fs::write(&file_path, input).expect("failed to write test file");
+    run_cli_with_args(&[
+        "--code-emphasis",
+        "--in-place",
+        file_path.to_str().expect("path is not valid UTF-8"),
+    ])
+    .success()
+    .stdout("");
+    let out = fs::read_to_string(&file_path).expect("failed to read output file");
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn cli_code_emphasis_with_wrap_and_renumber() {
+    let input = "8. `StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**\n10. Second item\n";
+    let expected = "1. **`StepContext` Enhancement (in `crates/rstest-bdd/src/context.rs`)**\n2. Second item\n";
+    run_cli_with_stdin(&["--code-emphasis", "--wrap", "--renumber"], input)
+        .success()
+        .stdout(expected);
+}

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -109,3 +109,11 @@ fn cli_preserves_inner_backticks() {
         .success()
         .stdout(input);
 }
+
+#[test]
+fn cli_preserves_standalone_code() {
+    let input = "`code` text\n";
+    run_cli_with_stdin(&["--code-emphasis"], input)
+        .success()
+        .stdout(input);
+}

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -17,6 +17,12 @@ fn cli_stdin_code_emphasis() {
 }
 
 #[test]
+fn cli_without_flag_is_noop_for_code_emphasis_input() {
+    let input = "`StepContext`** Enhancement (in **`crates/rstest-bdd/src/context.rs`**)**\n";
+    run_cli_with_stdin(&[], input).success().stdout(input);
+}
+
+#[test]
 fn cli_preserves_emphasised_code_only() {
     let input = "**`code`**\n";
     run_cli_with_stdin(&["--code-emphasis"], input)

--- a/tests/code_emphasis.rs
+++ b/tests/code_emphasis.rs
@@ -18,6 +18,14 @@ fn cli_stdin_code_emphasis() {
 }
 
 #[test]
+fn cli_preserves_emphasised_code_only() {
+    let input = "**`code`**\n";
+    run_cli_with_stdin(&["--code-emphasis"], input)
+        .success()
+        .stdout(input);
+}
+
+#[test]
 fn cli_in_place_code_emphasis() {
     let dir = tempdir().expect("failed to create temporary directory");
     let file_path = dir.path().join("sample.md");
@@ -76,4 +84,12 @@ fn cli_code_emphasis_with_wrap_and_renumber() {
     run_cli_with_stdin(&["--code-emphasis", "--wrap", "--renumber"], input)
         .success()
         .stdout(expected);
+}
+
+#[test]
+fn cli_preserves_inner_backticks() {
+    let input = "``a`b``\n";
+    run_cli_with_stdin(&["--code-emphasis"], input)
+        .success()
+        .stdout(input);
 }


### PR DESCRIPTION
## Summary
- add `--code-emphasis` flag to normalise emphasis markers around inline code
- document and test `--code-emphasis`, including combinations with other flags

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b31e2e1b888322bd73718a6388b4f3

## Summary by Sourcery

Add a new --code-emphasis option to normalize emphasis markers adjacent to inline code spans across rendered Markdown.

New Features:
- Introduce a --code-emphasis CLI flag to reorder or remove emphasis markers around inline code without spaces.

Enhancements:
- Integrate fix_code_emphasis into the processing pipeline and expose it in the library API.

Documentation:
- Document the --code-emphasis flag in README and update CHANGELOG accordingly.

Tests:
- Add unit tests for fix_code_emphasis logic and integration tests for CLI usage with the code-emphasis flag.