### PR TITLE
Handle checkbox list items in wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences]
 
 - Use `--version` to print the current version and exit.
 
-- Use `--wrap` to reflow paragraphs and list items to 80 columns.
+- Use `--wrap` to reflow paragraphs and list items to 80 columns. Task list
+  items (`- [ ]`/`- [x]`) are indented correctly.
 
 - Use `--renumber` to rewrite ordered lists with consistent sequential
   numbering. The renumbering logic correctly handles nested lists by tracking

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -28,7 +28,7 @@ pub use tokenize::Token;
 pub use tokenize::tokenize_markdown;
 
 static BULLET_RE: std::sync::LazyLock<Regex> = lazy_regex!(
-    r"^(\s*(?:[-*+]|\d+[.)])\s+)(.*)",
+    r"^(\s*(?:[-*+]|\d+[.)])\s+(?:\[[xX ]\]\s+)?)(.*)",
     "bullet pattern regex should compile",
 );
 

--- a/tests/wrap/lists.rs
+++ b/tests/wrap/lists.rs
@@ -147,3 +147,45 @@ fn test_wrap_list_item_semicolon_after_code() {
     let output = process_stream(&input);
     assert_eq!(output, expected);
 }
+
+#[test]
+fn test_wrap_list_items_with_checkboxes() {
+    let input = lines_vec![
+        "- [ ] Create a `HttpTravelTimeProvider` struct that implements the `TravelTimeProvider` trait.",
+        concat!(
+            "- [ ] Using `tokio` and `reqwest`, implement the `get_travel_time_matrix` ",
+            "method to make concurrent requests to an external OSRM API's `table` ",
+            "service."
+        ),
+    ];
+    let expected = lines_vec![
+        "- [ ] Create a `HttpTravelTimeProvider` struct that implements the",
+        "      `TravelTimeProvider` trait.",
+        "- [ ] Using `tokio` and `reqwest`, implement the `get_travel_time_matrix`",
+        "      method to make concurrent requests to an external OSRM API's `table`",
+        "      service.",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_wrap_indented_list_items_with_checkboxes() {
+    let input = lines_vec![
+        "  - [ ] Create a `HttpTravelTimeProvider` struct that implements the `TravelTimeProvider` trait.",
+        concat!(
+            "  - [ ] Using `tokio` and `reqwest`, implement the `get_travel_time_matrix` ",
+            "method to make concurrent requests to an external OSRM API's `table` ",
+            "service."
+        ),
+    ];
+    let expected = lines_vec![
+        "  - [ ] Create a `HttpTravelTimeProvider` struct that implements the",
+        "        `TravelTimeProvider` trait.",
+        "  - [ ] Using `tokio` and `reqwest`, implement the `get_travel_time_matrix`",
+        "        method to make concurrent requests to an external OSRM API's `table`",
+        "        service.",
+    ];
+    let output = process_stream(&input);
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
## Summary
- ensure wrapping logic accounts for task list markers
- add tests for wrapping list items with checkboxes
- document that `--wrap` indents task list items correctly

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68bb629bf4b483229a9e830e58359022