### PR TITLE
Document code span wrapping improvements and frontmatter docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,8 @@
   ([#261](https://github.com/leynos/mdtablefix/issues/261))
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
+- Allow wrapping between space-separated inline code spans instead of treating
+  the full sequence as a single unbreakable unit.
+  ([#252](https://github.com/leynos/mdtablefix/issues/252))
 - Avoid converting numeric references in ATX heading text (including headings in
   blockquotes and list items) when the `--footnotes` option is enabled.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -441,3 +441,9 @@ when wrapping. This prevents sentences such as:
 
 from splitting the full stop onto a new line, preserving the code span's
 readability.
+
+This grouping is deliberately narrow. Whitespace between separate inline code
+spans remains a valid break opportunity, so sequences such as `.toml`, `.json`,
+`.json5`, `.yaml`, and `.yml` can wrap between spans when required. The
+coupling rule only keeps immediately trailing punctuation with the preceding
+code span.

--- a/docs/execplans/yaml-frontmatter.md
+++ b/docs/execplans/yaml-frontmatter.md
@@ -62,20 +62,25 @@ according to the selected options.
 
 - Risk: frontmatter might still be modified by CLI-only transforms such as
   `renumber_lists` or `format_breaks` after the main stream processor returns.
-  Severity: high Likelihood: medium Mitigation: protect the body split at the
-  highest shared pipeline boundary and add a CLI regression that includes
-  `--breaks`.
+  - Severity: high
+  - Likelihood: medium
+  - Mitigation: protect the body split at the highest shared pipeline boundary
+    and add a CLI regression that includes `--breaks`.
 
 - Risk: delimiter detection can become too permissive and accidentally treat a
-  thematic break or ordinary `---` block as frontmatter. Severity: medium
-  Likelihood: medium Mitigation: only detect frontmatter when the very first
-  line is a delimiter and require a matching closing delimiter before shielding
-  the block.
+  thematic break or ordinary `---` block as frontmatter.
+  - Severity: medium
+  - Likelihood: medium
+  - Mitigation: only detect frontmatter when the very first line is a
+    delimiter and require a matching closing delimiter before shielding the
+    block.
 
 - Risk: `src/process.rs` is already close to the repository's file-length
-  ceiling. Severity: medium Likelihood: high Mitigation: place the detector and
-  splitter logic in a new small module instead of extending `src/process.rs`
-  significantly.
+  ceiling.
+  - Severity: medium
+  - Likelihood: high
+  - Mitigation: place the detector and splitter logic in a new small module
+    instead of extending `src/process.rs` significantly.
 
 ## Progress
 

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -271,6 +271,31 @@ fn wrap_text_preserves_hyphenated_words() {
 }
 
 #[test]
+fn wrap_text_breaks_between_space_separated_code_spans() {
+    let input = vec![
+        "The file loader selects the parser based on the extension (`.toml`, `.json`, `.json5`, \
+         `.yaml`, `.yml`). When the `json5` feature is active, both `.json` and `.json5` files \
+         are parsed using the JSON5 format."
+            .to_string(),
+    ];
+    let wrapped = wrap_text(&input, 80);
+
+    for line in &wrapped {
+        assert!(
+            unicode_width::UnicodeWidthStr::width(line.as_str()) <= 80,
+            "line too wide ({} cols): {line:?}",
+            unicode_width::UnicodeWidthStr::width(line.as_str())
+        );
+    }
+
+    assert!(
+        wrapped[0].ends_with("`.toml`,") || wrapped[0].ends_with("`.json`,"),
+        "expected first line to break inside the code-span list, got: {:?}",
+        wrapped[0]
+    );
+}
+
+#[test]
 fn wrap_text_does_not_insert_spaces_in_hyphenated_words() {
     let input = vec![
         concat!(

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -273,10 +273,13 @@ fn wrap_text_preserves_hyphenated_words() {
 #[test]
 fn wrap_text_breaks_between_space_separated_code_spans() {
     let input = vec![
-        "The file loader selects the parser based on the extension (`.toml`, `.json`, `.json5`, \
-         `.yaml`, `.yml`). When the `json5` feature is active, both `.json` and `.json5` files \
-         are parsed using the JSON5 format."
-            .to_string(),
+        concat!(
+            "The file loader selects the parser based on the extension ",
+            "(`.toml`, `.json`, `.json5`, `.yaml`, `.yml`). When the `json5` ",
+            "feature is active, both `.json` and `.json5` files are parsed ",
+            "using the JSON5 format."
+        )
+        .to_string(),
     ];
     let wrapped = wrap_text(&input, 80);
 


### PR DESCRIPTION
## Summary

- Documented the improved wrapping behavior for inline code spans, allowing wrapping between space-separated spans and clarifying punctuation handling.
- Updated YAML frontmatter handling documentation to reflect preservation during formatting.
- Adjusted several docs style and examples to align with current formatting rules.
- Added a new unit test to verify wrapping between space-separated inline code spans (src/wrap/tests.rs).

## Changes

### Documentation updates
- CHANGELOG.md: Added entry noting that wrapping is allowed between space-separated inline code spans (#252).
- docs/architecture.md: Updated diagrams and added note that wrapping may occur between code spans; fixed fence syntax.
- docs/documentation-style-guide.md: Corrected code block fences for readability and consistency.
- docs/execplans/yaml-frontmatter.md: Clarified frontmatter preservation, output stability, and risk notes; updated wording on CLI usage and formatting behavior.
- docs/rust-doctest-dry-guide.md: Tidied prose around doctest code blocks and inline formatting.
- docs/rust-testing-with-rstest-fixtures.md: Aligned table formatting in header rows for readability.

### Tests
- src/wrap/tests.rs: Added test wrap_text_breaks_between_space_separated_code_spans to verify wrapping between space-separated code spans.

### Other
- Minor wording tweaks to ensure frontmatter grouping is narrow and only affects requested wrap opportunities.

## Validation plan

- Build and verify documentation builds cleanly (no broken code blocks or syntax issues).
- Run repository linters for docs (markdownlint, style checks) as part of CI.

## Notes

- This change is documentation-only; no runtime behavior changes.
- Feeds into the docs to reflect the new wrapping behavior and frontmatter handling described in the changelog and architecture notes.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/87009be1-c153-4fa1-866d-a004768bf44f

📝 Closes #252

## Summary by Sourcery

Update documentation to reflect refined inline code-span wrapping behavior and YAML frontmatter preservation while aligning existing docs and examples with current formatting rules.

Documentation:
- Document that wrapping is allowed between space-separated inline code spans while keeping trailing punctuation attached to the preceding span.
- Clarify YAML frontmatter handling and risks in exec plan docs, emphasizing byte-for-byte preservation alongside normal body formatting.
- Fix and standardize Markdown fences, tables, and prose wrapping across architecture, style guide, doctest, and rstest fixture documentation.
