### PR TITLE
Refine HTML tag predicates for clarity

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -34,8 +34,12 @@ fn node_text(handle: &Handle) -> String {
 
 fn is_ignored_tag(tag: &str) -> bool {
     matches!(
-        tag.to_ascii_lowercase().as_str(),
-        "script" | "style" | "noscript" | "template" | "head"
+        tag,
+        t if t.eq_ignore_ascii_case("script")
+            || t.eq_ignore_ascii_case("style")
+            || t.eq_ignore_ascii_case("noscript")
+            || t.eq_ignore_ascii_case("template")
+            || t.eq_ignore_ascii_case("head")
     )
 }
 
@@ -108,7 +112,10 @@ fn collect_rows(handle: &Handle, rows: &mut Vec<Handle>) {
 }
 
 fn is_bold_tag(tag: &str) -> bool {
-    matches!(tag.to_ascii_lowercase().as_str(), "strong" | "b")
+    matches!(
+        tag,
+        t if t.eq_ignore_ascii_case("strong") || t.eq_ignore_ascii_case("b")
+    )
 }
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.

--- a/src/html.rs
+++ b/src/html.rs
@@ -33,11 +33,10 @@ fn node_text(handle: &Handle) -> String {
 }
 
 fn is_ignored_tag(tag: &str) -> bool {
-    tag.eq_ignore_ascii_case("script")
-        || tag.eq_ignore_ascii_case("style")
-        || tag.eq_ignore_ascii_case("noscript")
-        || tag.eq_ignore_ascii_case("template")
-        || tag.eq_ignore_ascii_case("head")
+    matches!(
+        tag.to_ascii_lowercase().as_str(),
+        "script" | "style" | "noscript" | "template" | "head"
+    )
 }
 
 /// Recursively appends text nodes from `handle` to `out`, tracking whether the
@@ -109,7 +108,7 @@ fn collect_rows(handle: &Handle, rows: &mut Vec<Handle>) {
 }
 
 fn is_bold_tag(tag: &str) -> bool {
-    tag.eq_ignore_ascii_case("strong") || tag.eq_ignore_ascii_case("b")
+    matches!(tag.to_ascii_lowercase().as_str(), "strong" | "b")
 }
 
 /// Returns `true` if `handle` contains a `<b>` or `<strong>` descendant.


### PR DESCRIPTION
## Summary
- simplify ignored HTML tag detection
- streamline bold tag predicate

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #49

------
https://chatgpt.com/codex/tasks/task_e_68c2b5cc5b908322ada77a0979cc5f0c

## Summary by Sourcery

Refactor HTML tag predicate functions to use the matches! macro and lowercase conversion for clearer and more concise code

Enhancements:
- Replace chained eq_ignore_ascii_case calls in is_ignored_tag with a single matches! construct
- Simplify is_bold_tag by using matches! on lowercase tag strings