### PR TITLE
Refactor wrap_preserving_code into helper utilities

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -199,10 +199,9 @@ impl LineBuffer {
             }
             self.push_token(tok.as_str());
         }
-        if end > start && tokens[end - 1].chars().all(char::is_whitespace) && !self.text.is_empty()
-        {
-            self.last_split = Some(self.text.len());
-        }
+
+        // No whitespace was appended; keep split unset.
+        self.last_split = None;
     }
 
     fn flush_into(&mut self, lines: &mut Vec<String>) {
@@ -227,16 +226,15 @@ impl LineBuffer {
         };
 
         let (head, tail) = self.text.split_at(pos);
-        let trimmed = head.trim_end();
-        let whitespace = &head[trimmed.len()..];
+        let trimmed_head = head.trim_end();
+        let trailing_ws = &head[trimmed_head.len()..];
 
-        if !trimmed.is_empty() {
-            let line = if whitespace.chars().count() > 1 {
-                head.to_string()
+        if !trimmed_head.is_empty() {
+            if trailing_ws.chars().count() > 1 {
+                lines.push(head.to_string());
             } else {
-                trimmed.to_string()
-            };
-            lines.push(line);
+                lines.push(trimmed_head.to_string());
+            }
         }
 
         let mut remainder = tail.trim_start().to_string();

--- a/src/wrap/line_buffer.rs
+++ b/src/wrap/line_buffer.rs
@@ -1,0 +1,166 @@
+//! Line buffer utilities for `wrap_preserving_code`.
+//!
+//! This module encapsulates the mutable state required to accumulate tokens into
+//! wrapped lines while reusing allocations between iterations.
+
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Default)]
+pub(crate) struct LineBuffer {
+    text: String,
+    width: usize,
+    last_split: Option<usize>,
+}
+
+impl LineBuffer {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        self.text.as_str()
+    }
+
+    pub(crate) fn width(&self) -> usize {
+        self.width
+    }
+
+    pub(crate) fn push_token(&mut self, token: &str) {
+        if token.len() == 1 && ".?!,:;".contains(token) && self.text.trim_end().ends_with('`') {
+            let trimmed_len = self.text.trim_end_matches(char::is_whitespace).len();
+            if trimmed_len < self.text.len() {
+                let removed = &self.text[trimmed_len..];
+                let removed_width = UnicodeWidthStr::width(removed);
+                self.text.truncate(trimmed_len);
+                self.width = self.width.saturating_sub(removed_width);
+                self.last_split = self
+                    .text
+                    .char_indices()
+                    .rev()
+                    .find(|(_, ch)| ch.is_whitespace())
+                    .map(|(idx, ch)| idx + ch.len_utf8());
+            }
+        }
+
+        self.text.push_str(token);
+        self.width += UnicodeWidthStr::width(token);
+        if token.chars().all(char::is_whitespace) {
+            self.last_split = Some(self.text.len());
+        }
+    }
+
+    pub(crate) fn push_span(&mut self, tokens: &[String], start: usize, end: usize) {
+        for tok in &tokens[start..end] {
+            self.push_token(tok.as_str());
+        }
+    }
+
+    pub(crate) fn push_non_whitespace_span(&mut self, tokens: &[String], start: usize, end: usize) {
+        for tok in &tokens[start..end] {
+            if tok.chars().all(char::is_whitespace) {
+                continue;
+            }
+            self.push_token(tok.as_str());
+        }
+
+        // No whitespace was appended; keep split unset.
+        self.last_split = None;
+    }
+
+    pub(crate) fn flush_into(&mut self, lines: &mut Vec<String>) {
+        if self.text.is_empty() {
+            return;
+        }
+        lines.push(std::mem::take(&mut self.text));
+        self.width = 0;
+        self.last_split = None;
+    }
+
+    pub(crate) fn split_with_span(
+        &mut self,
+        lines: &mut Vec<String>,
+        tokens: &[String],
+        start: usize,
+        end: usize,
+        width: usize,
+    ) -> bool {
+        let Some(pos) = self.last_split else {
+            return false;
+        };
+
+        let (head_bounds, trimmed_tail_start) = {
+            let (head, tail) = self.text.split_at(pos);
+            let trimmed_head = head.trim_end();
+            let trimmed_head_len = trimmed_head.len();
+            let trailing_ws = &head[trimmed_head_len..];
+            let head_bounds = if trimmed_head_len == 0 {
+                None
+            } else if trailing_ws.chars().count() > 1 {
+                Some((0, pos))
+            } else {
+                Some((0, trimmed_head_len))
+            };
+
+            let trimmed_tail = tail.trim_start();
+            let trimmed_tail_start = pos + (tail.len() - trimmed_tail.len());
+            (head_bounds, trimmed_tail_start)
+        };
+
+        if let Some((start_idx, end_idx)) = head_bounds {
+            lines.push(self.text[start_idx..end_idx].to_owned());
+        }
+
+        self.text.drain(..trimmed_tail_start);
+        for tok in &tokens[start..end] {
+            self.text.push_str(tok);
+        }
+
+        self.width = UnicodeWidthStr::width(self.text.as_str());
+        if end > start && tokens[end - 1].chars().all(char::is_whitespace) && !self.text.is_empty()
+        {
+            self.last_split = Some(self.text.len());
+        } else {
+            self.last_split = None;
+        }
+
+        if self.width > width {
+            lines.push(self.text.trim_end().to_string());
+            self.text.clear();
+            self.width = 0;
+            self.last_split = None;
+        }
+
+        true
+    }
+
+    pub(crate) fn flush_trailing_whitespace(
+        &mut self,
+        lines: &mut Vec<String>,
+        tokens: &[String],
+        start: usize,
+        end: usize,
+    ) -> bool {
+        if end != tokens.len() {
+            return false;
+        }
+        if !tokens[start..end]
+            .iter()
+            .all(|tok| tok.chars().all(char::is_whitespace))
+        {
+            return false;
+        }
+
+        if self.text.is_empty() {
+            self.last_split = None;
+            return true;
+        }
+
+        for tok in &tokens[start..end] {
+            self.text.push_str(tok);
+        }
+        lines.push(std::mem::take(&mut self.text));
+        self.width = 0;
+        self.last_split = None;
+        true
+    }
+}

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -6,7 +6,130 @@
 use rstest::rstest;
 
 use super::super::*;
