### PR TITLE
Refactor list renumbering logic

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -81,21 +81,6 @@ fn handle_paragraph_restart(
 /// - Preserve code fences; do not renumber inside them.
 /// - Reset numbering on headings and thematic breaks.
 /// - Restart numbering after a blank line followed by a plain paragraph at the same or a shallower indent.
-///
-/// # Examples
-///
-/// ```
-/// use mdtablefix::renumber_lists;
-///
-/// let lines = vec![
-///     String::from("1. first"),
-///     String::from("4. second"),
-/// ];
-/// assert_eq!(
-///     renumber_lists(&lines),
-///     vec![String::from("1. first"), String::from("2. second")]
-/// );
-/// ```
 #[must_use]
 pub fn renumber_lists(lines: &[String]) -> Vec<String> {
     let mut out = Vec::with_capacity(lines.len());

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,6 +1,7 @@
 //! Ordered list renumbering utilities.
 
 use regex::Regex;
+use std::collections::HashMap;
 
 use crate::{breaks::THEMATIC_BREAK_RE, wrap::is_fence};
 
@@ -13,27 +14,22 @@ static HEADING_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"^[ ]{0,3}#{1,6}(?:\s|$)").expect("valid heading regex")
 });
 
-fn parse_numbered(line: &str) -> Option<(&str, &str, &str)> {
+fn parse_numbered(line: &str) -> Option<(usize, &str, &str, &str)> {
     static NUMBERED_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
         Regex::new(r"^(\s*)([1-9][0-9]*)\.(\s+)(.*)").expect("valid list number regex")
     });
     let cap = NUMBERED_RE.captures(line)?;
-    let indent = cap.get(1)?.as_str();
+    let indent_str = cap.get(1)?.as_str();
+    let indent = indent_len(indent_str);
     let sep = cap.get(3)?.as_str();
     let rest = cap.get(4)?.as_str();
