### PR TITLE
Unify fence tracking across modules

### DIFF
--- a/src/wrap/fence.rs
+++ b/src/wrap/fence.rs
@@ -63,6 +63,19 @@ pub(crate) fn handle_fence_line(
 ///
 /// The tracker centralises fence matching logic so that callers share the
 /// same semantics for opening and closing blocks.
+///
+/// # Examples
+///
+/// ```
+/// use mdtablefix::wrap::FenceTracker;
+///
+/// let mut tracker = FenceTracker::new();
+/// assert!(!tracker.in_fence());
+/// assert!(tracker.observe("```rust"));
+/// assert!(tracker.in_fence());
+/// assert!(tracker.observe("```"));
+/// assert!(!tracker.in_fence());
+/// ```
 #[derive(Default)]
 pub struct FenceTracker {
     state: Option<(char, usize)>,

--- a/src/wrap/fence.rs
+++ b/src/wrap/fence.rs
@@ -76,7 +76,7 @@ pub(crate) fn handle_fence_line(
 /// assert!(tracker.observe("```"));
 /// assert!(!tracker.in_fence());
 /// ```
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FenceTracker {
     state: Option<(char, usize)>,
 }
@@ -92,6 +92,11 @@ impl FenceTracker {
     ///
     /// Returns `true` when the line is treated as a fence marker and updates
     /// the internal state accordingly.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the fence regular expression yields an empty marker, which
+    /// would indicate the regex is inconsistent with Markdown fence rules.
     #[must_use]
     pub fn observe(&mut self, line: &str) -> bool {
         let Some((_indent, fence, _info)) = is_fence(line) else {
@@ -99,7 +104,7 @@ impl FenceTracker {
         };
 
         let mut chars = fence.chars();
-        let marker_ch = chars.next().unwrap_or('`');
+        let marker_ch = chars.next().expect("FENCE_RE guarantees a non-empty fence");
         let marker_len = chars.count() + 1;
 
         match self.state {

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -377,3 +377,51 @@ fn fence_tracker_requires_matching_marker_to_close() {
     assert!(tracker.observe("````"));
     assert!(!tracker.in_fence());
 }
+
+#[test]
+fn fence_tracker_handles_inline_and_indented_markers() {
+    let lines = [
+        "```rust code fence on one line```",
+        "   ```   ",
+        "text outside fence",
+        "```",
+        concat!(
+            "text inside fence that should remain intact even if it exceeds the usual width ",
+            "limit when wrapping is enabled."
+        ),
+        "```   ",
+        "text after fence",
+    ];
+    let mut tracker = FenceTracker::default();
+    let results: Vec<bool> = lines.iter().map(|line| tracker.observe(line)).collect();
+    assert_eq!(
+        results,
+        vec![true, true, false, true, false, true, false],
+        "expected fences to be recognised with inline markers and atypical spacing"
+    );
+    assert!(
+        !tracker.in_fence(),
+        "tracker should end outside of a fence after matching closures"
+    );
+}
+
+#[test]
+fn fence_tracker_handles_tilde_fences() {
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("~~~~rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~~"));
+    assert!(!tracker.in_fence());
+}
+
+#[rstest]
+#[case("`")]
+#[case("``")]
+#[case("`~~`")]
+#[case("~~`")]
+#[case("`` ~~")]
+fn fence_tracker_rejects_short_or_mixed_markers(#[case] line: &str) {
+    let mut tracker = FenceTracker::default();
+    assert!(!tracker.observe(line));
+    assert!(!tracker.in_fence());
+}

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -9,7 +9,7 @@ use super::{
     LineBuffer, attach_punctuation_to_previous_line, determine_token_span,
     tokenize::segment_inline, wrap_preserving_code,
 };
-use crate::wrap::wrap_text;
+use crate::wrap::{FenceTracker, wrap_text};
 
 #[rstest]
 #[case("`code`!", "`code`!")]
@@ -331,4 +331,25 @@ fn wrap_text_keeps_trailing_spaces_for_bullet_final_line() {
         wrapped,
         vec!["- word1".to_string(), "  word2  ".to_string()]
     );
+}
+
+#[test]
+fn fence_tracker_closes_matching_markers() {
+    let mut tracker = FenceTracker::default();
+    assert!(!tracker.in_fence());
+    assert!(tracker.observe("```rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```"));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
+fn fence_tracker_requires_matching_marker_to_close() {
+    let mut tracker = FenceTracker::default();
+    assert!(tracker.observe("```"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("````"));
+    assert!(!tracker.in_fence());
 }

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -350,6 +350,15 @@ fn fence_tracker_closes_matching_markers() {
 }
 
 #[test]
+fn fence_tracker_closes_with_info_string() {
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("```rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```   "));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
 fn fence_tracker_ignores_shorter_closing_marker() {
     let mut tracker = FenceTracker::new();
     assert!(tracker.observe("````"));

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -334,6 +334,12 @@ fn wrap_text_keeps_trailing_spaces_for_bullet_final_line() {
 }
 
 #[test]
+fn fence_tracker_new_starts_outside_fence() {
+    let tracker = FenceTracker::new();
+    assert!(!tracker.in_fence());
+}
+
+#[test]
 fn fence_tracker_closes_matching_markers() {
     let mut tracker = FenceTracker::default();
     assert!(!tracker.in_fence());
@@ -341,6 +347,15 @@ fn fence_tracker_closes_matching_markers() {
     assert!(tracker.in_fence());
     assert!(tracker.observe("```"));
     assert!(!tracker.in_fence());
+}
+
+#[test]
+fn fence_tracker_ignores_shorter_closing_marker() {
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("````"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```"));
+    assert!(tracker.in_fence());
 }
 
 #[test]

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -76,6 +76,58 @@ fn test_cli_renumber_option() {
         .stdout("1. a\n2. b\n");
 }
 
+#[test]
+fn nested_lists_respect_fence_tracker() {
+    let input = lines_vec![
+        "1. Outer list",
+        "   ```",
+        "   1. Code block list",
+        "   ```",
+        "9. Outer list continued",
+        "   4. Nested list",
+        "      ```",
+        "      - Malformed fence",
+        "      ```",
+        "   8. Nested list continued",
+    ];
+    let expected = lines_vec![
+        "1. Outer list",
+        "   ```",
+        "   1. Code block list",
+        "   ```",
+        "2. Outer list continued",
+        "   1. Nested list",
+        "      ```",
+        "      - Malformed fence",
+        "      ```",
+        "   2. Nested list continued",
+    ];
+    assert_eq!(renumber_lists(&input), expected);
+}
+
+#[test]
+fn malformed_fences_do_not_break_list_renumbering() {
+    let input = lines_vec![
+        "1. List before fence",
+        "   ```",
+        "   1. Inside code block",
+        "   ``",
+        "   still inside fence",
+        "   ```",
+        "7. List after fence",
+    ];
+    let expected = lines_vec![
+        "1. List before fence",
+        "   ```",
+        "   1. Inside code block",
+        "   ``",
+        "   still inside fence",
+        "   ```",
+        "2. List after fence",
+    ];
+    assert_eq!(renumber_lists(&input), expected);
+}
+
 #[rstest(
     input,
     expected,

--- a/tests/wrap/fence_behaviour.rs
+++ b/tests/wrap/fence_behaviour.rs
@@ -19,6 +19,7 @@ fn wrap_respects_fence_boundaries_in_paragraphs() {
     );
     let input = lines_vec![first_paragraph, "```", code_line, "```", closing_paragraph];
     let output = process_stream(&input);
+    assert!(!output.iter().any(|l| l.starts_with("``") && l.len() == 2), "no false 2-tick fences");
 
     let fence_positions: Vec<usize> = output
         .iter()

--- a/tests/wrap/fence_behaviour.rs
+++ b/tests/wrap/fence_behaviour.rs
@@ -158,15 +158,20 @@ fn wrap_does_not_close_on_shorter_closing_marker() {
         "all fence markers, including the ignored shorter one, should be retained"
     );
 
-    let post_fence: Vec<_> = output
+    let closing_idx = output
         .iter()
-        .skip_while(|line| !line.trim_start().starts_with("````"))
-        .skip(1)
-        .take_while(|line| !line.trim_start().starts_with("```"))
-        .collect();
+        .rposition(|line| line.trim_start().starts_with("````"))
+        .expect("closing fence should exist");
+    let post_fence = &output[closing_idx + 1..];
     assert!(
         post_fence.len() > 1,
         "paragraph after the fence should resume wrapping"
+    );
+    assert!(
+        post_fence
+            .iter()
+            .all(|line| !line.trim_start().starts_with("```")),
+        "trailing paragraph must not be treated as fenced content"
     );
 }
 

--- a/tests/wrap/fence_behaviour.rs
+++ b/tests/wrap/fence_behaviour.rs
@@ -1,0 +1,43 @@
+//! Behavioural tests for fence-aware wrapping.
+
+use super::*;
+
+#[test]
+fn wrap_respects_fence_boundaries_in_paragraphs() {
+    let first_paragraph = concat!(
+        "This introductory paragraph is intentionally verbose to ensure that wrapping ",
+        "is required before reaching the fenced code block, demonstrating how the ",
+        "tracker suspends prose formatting once a fence begins.",
+    );
+    let closing_paragraph = concat!(
+        "This closing paragraph is equally loquacious so that we can prove wrapping ",
+        "resumes immediately after the fenced block without altering the code content.",
+    );
+    let code_line = concat!(
+        "fn demonstrate() { println!(\"This code line intentionally exceeds eighty characters ",
+        "to ensure the wrapping logic would normally split it if fences were not honoured.\"); }",
+    );
+    let input = lines_vec![first_paragraph, "```", code_line, "```", closing_paragraph];
+    let output = process_stream(&input);
+
+    let fence_positions: Vec<usize> = output
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| (line == "```").then_some(idx))
+        .collect();
+    assert_eq!(fence_positions.len(), 2, "expected exactly two fence markers");
+    assert!(output.contains(&code_line.to_string()), "expected code line to remain intact");
+
+    let before_fence = &output[..fence_positions[0]];
+    assert!(before_fence.len() > 1, "prose before the fence should wrap");
+
+    let after_fence = &output[fence_positions[1] + 1..];
+    assert!(after_fence.len() > 1, "prose after the fence should resume wrapping");
+    assert!(
+        after_fence
+            .iter()
+            .any(|line| line.contains("closing paragraph is equally loquacious")),
+        "expected trailing paragraph content after fence",
+    );
+}
+

--- a/tests/wrap/mod.rs
+++ b/tests/wrap/mod.rs
@@ -15,4 +15,5 @@ mod footnotes;
 mod blockquotes;
 mod hard_line_breaks;
 mod links;
+mod fence_behaviour;
 mod cli;


### PR DESCRIPTION
## Summary
- add a shared `FenceTracker` helper in `wrap::fence` and re-export it for downstream callers
- update stream processing, list renumbering, thematic break formatting, and footnote detection to use the tracker instead of bespoke toggles
- cover the tracker behaviour with dedicated unit tests

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d81d0b061c832283fd3f68d4d9c09a

## Summary by Sourcery

Unify fenced code block tracking across multiple modules by introducing a shared FenceTracker, updating all fence-sensitive logic to use it, and covering its behavior with dedicated tests

New Features:
- Add FenceTracker helper to centralise fenced code block detection
- Re-export FenceTracker from the wrap module for downstream callers

Enhancements:
- Replace bespoke fence toggles with FenceTracker in wrap_text, process_stream, thematic break formatting, list renumbering, and footnote detection
- Simplify handle_fence_line to delegate fence matching logic to FenceTracker

Tests:
- Add unit tests covering FenceTracker open/close semantics
- Add behavioural tests to verify fence-aware text wrapping suspends and resumes formatting correctly