### PR TITLE
Ignore footnotes in headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
   details. ([#65](https://github.com/leynos/mdtablefix/issues/65))
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
+- Avoid converting numeric references in heading text when the `--footnotes`
+  option is enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,5 @@
   details. ([#65](https://github.com/leynos/mdtablefix/issues/65))
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
-- Avoid converting numeric references in ATX heading text when the `--footnotes`
-  option is enabled.
+- Avoid converting numeric references in ATX heading text (including headings in
+  blockquotes) when the `--footnotes` option is enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,5 @@
   details. ([#65](https://github.com/leynos/mdtablefix/issues/65))
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
-- Avoid converting numeric references in heading text when the `--footnotes`
+- Avoid converting numeric references in ATX heading text when the `--footnotes`
   option is enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,4 @@
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
 - Avoid converting numeric references in ATX heading text (including headings in
-  blockquotes) when the `--footnotes` option is enabled.
+  blockquotes and list items) when the `--footnotes` option is enabled.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,9 @@ Core types[^7]:
 
 Numbers inside inline code or parentheses are ignored.
 
-Heading lines are also left untouched so identifiers like "A.2" remain verbatim.
+Heading lines are also left untouched, so identifiers like "A.2" remain
+verbatim (this applies to ATX-style headings, including those inside
+blockquotes; Setext-style headings are not detected).
 
 Before:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,7 +298,7 @@ classDiagram
     process ..> fences : uses compress_fences, attach_orphan_specifiers
     process ..> ellipsis : uses replace_ellipsis
     process ..> footnotes : uses convert_footnotes
-    footnotes ..> textproc : uses process_tokens
+    footnotes ..> textproc : uses tokenize_markdown, push_original_token
     io ..> process : uses process_stream, process_stream_no_wrap
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,7 +298,8 @@ classDiagram
     process ..> fences : uses compress_fences, attach_orphan_specifiers
     process ..> ellipsis : uses replace_ellipsis
     process ..> footnotes : uses convert_footnotes
-    footnotes ..> textproc : uses tokenize_markdown, push_original_token
+    footnotes ..> wrap : uses tokenize_markdown
+    footnotes ..> textproc : uses push_original_token
     io ..> process : uses process_stream, process_stream_no_wrap
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,8 @@ Core types[^7]:
 
 Numbers inside inline code or parentheses are ignored.
 
+Heading lines are also left untouched so identifiers like "A.2" remain verbatim.
+
 Before:
 
 ```markdown

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,9 +131,9 @@ Core types[^7]:
 
 Numbers inside inline code or parentheses are ignored.
 
-Heading lines are also left untouched, so identifiers like "A.2" remain
-verbatim (this applies to ATX-style headings, including those inside
-blockquotes; Setext-style headings are not detected).
+ATX heading lines (including those nested in blockquotes and list items) are
+not processed for footnote conversion, so identifiers like "A.2" remain
+verbatim. Setext-style headings are not detected.
 
 Before:
 

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -76,7 +76,7 @@ where
     }
 
     let source = lines.join("\n");
-    let mut out = String::new();
+    let mut out = String::with_capacity(source.len());
     for token in tokenize_markdown(&source) {
         f(token, &mut out);
     }

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -62,6 +62,24 @@ fn test_ignores_numbers_in_headings() {
 }
 
 #[test]
+fn test_ignores_footnote_references_in_headings() {
+    let input = lines_vec!("### Heading with footnote[1]");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
+fn test_ignores_numbers_in_blockquoted_headings() {
+    let input = lines_vec!("> ### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
+fn test_ignores_numbers_in_list_headings() {
+    let input = lines_vec!("- ### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
 fn test_ignores_numbers_in_fenced_code_block() {
     let input = lines_vec!(
         "Here is a code block:",

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -55,45 +55,16 @@ fn test_ignores_numbers_in_parentheses() {
     assert_eq!(convert_footnotes(&input), input);
 }
 
-#[test]
-fn test_ignores_numbers_in_headings() {
-    let input = lines_vec!("### A.2 A Note on This List");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_footnote_references_in_headings() {
-    let input = lines_vec!("### Heading with footnote[1]");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_numbers_in_blockquoted_headings() {
-    let input = lines_vec!("> ### A.2 A Note on This List");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_numbers_in_list_headings() {
-    let input = lines_vec!("- ### A.2 A Note on This List");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_numbers_in_ordered_list_headings() {
-    let input = lines_vec!("1. ### A.2 A Note on This List");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_numbers_in_nested_list_headings() {
-    let input = lines_vec!("- 1. ### A.2 A Note on This List");
-    assert_eq!(convert_footnotes(&input), input);
-}
-
-#[test]
-fn test_ignores_numbers_in_deeply_quoted_headings() {
-    let input = lines_vec!(">> ### A.2 A Note on This List");
+#[rstest]
+#[case("### A.2 A Note on This List")]
+#[case("### Heading with footnote[1]")]
+#[case("> ### A.2 A Note on This List")]
+#[case("- ### A.2 A Note on This List")]
+#[case("1. ### A.2 A Note on This List")]
+#[case("- 1. ### A.2 A Note on This List")]
+#[case(">> ### A.2 A Note on This List")]
+fn heading_lines_are_left_verbatim(#[case] line: &str) {
+    let input = lines_vec!(line);
     assert_eq!(convert_footnotes(&input), input);
 }
 

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -80,6 +80,24 @@ fn test_ignores_numbers_in_list_headings() {
 }
 
 #[test]
+fn test_ignores_numbers_in_ordered_list_headings() {
+    let input = lines_vec!("1. ### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
+fn test_ignores_numbers_in_nested_list_headings() {
+    let input = lines_vec!("- 1. ### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
+fn test_ignores_numbers_in_deeply_quoted_headings() {
+    let input = lines_vec!(">> ### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
 fn test_ignores_numbers_in_fenced_code_block() {
     let input = lines_vec!(
         "Here is a code block:",

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -60,9 +60,13 @@ fn test_ignores_numbers_in_parentheses() {
 #[case("### Heading with footnote[1]")]
 #[case("> ### A.2 A Note on This List")]
 #[case("- ### A.2 A Note on This List")]
+#[case("* ### A.2 A Note on This List")]
+#[case("+ ### A.2 A Note on This List")]
 #[case("1. ### A.2 A Note on This List")]
+#[case("1) ### A.2 A Note on This List")]
 #[case("- 1. ### A.2 A Note on This List")]
 #[case(">> ### A.2 A Note on This List")]
+#[case(">>> ### A.2 A Note on This List")]
 fn heading_lines_are_left_verbatim(#[case] line: &str) {
     let input = lines_vec!(line);
     assert_eq!(convert_footnotes(&input), input);

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -56,6 +56,12 @@ fn test_ignores_numbers_in_parentheses() {
 }
 
 #[test]
+fn test_ignores_numbers_in_headings() {
+    let input = lines_vec!("### A.2 A Note on This List");
+    assert_eq!(convert_footnotes(&input), input);
+}
+
+#[test]
 fn test_ignores_numbers_in_fenced_code_block() {
     let input = lines_vec!(
         "Here is a code block:",


### PR DESCRIPTION
## Summary
- avoid converting footnote references inside heading text
- document that heading numbers are left verbatim
- test footnote conversion ignores headings

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68b7fa26a310832284c203c39d8e0438

## Summary by Sourcery

Skip converting numeric footnote references in ATX-style headings (including blockquoted and list-prefixed headings) during footnote conversion.

Bug Fixes:
- Prevent converting bare numeric footnote references inside ATX headings when processing footnotes.

Enhancements:
- Introduce a heading-detection helper to bypass footnote conversion for ATX-style headings.

Documentation:
- Update architecture documentation and changelog to note that heading text remains untouched during footnote conversion.

Tests:
- Add tests to verify that footnote conversion ignores ATX headings in various contexts.