-    Some((indent, sep, rest))
+    Some((indent, indent_str, sep, rest))
 }
 
 fn indent_len(indent: &str) -> usize {
     indent
         .chars()
         .fold(0, |acc, ch| acc + if ch == '\t' { 4 } else { 1 })
-}
-
-fn drop_deeper(indent: usize, counters: &mut Vec<(usize, usize)>) {
-    while counters.last().is_some_and(|(d, _)| *d > indent) {
-        counters.pop();
-    }
 }
 
 fn is_plain_paragraph_line(line: &str) -> bool {
@@ -44,40 +40,31 @@ fn is_plain_paragraph_line(line: &str) -> bool {
         .is_some_and(char::is_alphanumeric)
 }
 
-/// Remove counters deeper than or equal to `indent`.
-///
-/// ```
-/// use mdtablefix::lists::pop_counters_upto;
-/// let mut counters = vec![(0usize, 1usize), (4, 2), (8, 3)];
-/// pop_counters_upto(&mut counters, 4);
-/// assert_eq!(counters, vec![(0, 1)]);
-/// ```
-pub fn pop_counters_upto(counters: &mut Vec<(usize, usize)>, indent: usize) {
-    while counters.last().is_some_and(|(d, _)| *d >= indent) {
-        counters.pop();
-    }
-}
-
-fn handle_paragraph_restart(line: &str, prev_blank: bool, counters: &mut Vec<(usize, usize)>) {
-    let indent_end = line
-        .char_indices()
-        .find(|&(_, c)| !c.is_whitespace())
-        .map_or_else(|| line.len(), |(i, _)| i);
-    let indent = indent_len(&line[..indent_end]);
-
+fn handle_paragraph_restart(
+    indent: usize,
+    line: &str,
+    prev_blank: bool,
+    stack: &mut Vec<usize>,
+    counters: &mut HashMap<usize, usize>,
+) {
     if prev_blank
-        && counters
+        && stack
             .last()
-            .is_some_and(|(d, _)| indent <= *d && is_plain_paragraph_line(line))
+            .is_some_and(|&d| indent <= d && is_plain_paragraph_line(line))
     {
-        pop_counters_upto(counters, indent);
+        while stack.last().is_some_and(|&d| d >= indent) {
+            if let Some(d) = stack.pop() {
+                counters.remove(&d);
+            }
+        }
     }
 }
 
 #[must_use]
 pub fn renumber_lists(lines: &[String]) -> Vec<String> {
     let mut out = Vec::with_capacity(lines.len());
-    let mut counters: Vec<(usize, usize)> = Vec::new();
+    let mut stack = Vec::<usize>::new();
+    let mut counters = HashMap::<usize, usize>::new();
     let mut in_code = false;
     let mut prev_blank = lines.first().is_none_or(|l| l.trim().is_empty());
 
@@ -88,57 +75,55 @@ pub fn renumber_lists(lines: &[String]) -> Vec<String> {
             prev_blank = false;
             continue;
         }
-
         if in_code {
             out.push(line.clone());
             prev_blank = line.trim().is_empty();
             continue;
         }
-
         if line.trim().is_empty() {
             out.push(line.clone());
             prev_blank = true;
             continue;
         }
-
-        if let Some((indent_str, sep, rest)) = parse_numbered(line) {
-            let indent = indent_len(indent_str);
-            drop_deeper(indent, &mut counters);
-            let current = match counters.last_mut() {
-                Some((d, cnt)) if *d == indent => {
-                    *cnt += 1;
-                    *cnt
+        if let Some((indent, indent_str, sep, rest)) = parse_numbered(line) {
+            while stack.last().is_some_and(|&d| d > indent) {
+                if let Some(d) = stack.pop() {
+                    counters.remove(&d);
                 }
-                _ => {
-                    counters.push((indent, 1));
-                    1
-                }
-            };
+            }
+            if stack.last().is_none_or(|&d| d < indent) {
+                stack.push(indent);
+                counters.entry(indent).or_insert(1);
+            }
+            let num = counters.entry(indent).or_insert(1);
+            let current = *num;
+            *num += 1;
             out.push(format!("{indent_str}{current}.{sep}{rest}"));
             prev_blank = false;
             continue;
         }
-
         let indent_end = line
             .char_indices()
             .find(|&(_, c)| !c.is_whitespace())
             .map_or_else(|| line.len(), |(i, _)| i);
         let indent_str = &line[..indent_end];
         let indent = indent_len(indent_str);
-
         if HEADING_RE.is_match(line) || THEMATIC_BREAK_RE.is_match(line.trim_end()) {
+            stack.clear();
             counters.clear();
             out.push(line.clone());
             prev_blank = false;
             continue;
         }
-
-        handle_paragraph_restart(line, prev_blank, &mut counters);
-        drop_deeper(indent, &mut counters);
+        handle_paragraph_restart(indent, line, prev_blank, &mut stack, &mut counters);
+        while stack.last().is_some_and(|&d| d > indent) {
+            if let Some(d) = stack.pop() {
+                counters.remove(&d);
+            }
+        }
         out.push(line.clone());
-        prev_blank = line.trim().is_empty();
+        prev_blank = false;
     }
-
     out
 }
 

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -43,6 +43,13 @@ fn restart_after_nested_paragraph() {
 }
 
 #[test]
+fn restart_after_equal_indent_paragraph() {
+    let input = lines_vec!("1. One", "    1. Sub", "", "    Paragraph", "    5. Next");
+    let expected = lines_vec!("1. One", "    1. Sub", "", "    Paragraph", "    1. Next");
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
 fn restart_after_formatting_paragraph() {
     let input = lines_vec!("1. Start", "", "**Bold intro**", "", "4. Next");
     let expected = lines_vec!("1. Start", "", "**Bold intro**", "", "1. Next");

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -8,7 +8,7 @@ mod prelude;
 use prelude::*;
 
 #[test]
-fn restart_after_lower_paragraph() {
+fn restart_after_equal_indent_paragraph() {
     let input = lines_vec!("1. One", "", "Paragraph", "3. Next");
     let expected = lines_vec!("1. One", "", "Paragraph", "1. Next");
     assert_eq!(renumber_lists(&input), expected);
@@ -43,7 +43,7 @@ fn restart_after_nested_paragraph() {
 }
 
 #[test]
-fn restart_after_equal_indent_paragraph() {
+fn restart_after_nested_equal_indent_paragraph() {
     let input = lines_vec!("1. One", "    1. Sub", "", "    Paragraph", "    5. Next");
     let expected = lines_vec!("1. One", "    1. Sub", "", "    Paragraph", "    1. Next");
     assert_eq!(renumber_lists(&input), expected);
@@ -53,6 +53,13 @@ fn restart_after_equal_indent_paragraph() {
 fn restart_after_formatting_paragraph() {
     let input = lines_vec!("1. Start", "", "**Bold intro**", "", "4. Next");
     let expected = lines_vec!("1. Start", "", "**Bold intro**", "", "1. Next");
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
+fn reset_on_heading_and_thematic_break() {
+    let input = lines_vec!("1. a", "2. b", "# Heading", "1. c", "---", "5. d");
+    let expected = lines_vec!("1. a", "2. b", "# Heading", "1. c", "---", "1. d");
     assert_eq!(renumber_lists(&input), expected);
 }
 /// Tests the CLI `--renumber` option.

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -1,25 +1,11 @@
-//! Integration tests for list renumbering and counters.
+//! Integration tests for list renumbering.
 
-use mdtablefix::{lists::pop_counters_upto, renumber_lists};
+use mdtablefix::renumber_lists;
 use rstest::rstest;
 
 #[macro_use]
 mod prelude;
 use prelude::*;
-
-#[test]
-fn pop_counters_removes_deeper_levels() {
-    let mut counters = vec![(0usize, 1usize), (4, 2), (8, 3)];
-    pop_counters_upto(&mut counters, 4);
-    assert_eq!(counters, vec![(0, 1)]);
-}
-
-#[test]
-fn pop_counters_no_change_when_indent_deeper() {
-    let mut counters = vec![(0usize, 1usize), (4, 2)];
-    pop_counters_upto(&mut counters, 6);
-    assert_eq!(counters, vec![(0, 1), (4, 2)]);
-}
 
 #[test]
 fn restart_after_lower_paragraph() {


### PR DESCRIPTION
## Summary
- simplify ordered list renumbering using indentation stack and HashMap counters
- drop unused counter helpers and related tests

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #56

------
https://chatgpt.com/codex/tasks/task_e_68c2b61debc4832281f9094856ad6c86

## Summary by Sourcery

Refactor ordered list renumbering to use an indentation stack and HashMap for counters, dropping obsolete helpers and related tests

Enhancements:
- Replace vector-based counters with an indentation stack and HashMap to track numbering levels
- Update parse_numbered to calculate numeric indentation and return both raw and computed indent
- Simplify paragraph restart and deeper-level removal logic using stack operations and HashMap removal
- Clear stack and counters upon encountering headings or thematic breaks

Tests:
- Remove deprecated pop_counters_upto tests and adjust imports for renumber_lists