### PR TITLE
Add ellipsis wrap in-place test

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -299,6 +299,7 @@ fn run_in_place(flags: &[&str], input: &str, expected: &str) {
 #[case(&["--footnotes"], include_str!("data/footnotes_input.txt"), include_str!("data/footnotes_expected.txt"))]
 #[case(&["--fences", "--footnotes"], include_str!("data/fences_footnotes_input.txt"), include_str!("data/fences_footnotes_expected.txt"))]
 #[case(&["--wrap", "--footnotes"], include_str!("data/footnotes_input.txt"), include_str!("data/footnotes_wrap_expected.txt"))]
+#[case(&["--wrap", "--ellipsis"], include_str!("data/ellipsis_wrap_input.txt"), include_str!("data/ellipsis_wrap_expected.txt"))]
 fn test_cli_in_place_variants(#[case] flags: &[&str], #[case] input: &str, #[case] expected: &str) {
     run_in_place(flags, input, expected);
 }

--- a/tests/data/ellipsis_wrap_expected.txt
+++ b/tests/data/ellipsis_wrap_expected.txt
@@ -1,0 +1,2 @@
+This is a long line with some text that contains three dots… which should be
+converted to an ellipsis and wrapped neatly across several lines when processed.

--- a/tests/data/ellipsis_wrap_input.txt
+++ b/tests/data/ellipsis_wrap_input.txt
@@ -1,0 +1,1 @@
+This is a long line with some text that contains three dots... which should be converted to an ellipsis and wrapped neatly across several lines when processed.


### PR DESCRIPTION
## Summary
- ensure ellipsis replacement works when combined with wrap and in-place rewriting
- add fixtures for ellipsis wrap integration test

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b634cd39708322acd1a6a59303493a