### PR TITLE
Honour markdownlint disable-next-line directives

### DIFF
--- a/tests/data/markdownlint_disable_next_line_expected.txt
+++ b/tests/data/markdownlint_disable_next_line_expected.txt
@@ -1,0 +1,5 @@
+Consider a component that fetches data. Instead of managing state with multiple
+booleans
+<!-- markdownlint-disable-next-line MD013 -->
+(`const [isLoading, setIsLoading] = useState(true); const [isError, setIsError] = useState(false);`),
+an FSM approach would use a single state object:

--- a/tests/data/markdownlint_disable_next_line_input.txt
+++ b/tests/data/markdownlint_disable_next_line_input.txt
@@ -1,0 +1,5 @@
+Consider a component that fetches data. Instead of managing state with multiple
+booleans
+<!-- markdownlint-disable-next-line MD013 -->
+(`const [isLoading, setIsLoading] = useState(true); const [isError, setIsError] = useState(false);`),
+an FSM approach would use a single state object:

--- a/tests/wrap/paragraphs.rs
+++ b/tests/wrap/paragraphs.rs
@@ -29,3 +29,12 @@ fn test_wrap_paragraph_with_long_word_parameterised(#[case] word_length: usize) 
     assert_eq!(output.len(), 1);
     assert_eq!(output[0], long_word);
 }
+
+#[test]
+fn test_markdownlint_disable_next_line_preserved() {
+    let input: Vec<String> =
+        include_lines!("data/markdownlint_disable_next_line_input.txt");
+    let expected: Vec<String> =
+        include_lines!("data/markdownlint_disable_next_line_expected.txt");
+    assert_eq!(process_stream(&input), expected);
+}


### PR DESCRIPTION
## Summary
- skip wrapping when encountering `markdownlint-disable-next-line`
- test paragraph with markdownlint directive to ensure text stays verbatim

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b45e7c3ed48322a99b430facff7547

## Summary by Sourcery

Enable skip-wrapping of lines following a markdownlint-disable-next-line directive, refactor unwrapped line handling into a helper function, and add a test for the new behavior

New Features:
- Honor markdownlint-disable-next-line directives by skipping wrapping on the following line

Enhancements:
- Extract emit_line_unwrapped helper to unify and simplify unwrapped line emission
- Replace duplicated flush-paragraph, clear-buffer, and push-line logic with emit_line_unwrapped

Tests:
- Add integration test to verify paragraphs after markdownlint-disable-next-line remain verbatim