### PR TITLE
Improve wrapping for grouped inline code spans and punctuation

### DIFF
--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -19,6 +19,7 @@ use crate::wrap::{BlockKind, classify_block, wrap_text};
 #[case("`code`,", "`code`,")]
 #[case("`code`!`more`", "`code`!`more`")]
 #[case("`code` `more`", "`code`")]
+#[case("`code` `more`,", "`code`")]
 #[case("[link](url),", "[link](url),")]
 #[case("[link](url)[another](url2)", "[link](url)[another](url2)")]
 #[case("[link](url) [another](url2)", "[link](url) [another](url2)")]
@@ -182,7 +183,7 @@ fn wrap_preserving_code_glues_punctuation_after_code() {
 #[test]
 fn wrap_preserving_code_breaks_between_inline_code_spans() {
     let text = "Extensions (`.toml`, `.json`, `.json5`, `.yaml`, `.yml`).";
-    // Width 40 sits between the width of the `.json` and `.json5` prefixes,
+    // Width 35 sits between the width of the `.json` and `.json5` prefixes,
     // forcing the wrapper to decide whether it can break between separate
     // inline code spans that are spaced apart.
     let lines = wrap_preserving_code(text, 35);
@@ -192,6 +193,16 @@ fn wrap_preserving_code_breaks_between_inline_code_spans() {
             "Extensions (`.toml`, `.json`,".to_string(),
             "`.json5`, `.yaml`, `.yml`).".to_string(),
         ]
+    );
+}
+
+#[test]
+fn wrap_preserving_code_retains_punctuation_after_separate_spans() {
+    let text = "Alpha `code` `more`, trailing.";
+    let lines = wrap_preserving_code(text, 18);
+    assert_eq!(
+        lines,
+        vec!["Alpha `code`".to_string(), "`more`, trailing.".to_string(),]
     );
 }
 


### PR DESCRIPTION
## Summary
- Improves wrapping for grouped inline code spans and trailing punctuation
- Extends SpanKind to Copy and Clone to support safe usage in pattern matching
- Adjusts wrapping logic to more reliably couple whitespace with the next token when appropriate (links, inline code, trailing punctuation)
- Adds tests to cover new wrapping behavior, including breaking between adjacent code spans and punctuation handling when code spans are separated by whitespace

## Changes
### Core Functionality
- Derive Copy and Clone for SpanKind to enable value copying in matching logic
- Refactor determine_token_span to compute a should_couple_with_next flag based on the current SpanKind and the following token
- If should_couple_with_next is true, the whitespace token is treated as part of the current span (preserving grouping with next token)
- Preserve existing behavior for links and trailing punctuation while expanding coupling rules to include inline code tokens and trailing punctuation scenarios

### Tests
- Added test cases to verify new wrapping behavior:
  - wrap_preserving_code_glues_punctuation_after_code: input "`code` `more`" -> "`code`" (and similar for trailing punctuation: "`code` `more`," -> "`code`")
  - wrap_preserving_code_breaks_between_inline_code_spans:
    - Input: "Extensions (`.toml`, `.json`, `.json5`, `.yaml`, `.yml`)."
    - Expected:
      - "Extensions (`.toml`, `.json`," 
      - "`.json5`, `.yaml`, `.yml`)." 
  - wrap_preserving_code_retains_punctuation_after_separate_spans:
    - Input: "Alpha `code` `more`, trailing."
    - Expected:
      - "Alpha `code`"
      - "`more`, trailing."

## Test plan
- Run cargo test to execute existing and new tests
- Validate that the new wrapping behavior preserves grouping for inline code spans with trailing punctuation and correctly breaks between adjacent code spans
- Manually review edge cases with links and punctuation near code spans to ensure no regressions

📎 **Task**: https://www.terragonlabs.com/task/d3161b9d-dc88-4dc4-8dd9-bb6bbc53c76f