-use super::wrap_preserving_code;
+use super::{
+    LineBuffer, append_group_to_line, determine_token_span, handle_split_overflow,
+    handle_trailing_whitespace_group, start_new_line_with_group, tokenize::segment_inline,
+    wrap_preserving_code,
+};
+
+#[rstest]
+#[case("`code`!", "`code`!")]
+#[case("[link](url).", "[link](url).")]
+#[case("plain,", "plain,")]
+fn determine_token_span_groups_related_tokens(#[case] input: &str, #[case] expected_group: &str) {
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, 0);
+    let grouped = tokens[..end].join("");
+    assert_eq!(grouped, expected_group);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected_group));
+}
+
+#[test]
+fn append_group_to_line_updates_last_split_for_whitespace() {
+    let tokens = segment_inline("foo bar");
+    let mut current = String::new();
+    let mut current_width = 0;
+    let mut last_split = None;
+
+    {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        append_group_to_line(&tokens, 0, 1, &mut buffer);
+    }
+    assert_eq!(current, "foo");
+    assert_eq!(current_width, unicode_width::UnicodeWidthStr::width("foo"));
+    assert_eq!(last_split, None);
+
+    {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        append_group_to_line(&tokens, 1, 2, &mut buffer);
+    }
+    assert_eq!(current, "foo ");
+    assert_eq!(current_width, unicode_width::UnicodeWidthStr::width("foo "));
+    assert_eq!(last_split, Some(current.len()));
+}
+
+#[test]
+fn handle_split_overflow_moves_tokens_to_new_line() {
+    let tokens = segment_inline("foo bar baz");
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0;
+    let mut last_split = None;
+
+    for start in 0..4 {
+        let (end, _) = determine_token_span(&tokens, start);
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        append_group_to_line(&tokens, start, end, &mut buffer);
+    }
+
+    let (group_end, _) = determine_token_span(&tokens, 4);
+    let handled = {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        handle_split_overflow(&mut lines, &mut buffer, &tokens, 4, group_end, 10)
+    };
+
+    assert!(handled);
+    assert_eq!(lines, vec!["foo bar".to_string()]);
+    assert_eq!(current, "baz");
+    assert_eq!(current_width, unicode_width::UnicodeWidthStr::width("baz"));
+    assert_eq!(last_split, None);
+}
+
+#[test]
+fn handle_trailing_whitespace_group_preserves_spaces() {
+    let tokens = segment_inline("foo  ");
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0;
+    let mut last_split = None;
+
+    let (word_end, _) = determine_token_span(&tokens, 0);
+    {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        append_group_to_line(&tokens, 0, word_end, &mut buffer);
+    }
+
+    let start = tokens
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, tok)| tok.chars().all(char::is_whitespace))
+        .map(|(idx, _)| idx)
+        .expect("at least one trailing whitespace token");
+    let (group_end, _) = determine_token_span(&tokens, start);
+
+    let handled = {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        handle_trailing_whitespace_group(&mut lines, &mut buffer, &tokens, start, group_end)
+    };
+
+    assert!(handled);
+    assert_eq!(lines, vec!["foo  ".to_string()]);
+    assert!(current.is_empty());
+    assert_eq!(current_width, 0);
+    assert_eq!(last_split, None);
+}
+
+#[test]
+fn start_new_line_with_group_flushes_existing_line() {
+    let tokens = segment_inline("baz ");
+    let mut lines = Vec::new();
+    let mut current = "foo".to_string();
+    let mut current_width = unicode_width::UnicodeWidthStr::width("foo");
+    let mut last_split = Some(current.len());
+
+    let (group_end, _) = determine_token_span(&tokens, 0);
+
+    {
+        let mut buffer = LineBuffer::new(&mut current, &mut current_width, &mut last_split);
+        start_new_line_with_group(&mut lines, &mut buffer, &tokens, 0, group_end);
+    }
+
+    assert_eq!(lines, vec!["foo".to_string()]);
+    assert_eq!(current, "baz");
+    assert_eq!(current_width, unicode_width::UnicodeWidthStr::width("baz"));
+    assert_eq!(last_split, None);
+}
 
 #[test]
 fn wrap_text_preserves_hyphenated_words() {

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -5,7 +5,7 @@
 
 use rstest::rstest;
 
-use super::super::*;
+use super::super::wrap_text;
 use super::{
     LineBuffer, attach_punctuation_to_previous_line, determine_token_span,
     tokenize::segment_inline, wrap_preserving_code,
@@ -101,6 +101,26 @@ fn line_buffer_split_preserves_multi_space_lines() {
     assert!(buffer.try_split_with_group(&mut lines, &tokens, 2, 4, 8));
     assert_eq!(lines, vec!["alpha  ".to_string()]);
     assert_eq!(buffer.text(), "beta   ");
+    assert_eq!(
+        buffer.width(),
+        unicode_width::UnicodeWidthStr::width(buffer.text())
+    );
+}
+
+#[test]
+fn line_buffer_split_trims_single_trailing_space() {
+    let tokens = vec!["alpha".to_string(), " ".to_string(), "beta".to_string()];
+    let mut buffer = LineBuffer::new();
+    buffer.push_group(&tokens, 0, 2);
+
+    let mut lines = Vec::new();
+    assert!(buffer.try_split_with_group(&mut lines, &tokens, 2, 3, 5));
+    assert_eq!(lines, vec!["alpha".to_string()]);
+    assert_eq!(buffer.text(), "beta");
+    assert_eq!(
+        buffer.width(),
+        unicode_width::UnicodeWidthStr::width(buffer.text())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extract a `LineBuffer` helper and other utilities so `wrap_preserving_code` no longer manages every concern inline
- route the wrapping control flow through the new helpers to clarify punctuation handling, splits, and trailing whitespace logic
- add focused tests for the helper behaviours and token grouping scenarios

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d502e4898c832288984f8bc44f8d70

## Summary by Sourcery

Refactor wrap_preserving_code by extracting line buffering and token‐grouping logic into dedicated helper functions to simplify wrapping control flow and punctuation/whitespace handling, and add targeted unit tests for each helper.

Enhancements:
- Extract LineBuffer struct and related utilities to manage buffer state and splitting logic in wrap_preserving_code
- Consolidate token span determination, punctuation attachment, overflow handling, and new‐line logic into separate helper functions
- Simplify wrap_preserving_code by routing control flow through the new helpers

Tests:
- Add focused unit tests for determine_token_span, append_group_to_line, split overflow, trailing whitespace, and new line grouping behaviors