### PR TITLE
Preserve nested fenced blocks (#262)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,17 +230,14 @@ project:
 
 ### Dependency Management
 
-- **Mandate caret requirements for all dependencies.** All crate versions
-  specified in `Cargo.toml` must use SemVer-compatible caret requirements (e.g.,
-   `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
-  non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring build
-  stability and reproducibility.
+- **Mandate caret requirements for all dependencies.** All crate versions in
+  `Cargo.toml` must use SemVer-compatible caret requirements
+  (e.g., `some-crate = "1.2.3"`). This allows safe, non-breaking minor and
+  patch updates while preventing breaking changes from new major versions.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden as
-  they introduce unacceptable risk and unpredictability. Tilde requirements (
-  `~`) should only be used where a dependency must be locked to patch-level
-  updates for a specific, documented reason.
+  open-ended inequality (`>=`) version requirements is strictly forbidden.
+  Tilde requirements (`~`) should only be used where a dependency must be
+  locked to patch-level updates for a specific, documented reason.
 
 ### Error Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,15 +231,15 @@ project:
 ### Dependency Management
 
 - **Mandate caret requirements for all dependencies.** All crate versions
-  specified in `Cargo.toml` must use SemVer-compatible caret requirements
-  (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
+  specified in `Cargo.toml` must use SemVer-compatible caret requirements (e.g.,
+   `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
   open-ended inequality (`>=`) version requirements is strictly forbidden as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
-  (`~`) should only be used where a dependency must be locked to patch-level
+  they introduce unacceptable risk and unpredictability. Tilde requirements (
+  `~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
 ### Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,10 +230,10 @@ project:
 
 ### Dependency Management
 
-- **Mandate caret requirements for all dependencies.** All crate versions in
-  `Cargo.toml` must use SemVer-compatible caret requirements
-  (e.g., `some-crate = "1.2.3"`). This allows safe, non-breaking minor and
-  patch updates while preventing breaking changes from new major versions.
+- **Mandate caret requirements.** Use caret requirements (e.g.,
+  `some-crate = "1.2.3"`) in `Cargo.toml`; they must be SemVer-compatible.
+  This allows safe, non-breaking minor and patch updates while preventing
+  breaking changes from new major versions.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
   open-ended inequality (`>=`) version requirements is strictly forbidden.
   Tilde requirements (`~`) should only be used where a dependency must be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@
   hard break semantics. See [trailing spaces](docs/trailing-spaces.md) for
   details. ([#65](https://github.com/leynos/mdtablefix/issues/65))
 - Preserve fenced and indented code blocks verbatim when `--wrap` is used, so
-  commands inside code examples are not joined or re-wrapped.
-  ([#261](https://github.com/leynos/mdtablefix/issues/261))
+  commands inside code examples are not joined or re-wrapped. (
+  [#261](https://github.com/leynos/mdtablefix/issues/261))
 - Keep trailing punctuation attached to inline code spans during wrapping to
   maintain readability.
 - Allow wrapping between space-separated inline code spans instead of treating
-  the full sequence as a single unbreakable unit.
-  ([#252](https://github.com/leynos/mdtablefix/issues/252))
+  the full sequence as a single unbreakable unit. (
+  [#252](https://github.com/leynos/mdtablefix/issues/252))
 - Avoid converting numeric references in ATX heading text (including headings in
   blockquotes and list items) when the `--footnotes` option is enabled.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ mdtablefix [--version] [--wrap] [--renumber] [--breaks] [--ellipsis] [--fences]
   character (`…`). Longer runs are processed left-to-right, so any leftover
   dots are preserved.
 
-- Use `--fences` to normalize code block delimiters to three backticks before
-  other processing.
+- Use `--fences` to normalize code block delimiters. Outer fences are
+  compressed to three backticks where safe; when same-marker nested fence
+  content would become structural, the outer delimiter width is preserved.
 
 - Use `--footnotes` to convert bare numeric references and the final numbered
   list into GitHub-flavoured footnote links.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -439,10 +439,10 @@ flowchart TD
 
 Figure: `wrap_text` control flow. The wrapper classifies each incoming line,
 passes fenced blocks, tables, headings, directives, and indented code through
-unchanged, flushes paragraphs on blanks, routes prose and prefixed lines
-through `ParagraphWriter`, computes visible widths with `unicode-width`, and
-delegates inline line fitting to `textwrap` before reconstructing the emitted
-Markdown lines.
+unchanged, flushes paragraphs on blanks, routes prose and prefixed lines through
+ `ParagraphWriter`, computes visible widths with `unicode-width`, and delegates
+inline line fitting to `textwrap` before reconstructing the emitted Markdown
+lines.
 
 ### Wrap sequence
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,11 +31,12 @@ The function combines several helpers documented in `docs/`:
   delimiters. Fence normalization uses the same `FenceTracker` semantics as
   wrapping, so fence-like lines inside an already open fenced block remain
   literal content. Outer delimiters are only compressed when doing so cannot
-  make a nested literal fence look structural. The latter keeps indentation
-  from the language line when the fence lacks it. Language specifiers
-  explicitly set to `null` (case-insensitive) or consisting solely of
-  whitespace are treated as absent. `compress_fences` also tolerates spaces
-  within comma-separated specifiers, e.g. `TOML, Ini` becomes `toml,ini`.
+  make a nested literal fence look structural. `attach_orphan_specifiers`
+  preserves and propagates indentation from the language line when the target
+  fence lacks indentation. Language specifiers explicitly set to `null`
+  (case-insensitive) or consisting solely of whitespace are treated as absent.
+  `compress_fences` also tolerates spaces within comma-separated specifiers,
+  e.g. `TOML, Ini` becomes `toml,ini`.
 - `html::convert_html_tables` transforms basic HTML tables into Markdown so \
   they can be reflowed like regular tables. See \
   [HTML table support](#html-table-support-in-mdtablefix).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,11 +28,14 @@ The function combines several helpers documented in `docs/`:
   processed. This shielding also applies to CLI-only transforms such as
   `renumber_lists` and `format_breaks`.
 - `fences::compress_fences` and `attach_orphan_specifiers` normalize code block
-  delimiters. The latter keeps indentation from the language line when the
-  fence lacks it. Language specifiers explicitly set to `null`
-  (case-insensitive) or consisting solely of whitespace are treated as absent.
-  `compress_fences` also tolerates spaces within comma-separated specifiers,
-  e.g. `TOML, Ini` becomes `toml,ini`.
+  delimiters. Fence normalization uses the same `FenceTracker` semantics as
+  wrapping, so fence-like lines inside an already open fenced block remain
+  literal content. Outer delimiters are only compressed when doing so cannot
+  make a nested literal fence look structural. The latter keeps indentation
+  from the language line when the fence lacks it. Language specifiers
+  explicitly set to `null` (case-insensitive) or consisting solely of
+  whitespace are treated as absent. `compress_fences` also tolerates spaces
+  within comma-separated specifiers, e.g. `TOML, Ini` becomes `toml,ini`.
 - `html::convert_html_tables` transforms basic HTML tables into Markdown so \
   they can be reflowed like regular tables. See \
   [HTML table support](#html-table-support-in-mdtablefix).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -82,18 +82,18 @@ restores the separator row with widths derived from the final table body.
 - `format_separator_cells`: Expands separator cells to the target widths while
   preserving Markdown alignment markers.
 
-## Fence normalisation module
+## Fence normalization module
 
 `src/fences.rs` exposes the preprocessing helpers used by the `--fences` option.
 
 - `compress_fences(lines: &[String]) -> Vec<String>` performs
   `FenceTracker`-driven conditional rewriting. For each matched fenced block,
-  it determines whether normalising the outer delimiter would make an inner
+  it determines whether normalizing the outer delimiter would make an inner
   fence line structural. This covers same-marker inner fences and the
   cross-marker case where an inner backtick fence would become structural after
   an outer tilde fence is converted to backticks. If so, it preserves the
   original outer delimiter width and marker family. Unmatched or malformed
-  delimiter runs fall through the legacy stateless normalisation path.
+  delimiter runs fall through the legacy stateless normalization path.
 - `attach_orphan_specifiers(lines: &[String]) -> Vec<String>` attaches a lone
   language identifier line to the following unlabelled fence, but only when the
   scanner is outside any active fenced block. It uses `FenceTracker` to skip

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -82,6 +82,28 @@ restores the separator row with widths derived from the final table body.
 - `format_separator_cells`: Expands separator cells to the target widths while
   preserving Markdown alignment markers.
 
+## Fence normalisation module
+
+`src/fences.rs` exposes the preprocessing helpers used by the `--fences`
+option.
+
+- `compress_fences(lines: &[String]) -> Vec<String>` performs
+  `FenceTracker`-driven conditional rewriting. For each matched fenced block,
+  it determines whether compressing the outer delimiter would make a
+  same-marker inner fence line structural. If so, it preserves the original
+  outer delimiter width and marker family. Unmatched or malformed delimiter
+  runs fall through the legacy stateless normalisation path.
+- `attach_orphan_specifiers(lines: &[String]) -> Vec<String>` attaches a lone
+  language identifier line to the following unlabelled fence, but only when the
+  scanner is outside any active fenced block. It uses `FenceTracker` to skip
+  attachment for specifier-like lines and target fences that appear inside an
+  open block.
+
+Both functions reuse `FenceTracker` from [src/wrap/fence.rs](../src/wrap/fence.rs)
+for structural fence detection. This keeps preprocessing semantics consistent
+with the wrapping pipeline. See [docs/architecture.md](architecture.md) for the
+processing pipeline context.
+
 ## Design decisions
 
 The rationale for the staged table reflow pipeline is recorded in

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -84,8 +84,7 @@ restores the separator row with widths derived from the final table body.
 
 ## Fence normalisation module
 
-`src/fences.rs` exposes the preprocessing helpers used by the `--fences`
-option.
+`src/fences.rs` exposes the preprocessing helpers used by the `--fences` option.
 
 - `compress_fences(lines: &[String]) -> Vec<String>` performs
   `FenceTracker`-driven conditional rewriting. For each matched fenced block,
@@ -99,10 +98,10 @@ option.
   attachment for specifier-like lines and target fences that appear inside an
   open block.
 
-Both functions reuse `FenceTracker` from [src/wrap/fence.rs](../src/wrap/fence.rs)
-for structural fence detection. This keeps preprocessing semantics consistent
-with the wrapping pipeline. See [docs/architecture.md](architecture.md) for the
-processing pipeline context.
+Both functions reuse `FenceTracker` from
+[src/wrap/fence.rs](../src/wrap/fence.rs) for structural fence detection. This
+keeps preprocessing semantics consistent with the wrapping pipeline. See
+[docs/architecture.md](architecture.md) for the processing pipeline context.
 
 ## Design decisions
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -88,15 +88,17 @@ restores the separator row with widths derived from the final table body.
 
 - `compress_fences(lines: &[String]) -> Vec<String>` performs
   `FenceTracker`-driven conditional rewriting. For each matched fenced block,
-  it determines whether compressing the outer delimiter would make a
-  same-marker inner fence line structural. If so, it preserves the original
-  outer delimiter width and marker family. Unmatched or malformed delimiter
-  runs fall through the legacy stateless normalisation path.
+  it determines whether normalising the outer delimiter would make an inner
+  fence line structural. This covers same-marker inner fences and the
+  cross-marker case where an inner backtick fence would become structural after
+  an outer tilde fence is converted to backticks. If so, it preserves the
+  original outer delimiter width and marker family. Unmatched or malformed
+  delimiter runs fall through the legacy stateless normalisation path.
 - `attach_orphan_specifiers(lines: &[String]) -> Vec<String>` attaches a lone
   language identifier line to the following unlabelled fence, but only when the
   scanner is outside any active fenced block. It uses `FenceTracker` to skip
   attachment for specifier-like lines and target fences that appear inside an
-  open block.
+  open block, including nested cases preserved by `compress_fences`.
 
 Both functions reuse `FenceTracker` from
 [src/wrap/fence.rs](../src/wrap/fence.rs) for structural fence detection. This

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -14,9 +14,9 @@ Issue: <https://github.com/leynos/mdtablefix/issues/262>
 After this change, `mdtablefix --fences` must normalize only real fenced code
 block delimiters, not fence-like lines that appear as literal content inside an
 larger fenced block. A user should be able to format Markdown that uses four or
-more backticks, or tilde fences, to contain inner triple-backtick examples
-without the inner examples being rewritten or treated as attachment targets for
-orphaned language specifiers.
+more backticks, or longer tilde fences, to contain inner triple-backtick or
+triple-tilde examples without the inner examples being rewritten or treated as
+attachment targets for orphaned language specifiers.
 
 The observable success case is a document such as:
 
@@ -36,7 +36,9 @@ which must become:
 
 Only the outer opening and closing delimiters are compressed. The inner
 triple-backtick lines remain literal content because they are nested inside the
-outer block.
+outer block. The same preservation rule must apply to literal inner tilde
+fences such as `~~~rust` inside an outer four-backtick block, or `~~~` inside
+an outer `~~~~` block.
 
 ## Relevant references and skills
 
@@ -103,6 +105,9 @@ not an active Cargo integration target in this repository.
 - Keep fence normalization semantics stable for existing supported cases:
   backtick fences, tilde fences, null-language normalization, and orphan
   specifier attachment outside fenced blocks.
+- Preserve literal nested fence content for both marker families. Inner
+  backtick fences and inner tilde fences must survive unchanged unless they are
+  the real closing delimiter for the currently open outer fence.
 - Reuse the shared fence-state semantics from `FenceTracker` instead of
   creating a second independent nested-fence state machine in `src/fences.rs`.
 - Keep code files under the repository's 400-line limit. If new helper logic
@@ -146,7 +151,17 @@ not an active Cargo integration target in this repository.
   - Likelihood: high
   - Mitigation: make fence-state tracking explicit in
     `attach_orphan_specifiers`, and add a regression where a specifier-like
-    line appears inside an outer fence before an inner triple-backtick example.
+    line appears inside an outer fence before an inner triple-backtick or
+    triple-tilde example.
+
+- Risk: literal nested tilde fences could still be over-normalized into
+  backticks because `compress_fences` currently rewrites real tilde delimiters
+  to backticks.
+  - Severity: high
+  - Likelihood: medium
+  - Mitigation: add explicit regressions for `~~~` content nested inside outer
+    backtick fences and for shorter `~~~` content nested inside longer tilde
+    fences such as `~~~~`.
 
 - Risk: new regressions might be added in inactive test locations and give
   false confidence.
@@ -167,8 +182,8 @@ not an active Cargo integration target in this repository.
 
 - [x] (2026-04-23 00:00Z) Reviewed the current fence preprocessing code, the
   shared `FenceTracker`, and the active test targets.
-- [ ] Add failing regressions for nested backticks and nested backticks inside
-  tilde fences.
+- [ ] Add failing regressions for nested backticks, nested tildes, and mixed
+  backtick-versus-tilde nesting.
 - [ ] Refactor `compress_fences` to use shared fence-state tracking.
 - [ ] Refactor `attach_orphan_specifiers` so it ignores content inside active
   fenced blocks.
@@ -210,11 +225,14 @@ not an active Cargo integration target in this repository.
 Stage A is a regression-first pass. Add failing examples to `tests/fences.rs`
 that prove the current bug in both reported shapes: four-backtick outer fences
 containing inner triple-backtick lines, and triple-tilde outer fences
-containing inner triple-backtick lines. Add one case that shows
-`attach_orphan_specifiers` must not attach a specifier-like line when it
-appears inside an already open outer fence. Add a CLI regression in
-`tests/cli.rs` that exercises `--fences` on one of these documents so the
-user-visible behaviour is covered end to end.
+containing inner triple-backtick lines. Extend that matrix with explicit tilde
+preservation cases: a four-backtick outer fence containing literal `~~~`
+content, and a longer tilde outer fence such as `~~~~` containing a shorter
+literal `~~~` block that must remain unchanged because it does not close the
+outer fence. Add one case that shows `attach_orphan_specifiers` must not attach
+a specifier-like line when it appears inside an already open outer fence. Add a
+CLI regression in `tests/cli.rs` that exercises `--fences` on one of these
+documents so the user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a
@@ -222,7 +240,8 @@ Stage B is the implementation pass in `src/fences.rs`. Refactor
 the line is a real fence delimiter in the current state. Compress only those
 real delimiters. If the tracker is already inside a fence and the current line
 does not close it, preserve the line exactly as written even if it matches the
-old regex. This is what keeps nested literal triple-backtick examples intact.
+old regex. This is what keeps nested literal triple-backtick and triple-tilde
+examples intact.
 
 Stage C is the orphan-specifier pass. Update `attach_orphan_specifiers` to
 track fence state while scanning. Candidate orphan specifiers should only be
@@ -234,9 +253,11 @@ fence is found.
 Stage D is the shared-semantics lock-in. Extend
 `src/wrap/tests/fence_tracker.rs` with explicit cases that demonstrate the rule
 preprocessing now depends on: an outer four-backtick fence stays open when an
-inner triple-backtick line appears, and an outer tilde fence ignores inner
-backticks entirely. These tests are not the main user regressions, but they
-document the shared contract that now drives both wrapping and preprocessing.
+inner triple-backtick line appears, an outer fence ignores the other marker
+family entirely, and a longer tilde fence stays open when a shorter inner
+triple-tilde line appears. These tests are not the main user regressions, but
+they document the shared contract that now drives both wrapping and
+preprocessing.
 
 Stage E is the validation and documentation pass. Run focused fence tests
 first, then the broader repository gates required for the touched files. If the
@@ -300,10 +321,13 @@ Expected:
 
 - `compress_fences` compresses only actual outer delimiters and leaves nested
   fence-like content unchanged.
+- Literal nested tilde fences such as `~~~` inside outer backtick fences or
+  inside longer tilde fences remain unchanged.
 - `attach_orphan_specifiers` does not attach specifiers that appear inside an
   already open fenced block.
 - `FenceTracker` tests explicitly cover the outer-four-backticks and
-  outer-tildes cases that govern the new preprocessing behaviour.
+  outer-tildes cases, including shorter inner tilde runs, that govern the new
+  preprocessing behaviour.
 - `cargo test --test fences`, `cargo test --test cli`, `make check-fmt`,
   `make lint`, and `make test` all pass.
 - If architecture documentation is updated, `make fmt`, `make markdownlint`,

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -66,9 +66,9 @@ Use these skills while implementing the plan:
 
 The current fence preprocessing logic lives in
 [`src/fences.rs`](../../src/fences.rs). Two functions matter:
-`compress_fences(lines)` compresses any matching backtick or tilde fence to
-exactly three backticks, and `attach_orphan_specifiers(lines)` rewrites a lone
-language line such as `Rust` onto the following unlabeled fence.
+`compress_fences(lines)` performs conditional outer-fence normalization, and
+`attach_orphan_specifiers(lines)` rewrites a lone language line such as `Rust`
+onto the following unlabelled fence.
 
 The shared fence-state logic already exists in
 [`src/wrap/fence.rs`](../../src/wrap/fence.rs). `FenceTracker::observe(line)`

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -173,9 +173,10 @@ not an active Cargo integration target in this repository.
     backtick fences and for shorter `~~~` content nested inside longer tilde
     fences such as `~~~~`.
 
-- Risk: even a real outer fence delimiter can be over-compressed. If an outer
-  ` ```` ` block containing an inner ` ``` ` line is rewritten to ` ```
-  `, the inner close will terminate the outer block and corrupt the document structure.
+- Risk: even a real outer fence delimiter can be over-compressed.
+  If an outer ````` ```` ````` block containing an inner ```` ``` ```` line is
+  rewritten to ```` ``` ````, the inner close will terminate the outer block
+  and corrupt the document structure.
   - Severity: high
   - Likelihood: high
   - Mitigation: add a regression that asserts the outer four-character opening
@@ -232,6 +233,9 @@ not an active Cargo integration target in this repository.
   `cargo test --test fences`, `cargo test --test cli_fences`,
   `cargo test fence_tracker`, `make check-fmt`, `make lint`, `make test`,
   `make markdownlint`, and `make nixie`.
+- [x] (2026-04-24 00:00Z) Verified and addressed follow-up documentation review
+  comments in `docs/architecture.md`,
+  `docs/execplans/issue-262-nested-code-block-handling.md`, and `src/fences.rs`.
 
 ## Surprises & discoveries
 
@@ -326,8 +330,8 @@ longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
 block that must remain unchanged because it does not close the outer fence. Add
 one case that shows `attach_orphan_specifiers` must not attach a specifier-like
 line when it appears inside an already open outer fence. Add a CLI regression
-in `tests/cli.rs` that exercises `--fences` on one of these documents so the
-user-visible behaviour is covered end to end.
+in `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
+the user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -1,8 +1,8 @@
 # Preserve nested fenced blocks during fence normalization
 
-This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
-and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+This ExecPlan (execution plan) is a living document. Keep these sections
+current as work proceeds: `Constraints`, `Tolerances`, `Risks`, `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective`.
 
 Status: COMPLETE
 
@@ -88,9 +88,9 @@ The active regression targets are:
   integration-style behaviour.
 - [`tests/cli.rs`](../../tests/cli.rs) for end-to-end CLI behaviour with
   `--fences`.
-- [`tests/cli_fences.rs`](../../tests/cli_fences.rs) for additional
-  end-to-end CLI fence regressions, because `tests/cli.rs` is already close to
-  the repository's 400-line limit.
+- [`tests/cli_fences.rs`](../../tests/cli_fences.rs) for additional end-to-end
+  CLI fence regressions, because `tests/cli.rs` is already close to the
+  repository's 400-line limit.
 - [`src/wrap/tests/fence_tracker.rs`](../../src/wrap/tests/fence_tracker.rs)
   for the shared tracker semantics.
 - [`tests/wrap_unit.rs`](../../tests/wrap_unit.rs) if one additional wrapping
@@ -236,10 +236,14 @@ not an active Cargo integration target in this repository.
   comments in `docs/architecture.md`,
   `docs/execplans/issue-262-nested-code-block-handling.md`, and `src/fences.rs`.
 - [x] (2026-04-25 00:00Z) Verified and addressed follow-up review comments:
-  `compress_fences` now enters fenced-state tracking for openings recognised by
+  `compress_fences` now enters fenced-state tracking for openings recognized by
   `wrap::is_fence` even when they are outside `FENCE_RE`, including spaced info
   strings; nested `FenceTracker` tests are parameterized with `rstest`; and the
   CLI validation path consistently points at `tests/cli_fences.rs`.
+- [x] (2026-04-26 00:00Z) Verified and addressed follow-up review comments for
+  Markdown token wrapping and spaced-info fence rewriting. `compress_fences`
+  now preserves matched blocks unchanged when either outer delimiter is not
+  supported by the rewrite regex.
 
 ## Surprises & discoveries
 
@@ -332,10 +336,10 @@ wide after formatting. Extend that matrix with explicit tilde preservation
 cases: a four-backtick outer fence containing literal `~~~` content, and a
 longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
 block that must remain unchanged because it does not close the outer fence. Add
-one case that shows `attach_orphan_specifiers` must not attach a specifier-like
-line when it appears inside an already open outer fence. Add a CLI regression in
- `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
-the user-visible behaviour is covered end to end.
+one case that shows `attach_orphan_specifiers` must not attach a
+specifier-like line when it appears inside an already open outer fence. Add a
+CLI regression in `tests/cli_fences.rs` that exercises `--fences` on one of
+these documents so the user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a
@@ -453,7 +457,7 @@ Implemented nested-fence-safe normalization for `mdtablefix --fences`.
 `compress_fences` now analyses matched fenced blocks with `FenceTracker`,
 preserves literal nested fence-like lines, and keeps outer delimiters unchanged
 when shortening or changing their marker family would make nested literal
-content structural. `attach_orphan_specifiers` now tracks active fenced blocks
+content structural. `attach_orphan_specifiers` now tracks active fenced blocks,
 so specifier-like lines inside an outer fence remain content.
 
 The implementation kept existing legacy behaviour for unmatched mixed-marker

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -1,0 +1,314 @@
+# Preserve nested fenced blocks during fence normalization
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+Issue: <https://github.com/leynos/mdtablefix/issues/262>
+
+## Purpose / big picture
+
+After this change, `mdtablefix --fences` must normalize only real fenced code
+block delimiters, not fence-like lines that appear as literal content inside an
+larger fenced block. A user should be able to format Markdown that uses four or
+more backticks, or tilde fences, to contain inner triple-backtick examples
+without the inner examples being rewritten or treated as attachment targets for
+orphaned language specifiers.
+
+The observable success case is a document such as:
+
+    ```markdown
+    ```rust
+    fn main() {}
+    ```
+    ```
+
+which must become:
+
+    ```markdown
+    ```rust
+    fn main() {}
+    ```
+    ```
+
+Only the outer opening and closing delimiters are compressed. The inner
+triple-backtick lines remain literal content because they are nested inside the
+outer block.
+
+## Relevant references and skills
+
+Read these repository documents before touching the implementation:
+
+- [`docs/architecture.md`](../architecture.md) for the processing pipeline and
+  the relationship between `process_stream_inner`, fence normalization, and the
+  shared `FenceTracker`.
+- [`docs/developers-guide.md`](../developers-guide.md) for the internal module
+  boundaries and the wrap pipeline notes.
+- [`docs/documentation-style-guide.md`](../documentation-style-guide.md) for
+  Markdown and wording rules if this plan or architecture notes are updated
+  during delivery.
+
+Use these skills while implementing the plan:
+
+- `/root/.codex/skills/execplans/SKILL.md` to keep this document current as a
+  living ExecPlan.
+- `/root/.codex/skills/leta/SKILL.md` for symbol-aware navigation of
+  `compress_fences`, `attach_orphan_specifiers`, `FenceTracker`, and their
+  callers.
+- `/root/.codex/skills/rust-router/SKILL.md` if implementation work expands
+  beyond a local fix and needs deeper Rust-specific guidance.
+
+## Context and orientation
+
+The current fence preprocessing logic lives in
+[`src/fences.rs`](../../src/fences.rs). Two functions matter:
+`compress_fences(lines)` compresses any matching backtick or tilde fence to
+exactly three backticks, and `attach_orphan_specifiers(lines)` rewrites a lone
+language line such as `Rust` onto the following unlabeled fence.
+
+The shared fence-state logic already exists in
+[`src/wrap/fence.rs`](../../src/wrap/fence.rs). `FenceTracker::observe(line)`
+opens a fence when it sees three or more backticks or tildes, closes only when
+the marker character matches and the closing run is at least as long as the
+opening run, and otherwise leaves the tracker inside the current fence. That is
+the exact behaviour needed for nested-fence handling.
+
+`process_stream_inner` in [`src/process.rs`](../../src/process.rs) runs fence
+normalization first when `Options { fences: true, .. }` is enabled. That means
+the bug is not in paragraph wrapping; it is in the preprocessing step that runs
+before the rest of the formatting pipeline sees the lines.
+
+The active regression targets are:
+
+- [`tests/fences.rs`](../../tests/fences.rs) for fence normalization unit and
+  integration-style behaviour.
+- [`tests/cli.rs`](../../tests/cli.rs) for end-to-end CLI behaviour with
+  `--fences`.
+- [`src/wrap/tests/fence_tracker.rs`](../../src/wrap/tests/fence_tracker.rs)
+  for the shared tracker semantics.
+- [`tests/wrap_unit.rs`](../../tests/wrap_unit.rs) if one additional wrapping
+  regression is needed in an active top-level target.
+
+Do not plan new coverage in `tests/wrap/fence_behaviour.rs` alone. That file is
+not an active Cargo integration target in this repository.
+
+## Constraints
+
+- Do not add new dependencies. The fix must reuse existing regex and fence
+  tracking code.
+- Do not change the public API exported from `src/lib.rs`.
+- Keep fence normalization semantics stable for existing supported cases:
+  backtick fences, tilde fences, null-language normalization, and orphan
+  specifier attachment outside fenced blocks.
+- Reuse the shared fence-state semantics from `FenceTracker` instead of
+  creating a second independent nested-fence state machine in `src/fences.rs`.
+- Keep code files under the repository's 400-line limit. If new helper logic
+  would push a file past that limit, extract a small helper module or helper
+  functions instead of growing the file unchecked.
+- Add regression tests that fail before the fix and pass after it.
+- Run the repository quality gates relevant to the touched files before ending
+  the work.
+
+## Tolerances (exception triggers)
+
+- Scope: if the smallest correct fix requires changing more than 6 source files
+  or more than roughly 200 net lines of Rust, stop and reassess whether the
+  tracker logic should be extracted into a shared helper instead.
+- Interfaces: if reusing `FenceTracker` cleanly requires changing public
+  exports or widening module visibility beyond internal use, stop and escalate.
+- Semantics: if the current tracker cannot model the preprocessing needs
+  without changing its observable behaviour for wrapping, stop and document the
+  conflict before proceeding.
+- Tests: if focused regressions still fail after 3 fix iterations, stop and
+  record which input shape is still ambiguous.
+- Documentation: if the implementation reveals that
+  `docs/architecture.md` materially misdescribes fence normalization, update it
+  in the same change; do not leave the architecture notes stale.
+
+## Risks
+
+- Risk: `src/fences.rs` and `src/wrap/fence.rs` currently use similar but not
+  identical regex logic, so naïvely mixing them could change accepted info
+  strings or indentation handling.
+  - Severity: high
+  - Likelihood: medium
+  - Mitigation: decide early whether `src/fences.rs` should call
+    `wrap::is_fence`, reuse only `FenceTracker`, or extract one shared internal
+    parser that preserves current `compress_fences` output formatting.
+
+- Risk: orphan specifier attachment could still look through an open outer fence
+  and incorrectly attach a language line that is meant to be literal code block
+  content.
+  - Severity: high
+  - Likelihood: high
+  - Mitigation: make fence-state tracking explicit in
+    `attach_orphan_specifiers`, and add a regression where a specifier-like
+    line appears inside an outer fence before an inner triple-backtick example.
+
+- Risk: new regressions might be added in inactive test locations and give
+  false confidence.
+  - Severity: medium
+  - Likelihood: medium
+  - Mitigation: keep new behavioural coverage in `tests/fences.rs`,
+    `tests/cli.rs`, `tests/wrap_unit.rs`, or another top-level `tests/*.rs`
+    target only.
+
+- Risk: `src/fences.rs` is already moderately sized, and the extra stateful
+  logic could make it harder to read.
+  - Severity: medium
+  - Likelihood: medium
+  - Mitigation: prefer small helpers such as `compress_fence_line` or
+    `can_attach_orphan_specifier` rather than one large loop body.
+
+## Progress
+
+- [x] (2026-04-23 00:00Z) Reviewed the current fence preprocessing code, the
+  shared `FenceTracker`, and the active test targets.
+- [ ] Add failing regressions for nested backticks and nested backticks inside
+  tilde fences.
+- [ ] Refactor `compress_fences` to use shared fence-state tracking.
+- [ ] Refactor `attach_orphan_specifiers` so it ignores content inside active
+  fenced blocks.
+- [ ] Extend `FenceTracker` tests to lock in the nested-fence expectations used
+  by preprocessing.
+- [ ] Run focused tests, then the full required quality gates, and update this
+  ExecPlan with outcomes.
+
+## Surprises & discoveries
+
+- Discovery: the bug is earlier than the main streaming processor.
+  `process_stream_inner` only consumes the already-normalized output from
+  `compress_fences` and `attach_orphan_specifiers`, so fixing wrapping alone
+  cannot solve issue `#262`.
+
+- Discovery: the repository already contains the correct closing-fence rule in
+  `FenceTracker::observe`: only the same fence marker character can close a
+  block, and the closing run must be at least as long as the opening run.
+
+- Discovery: `tests/wrap/fence_behaviour.rs` looks relevant but is not run by
+  Cargo in this repository. New regressions must live in active top-level test
+  targets.
+
+## Decision log
+
+- Decision: plan around shared fence-state semantics instead of duplicating the
+  nested-fence rule in a new ad hoc parser. Rationale: the repository already
+  depends on `FenceTracker` to keep headings, breaks, wrapping, and other logic
+  aligned on fence boundaries. Date/Author: 2026-04-23 / Codex.
+
+- Decision: treat `compress_fences` and `attach_orphan_specifiers` as one
+  behavioural unit for this issue. Rationale: both functions currently inspect
+  lines without persistent fence state, so fixing only one would leave the
+  other able to mis-handle literal content inside an outer fence. Date/Author:
+  2026-04-23 / Codex.
+
+## Plan of work
+
+Stage A is a regression-first pass. Add failing examples to `tests/fences.rs`
+that prove the current bug in both reported shapes: four-backtick outer fences
+containing inner triple-backtick lines, and triple-tilde outer fences
+containing inner triple-backtick lines. Add one case that shows
+`attach_orphan_specifiers` must not attach a specifier-like line when it
+appears inside an already open outer fence. Add a CLI regression in
+`tests/cli.rs` that exercises `--fences` on one of these documents so the
+user-visible behaviour is covered end to end.
+
+Stage B is the implementation pass in `src/fences.rs`. Refactor
+`compress_fences` from a stateless `map` into a line-by-line loop that keeps a
+`FenceTracker` for the original input lines. For each line, determine whether
+the line is a real fence delimiter in the current state. Compress only those
+real delimiters. If the tracker is already inside a fence and the current line
+does not close it, preserve the line exactly as written even if it matches the
+old regex. This is what keeps nested literal triple-backtick examples intact.
+
+Stage C is the orphan-specifier pass. Update `attach_orphan_specifiers` to
+track fence state while scanning. Candidate orphan specifiers should only be
+considered when the scanner is outside any active fence, and the target fence
+search must likewise stay outside open blocks. Keep the existing attachment
+semantics for indentation and null-language fences once a legitimate outside
+fence is found.
+
+Stage D is the shared-semantics lock-in. Extend
+`src/wrap/tests/fence_tracker.rs` with explicit cases that demonstrate the rule
+preprocessing now depends on: an outer four-backtick fence stays open when an
+inner triple-backtick line appears, and an outer tilde fence ignores inner
+backticks entirely. These tests are not the main user regressions, but they
+document the shared contract that now drives both wrapping and preprocessing.
+
+Stage E is the validation and documentation pass. Run focused fence tests
+first, then the broader repository gates required for the touched files. If the
+implementation changes the architecture story in a meaningful way, add a short
+note to `docs/architecture.md` stating that fence normalization now shares the
+same nested-fence tracking semantics as the wrapping pipeline.
+
+## Concrete steps
+
+Work from the repository root:
+
+    pwd
+
+Expected:
+
+    /home/user/project
+
+Make the bug visible with focused tests first:
+
+    set -o pipefail && cargo test --test fences 2>&1 | tee /tmp/issue-262-fences.log
+
+Expected before the fix: at least one new nested-fence regression fails.
+
+After adding the CLI regression:
+
+    set -o pipefail && cargo test --test cli nested 2>&1 | tee /tmp/issue-262-cli.log
+
+Expected before the fix: the new `--fences` nested-fence case fails.
+
+Once the implementation is in place, rerun the focused suites:
+
+    set -o pipefail && cargo test --test fences 2>&1 | tee /tmp/issue-262-fences.log
+    set -o pipefail && cargo test --test cli 2>&1 | tee /tmp/issue-262-cli.log
+    set -o pipefail && cargo test fence_tracker 2>&1 | tee /tmp/issue-262-tracker.log
+
+Expected after the fix:
+
+    test result: ok. <N> passed; 0 failed
+
+Run the repository gates required for Rust code changes:
+
+    set -o pipefail && make check-fmt 2>&1 | tee /tmp/issue-262-check-fmt.log
+    set -o pipefail && make lint 2>&1 | tee /tmp/issue-262-lint.log
+    set -o pipefail && make test 2>&1 | tee /tmp/issue-262-test.log
+
+Expected:
+
+    All commands exit with status 0.
+
+If `docs/architecture.md` is updated, run the documentation gates as well:
+
+    set -o pipefail && make fmt 2>&1 | tee /tmp/issue-262-doc-fmt.log
+    set -o pipefail && make markdownlint 2>&1 | tee /tmp/issue-262-markdownlint.log
+    set -o pipefail && make nixie 2>&1 | tee /tmp/issue-262-nixie.log
+
+Expected:
+
+    All commands exit with status 0.
+
+## Acceptance criteria
+
+- `compress_fences` compresses only actual outer delimiters and leaves nested
+  fence-like content unchanged.
+- `attach_orphan_specifiers` does not attach specifiers that appear inside an
+  already open fenced block.
+- `FenceTracker` tests explicitly cover the outer-four-backticks and
+  outer-tildes cases that govern the new preprocessing behaviour.
+- `cargo test --test fences`, `cargo test --test cli`, `make check-fmt`,
+  `make lint`, and `make test` all pass.
+- If architecture documentation is updated, `make fmt`, `make markdownlint`,
+  and `make nixie` also pass.
+
+## Outcomes & retrospective
+
+Pending implementation approval.

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -333,17 +333,19 @@ not an active Cargo integration target in this repository.
 
 Stage A is a regression-first pass. Add failing examples to `tests/fences.rs`
 that prove the current bug in both reported shapes: four-backtick outer fences
-containing inner triple-backtick lines, and triple-tilde outer fences
-containing inner triple-backtick lines. Those same-marker cases must assert
-that the outer four-character opening and closing fences remain four characters
-wide after formatting. Extend that matrix with explicit tilde preservation
-cases: a four-backtick outer fence containing literal `~~~` content, and a
-longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
-block that must remain unchanged because it does not close the outer fence. Add
-one case that shows `attach_orphan_specifiers` must not attach a specifier-like
-line when it appears inside an already open outer fence. Add a CLI regression in
- `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
-the user-visible behaviour is covered end to end.
+containing inner triple-backtick lines as the same-marker case, and
+triple-tilde outer fences containing inner triple-backtick lines as the
+mixed-marker case. The same-marker case must assert that the outer
+four-character opening and closing fences remain four characters wide after
+formatting, and the tilde-outer cases must preserve their tilde width. Extend
+that matrix with explicit tilde preservation cases: a four-backtick outer fence
+containing literal `~~~` content, and a longer tilde outer fence such as `~~~~`
+containing a shorter literal `~~~` block that must remain unchanged because it
+does not close the outer fence. Add one case that shows
+`attach_orphan_specifiers` must not attach a specifier-like line when it
+appears inside an already open outer fence. Add a CLI regression in
+`tests/cli_fences.rs` that exercises `--fences` on one of these documents so the
+user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -19,19 +19,19 @@ attachment targets for orphaned language specifiers.
 
 The observable success case is a document such as:
 
-    ```markdown
+    ````markdown
     ```rust
     fn main() {}
     ```
-    ```
+    ````
 
 which must become:
 
-    ```markdown
+    ````markdown
     ```rust
     fn main() {}
     ```
-    ```
+    ````
 
 The outer opening and closing delimiters stay at four backticks because
 compressing them to three would let the inner triple-backtick close the outer
@@ -244,6 +244,10 @@ not an active Cargo integration target in this repository.
   Markdown token wrapping and spaced-info fence rewriting. `compress_fences`
   now preserves matched blocks unchanged when either outer delimiter is not
   supported by the rewrite regex.
+- [x] (2026-04-26 00:00Z) Updated the user guide and developer guide to
+  document nested-fence preservation, including the tilde-outer/backtick-inner
+  case. Re-ran documentation validation with `make markdownlint` and
+  `make nixie`.
 
 ## Surprises & discoveries
 
@@ -336,10 +340,10 @@ wide after formatting. Extend that matrix with explicit tilde preservation
 cases: a four-backtick outer fence containing literal `~~~` content, and a
 longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
 block that must remain unchanged because it does not close the outer fence. Add
-one case that shows `attach_orphan_specifiers` must not attach a
-specifier-like line when it appears inside an already open outer fence. Add a
-CLI regression in `tests/cli_fences.rs` that exercises `--fences` on one of
-these documents so the user-visible behaviour is covered end to end.
+one case that shows `attach_orphan_specifiers` must not attach a specifier-like
+line when it appears inside an already open outer fence. Add a CLI regression in
+ `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
+the user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -1,9 +1,8 @@
 # Preserve nested fenced blocks during fence normalization
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -236,6 +235,11 @@ not an active Cargo integration target in this repository.
 - [x] (2026-04-24 00:00Z) Verified and addressed follow-up documentation review
   comments in `docs/architecture.md`,
   `docs/execplans/issue-262-nested-code-block-handling.md`, and `src/fences.rs`.
+- [x] (2026-04-25 00:00Z) Verified and addressed follow-up review comments:
+  `compress_fences` now enters fenced-state tracking for openings recognised by
+  `wrap::is_fence` even when they are outside `FENCE_RE`, including spaced info
+  strings; nested `FenceTracker` tests are parameterized with `rstest`; and the
+  CLI validation path consistently points at `tests/cli_fences.rs`.
 
 ## Surprises & discoveries
 
@@ -329,8 +333,8 @@ cases: a four-backtick outer fence containing literal `~~~` content, and a
 longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
 block that must remain unchanged because it does not close the outer fence. Add
 one case that shows `attach_orphan_specifiers` must not attach a specifier-like
-line when it appears inside an already open outer fence. Add a CLI regression
-in `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
+line when it appears inside an already open outer fence. Add a CLI regression in
+ `tests/cli_fences.rs` that exercises `--fences` on one of these documents so
 the user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
@@ -387,14 +391,15 @@ Expected before the fix: at least one new nested-fence regression fails.
 
 After adding the CLI regression:
 
-    set -o pipefail && cargo test --test cli nested 2>&1 | tee /tmp/issue-262-cli.log
+    set -o pipefail && cargo test --test cli_fences nested 2>&1 | tee /tmp/issue-262-cli-fences.log
 
-Expected before the fix: the new `--fences` nested-fence case fails.
+Expected before the fix: the new `--fences` nested-fence case in
+`tests/cli_fences.rs` fails.
 
 Once the implementation is in place, rerun the focused suites:
 
     set -o pipefail && cargo test --test fences 2>&1 | tee /tmp/issue-262-fences.log
-    set -o pipefail && cargo test --test cli 2>&1 | tee /tmp/issue-262-cli.log
+    set -o pipefail && cargo test --test cli_fences 2>&1 | tee /tmp/issue-262-cli-fences.log
     set -o pipefail && cargo test fence_tracker 2>&1 | tee /tmp/issue-262-tracker.log
 
 Expected after the fix:
@@ -436,8 +441,9 @@ Expected:
 - `FenceTracker` tests explicitly cover the outer-four-backticks and
   outer-tildes cases, including shorter inner tilde runs, that govern the new
   preprocessing behaviour.
-- `cargo test --test fences`, `cargo test --test cli`, `make check-fmt`,
-  `make lint`, and `make test` all pass.
+- `cargo test --test fences`, `cargo test --test cli_fences` for
+  `tests/cli_fences.rs`, `make check-fmt`, `make lint`, and `make test` all
+  pass.
 - If architecture documentation is updated, `make fmt`, `make markdownlint`,
   and `make nixie` also pass.
 

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -224,6 +224,14 @@ not an active Cargo integration target in this repository.
 - [x] (2026-04-24 00:00Z) Updated `docs/architecture.md` to state that fence
   normalization now shares `FenceTracker` semantics and only compresses outer
   delimiters when doing so is structurally safe.
+- [x] (2026-04-24 00:00Z) Addressed code review feedback by replacing the
+  repeated `analyze_opening` forward scan with a single-pass pending-block
+  implementation, consolidating marker rewriting behind one helper, and adding
+  deeper orphan specifier, symmetric tracker, and broader CLI regressions.
+- [x] (2026-04-24 00:00Z) Ran review follow-up validation:
+  `cargo test --test fences`, `cargo test --test cli_fences`,
+  `cargo test fence_tracker`, `make check-fmt`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie`.
 
 ## Surprises & discoveries
 
@@ -256,6 +264,13 @@ not an active Cargo integration target in this repository.
   `compress_fences` only enables stateful shielding after confirming the
   opening delimiter has a real matching close in the original input.
 
+- Discovery: a fully linear implementation still needs to delay emitting a
+  matched fenced block until its closing delimiter is seen, because the opening
+  delimiter rewrite depends on whether later literal fence-like lines make
+  compression unsafe. The follow-up implementation buffers only the currently
+  open block and flushes unmatched blocks through the legacy stateless
+  normalization path at end of input.
+
 ## Decision log
 
 - Decision: plan around shared fence-state semantics instead of duplicating the
@@ -285,6 +300,18 @@ not an active Cargo integration target in this repository.
   `tests/cli.rs`. Rationale: `tests/cli.rs` was too close to the 400-line file
   limit, and a separate active integration target preserves coverage without
   creating a file-size violation. Date/Author: 2026-04-24 / Codex.
+
+- Decision: use a single-pass pending-block implementation instead of caching
+  lookahead results. Rationale: each input line is visited once, the current
+  open block carries the only needed safety state, and unmatched malformed
+  inputs can still be flushed with the previous line-by-line normalization
+  behaviour. Date/Author: 2026-04-24 / Codex.
+
+- Decision: keep `FENCE_RE` as the normalization grammar and use
+  `wrap::is_fence`/`FenceTracker` only for structural Markdown fence state.
+  Rationale: preprocessing has narrower language-normalization rules than
+  wrapping, but closure and marker-family semantics must stay shared.
+  Date/Author: 2026-04-24 / Codex.
 
 ## Plan of work
 
@@ -426,3 +453,9 @@ fixing the valid nested-fence cases from issue `#262`.
 
 Validation passed with `make check-fmt`, `make lint`, `make test`,
 `make markdownlint`, and `make nixie`.
+
+Code review follow-up replaced repeated forward scans with a linear
+pending-block pass and added regressions for deeper orphan specifier content,
+outer tilde fences containing inner backticks, and CLI nested-fence variants.
+The follow-up validation passed with the focused tests and full repository
+gates listed in `Progress`.

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -34,11 +34,11 @@ which must become:
     ```
     ```
 
-Only the outer opening and closing delimiters are compressed. The inner
-triple-backtick lines remain literal content because they are nested inside the
-outer block. The same preservation rule must apply to literal inner tilde
-fences such as `~~~rust` inside an outer four-backtick block, or `~~~` inside
-an outer `~~~~` block.
+The outer opening and closing delimiters stay at four backticks because
+compressing them to three would let the inner triple-backtick close the outer
+block. The same preservation rule must apply to literal inner tilde fences such
+as `~~~rust` inside an outer four-backtick block, or `~~~` inside an outer
+`~~~~` block.
 
 ## Relevant references and skills
 
@@ -108,6 +108,10 @@ not an active Cargo integration target in this repository.
 - Preserve literal nested fence content for both marker families. Inner
   backtick fences and inner tilde fences must survive unchanged unless they are
   the real closing delimiter for the currently open outer fence.
+- Preserve the original outer fence length when shortening it would make a
+  same-marker inner fence line terminate the outer block early. In particular,
+  a four-character outer fence that wraps a three-character inner fence of the
+  same type must remain four characters wide.
 - Reuse the shared fence-state semantics from `FenceTracker` instead of
   creating a second independent nested-fence state machine in `src/fences.rs`.
 - Keep code files under the repository's 400-line limit. If new helper logic
@@ -127,6 +131,9 @@ not an active Cargo integration target in this repository.
 - Semantics: if the current tracker cannot model the preprocessing needs
   without changing its observable behaviour for wrapping, stop and document the
   conflict before proceeding.
+- Compression rule: if the fix requires abandoning fence compression entirely
+  instead of making it conditional on safety, stop and confirm that scope
+  change before proceeding.
 - Tests: if focused regressions still fail after 3 fix iterations, stop and
   record which input shape is still ambiguous.
 - Documentation: if the implementation reveals that
@@ -163,6 +170,16 @@ not an active Cargo integration target in this repository.
     backtick fences and for shorter `~~~` content nested inside longer tilde
     fences such as `~~~~`.
 
+- Risk: even a real outer fence delimiter can be over-compressed. If an outer
+  ` ```` ` block containing an inner ` ``` ` line is rewritten to ` ```
+  `, the inner close will terminate the outer block and corrupt the document structure.
+  - Severity: high
+  - Likelihood: high
+  - Mitigation: add a regression that asserts the outer four-character opening
+    and closing fences remain four characters wide when they contain a
+    same-marker inner triple fence. Mirror the same check for `~~~~` wrapping
+    `~~~`.
+
 - Risk: new regressions might be added in inactive test locations and give
   false confidence.
   - Severity: medium
@@ -184,7 +201,8 @@ not an active Cargo integration target in this repository.
   shared `FenceTracker`, and the active test targets.
 - [ ] Add failing regressions for nested backticks, nested tildes, and mixed
   backtick-versus-tilde nesting.
-- [ ] Refactor `compress_fences` to use shared fence-state tracking.
+- [ ] Refactor `compress_fences` to use shared fence-state tracking and retain
+  original outer fence width when required for same-marker nesting safety.
 - [ ] Refactor `attach_orphan_specifiers` so it ignores content inside active
   fenced blocks.
 - [ ] Extend `FenceTracker` tests to lock in the nested-fence expectations used
@@ -203,6 +221,11 @@ not an active Cargo integration target in this repository.
   `FenceTracker::observe`: only the same fence marker character can close a
   block, and the closing run must be at least as long as the opening run.
 
+- Discovery: preserving nested literal content is not sufficient on its own.
+  A real outer four-character fence must also be preserved when it wraps a
+  three-character inner fence of the same marker type, or the inner close will
+  become a structural close for the outer block after compression.
+
 - Discovery: `tests/wrap/fence_behaviour.rs` looks relevant but is not run by
   Cargo in this repository. New regressions must live in active top-level test
   targets.
@@ -220,28 +243,40 @@ not an active Cargo integration target in this repository.
   other able to mis-handle literal content inside an outer fence. Date/Author:
   2026-04-23 / Codex.
 
+- Decision: define fence compression as a safety-preserving rewrite, not an
+  unconditional reduction to three markers. Rationale: same-marker nested
+  examples require the outer delimiter width to remain greater than the inner
+  literal fence width, otherwise the formatted output becomes structurally
+  incorrect. Date/Author: 2026-04-24 / Codex.
+
 ## Plan of work
 
 Stage A is a regression-first pass. Add failing examples to `tests/fences.rs`
 that prove the current bug in both reported shapes: four-backtick outer fences
 containing inner triple-backtick lines, and triple-tilde outer fences
-containing inner triple-backtick lines. Extend that matrix with explicit tilde
-preservation cases: a four-backtick outer fence containing literal `~~~`
-content, and a longer tilde outer fence such as `~~~~` containing a shorter
-literal `~~~` block that must remain unchanged because it does not close the
-outer fence. Add one case that shows `attach_orphan_specifiers` must not attach
-a specifier-like line when it appears inside an already open outer fence. Add a
-CLI regression in `tests/cli.rs` that exercises `--fences` on one of these
-documents so the user-visible behaviour is covered end to end.
+containing inner triple-backtick lines. Those same-marker cases must assert
+that the outer four-character opening and closing fences remain four characters
+wide after formatting. Extend that matrix with explicit tilde preservation
+cases: a four-backtick outer fence containing literal `~~~` content, and a
+longer tilde outer fence such as `~~~~` containing a shorter literal `~~~`
+block that must remain unchanged because it does not close the outer fence. Add
+one case that shows `attach_orphan_specifiers` must not attach a specifier-like
+line when it appears inside an already open outer fence. Add a CLI regression
+in `tests/cli.rs` that exercises `--fences` on one of these documents so the
+user-visible behaviour is covered end to end.
 
 Stage B is the implementation pass in `src/fences.rs`. Refactor
 `compress_fences` from a stateless `map` into a line-by-line loop that keeps a
 `FenceTracker` for the original input lines. For each line, determine whether
 the line is a real fence delimiter in the current state. Compress only those
-real delimiters. If the tracker is already inside a fence and the current line
-does not close it, preserve the line exactly as written even if it matches the
-old regex. This is what keeps nested literal triple-backtick and triple-tilde
-examples intact.
+delimiters that are safe to shorten. If an outer fence uses four or more
+markers and the block contains a same-marker literal fence line that would
+become a closing delimiter after compression, preserve the original outer
+delimiter width on both the opening and closing lines. If the tracker is
+already inside a fence and the current line does not close it, preserve the
+line exactly as written even if it matches the old regex. This is what keeps
+nested literal triple-backtick and triple-tilde examples intact without making
+the formatted output structurally invalid.
 
 Stage C is the orphan-specifier pass. Update `attach_orphan_specifiers` to
 track fence state while scanning. Candidate orphan specifiers should only be
@@ -257,7 +292,8 @@ inner triple-backtick line appears, an outer fence ignores the other marker
 family entirely, and a longer tilde fence stays open when a shorter inner
 triple-tilde line appears. These tests are not the main user regressions, but
 they document the shared contract that now drives both wrapping and
-preprocessing.
+preprocessing, including the requirement that outer width remains greater than
+same-marker inner literal fence width.
 
 Stage E is the validation and documentation pass. Run focused fence tests
 first, then the broader repository gates required for the touched files. If the
@@ -320,9 +356,13 @@ Expected:
 ## Acceptance criteria
 
 - `compress_fences` compresses only actual outer delimiters and leaves nested
-  fence-like content unchanged.
+  fence-like content unchanged, and preserves outer delimiter width when
+  shortening it would let a same-marker inner fence close the block early.
 - Literal nested tilde fences such as `~~~` inside outer backtick fences or
   inside longer tilde fences remain unchanged.
+- A four-character outer backtick fence wrapping an inner triple-backtick fence
+  remains four backticks wide after formatting. The same safety rule applies to
+  `~~~~` wrapping `~~~`.
 - `attach_orphan_specifiers` does not attach specifiers that appear inside an
   already open fenced block.
 - `FenceTracker` tests explicitly cover the outer-four-backticks and

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -5,14 +5,14 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 Issue: <https://github.com/leynos/mdtablefix/issues/262>
 
 ## Purpose / big picture
 
 After this change, `mdtablefix --fences` must normalize only real fenced code
-block delimiters, not fence-like lines that appear as literal content inside an
+block delimiters, not fence-like lines that appear as literal content inside a
 larger fenced block. A user should be able to format Markdown that uses four or
 more backticks, or longer tilde fences, to contain inner triple-backtick or
 triple-tilde examples without the inner examples being rewritten or treated as
@@ -89,6 +89,9 @@ The active regression targets are:
   integration-style behaviour.
 - [`tests/cli.rs`](../../tests/cli.rs) for end-to-end CLI behaviour with
   `--fences`.
+- [`tests/cli_fences.rs`](../../tests/cli_fences.rs) for additional
+  end-to-end CLI fence regressions, because `tests/cli.rs` is already close to
+  the repository's 400-line limit.
 - [`src/wrap/tests/fence_tracker.rs`](../../src/wrap/tests/fence_tracker.rs)
   for the shared tracker semantics.
 - [`tests/wrap_unit.rs`](../../tests/wrap_unit.rs) if one additional wrapping
@@ -185,8 +188,8 @@ not an active Cargo integration target in this repository.
   - Severity: medium
   - Likelihood: medium
   - Mitigation: keep new behavioural coverage in `tests/fences.rs`,
-    `tests/cli.rs`, `tests/wrap_unit.rs`, or another top-level `tests/*.rs`
-    target only.
+    `tests/cli.rs`, `tests/cli_fences.rs`, `tests/wrap_unit.rs`, or another
+    top-level `tests/*.rs` target only.
 
 - Risk: `src/fences.rs` is already moderately sized, and the extra stateful
   logic could make it harder to read.
@@ -199,16 +202,28 @@ not an active Cargo integration target in this repository.
 
 - [x] (2026-04-23 00:00Z) Reviewed the current fence preprocessing code, the
   shared `FenceTracker`, and the active test targets.
-- [ ] Add failing regressions for nested backticks, nested tildes, and mixed
-  backtick-versus-tilde nesting.
-- [ ] Refactor `compress_fences` to use shared fence-state tracking and retain
-  original outer fence width when required for same-marker nesting safety.
-- [ ] Refactor `attach_orphan_specifiers` so it ignores content inside active
-  fenced blocks.
-- [ ] Extend `FenceTracker` tests to lock in the nested-fence expectations used
-  by preprocessing.
-- [ ] Run focused tests, then the full required quality gates, and update this
-  ExecPlan with outcomes.
+- [x] (2026-04-24 00:00Z) Began implementation after explicit approval to
+  proceed, with the plan status updated to `IN PROGRESS`.
+- [x] (2026-04-24 00:00Z) Added failing regressions for nested backticks,
+  nested tildes, mixed marker nesting, orphan specifier attachment inside an
+  outer fence, and CLI `--fences` behaviour. The new red tests failed before
+  the implementation in `tests/fences.rs` and `tests/cli_fences.rs`.
+- [x] (2026-04-24 00:00Z) Refactored `compress_fences` to analyse matched
+  fenced blocks with `FenceTracker`, preserve nested literal fence content, and
+  keep unsafe outer delimiter widths and marker families unchanged.
+- [x] (2026-04-24 00:00Z) Refactored `attach_orphan_specifiers` to track active
+  fenced blocks and avoid attaching specifier-like lines inside them.
+- [x] (2026-04-24 00:00Z) Extended `FenceTracker` tests with explicit
+  same-marker and mixed-marker nested-fence expectations.
+- [x] (2026-04-24 00:00Z) Focused validation passed:
+  `cargo test --test fences`, `cargo test --test cli_fences`,
+  `cargo test --test cli`, and `cargo test fence_tracker`.
+- [x] (2026-04-24 00:00Z) Ran the full required quality gates:
+  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie`.
+- [x] (2026-04-24 00:00Z) Updated `docs/architecture.md` to state that fence
+  normalization now shares `FenceTracker` semantics and only compresses outer
+  delimiters when doing so is structurally safe.
 
 ## Surprises & discoveries
 
@@ -230,6 +245,17 @@ not an active Cargo integration target in this repository.
   Cargo in this repository. New regressions must live in active top-level test
   targets.
 
+- Discovery: `tests/cli.rs` was already 392 lines before this work, so adding
+  the CLI regression there would have pushed it over the repository's 400-line
+  code-file limit. The end-to-end nested fence case now lives in the active
+  top-level integration target `tests/cli_fences.rs`.
+
+- Discovery: the existing mixed-marker regression covers malformed input where
+  a tilde opening is followed by a backtick delimiter, or vice versa, without a
+  matching same-marker close. To keep that legacy behaviour stable,
+  `compress_fences` only enables stateful shielding after confirming the
+  opening delimiter has a real matching close in the original input.
+
 ## Decision log
 
 - Decision: plan around shared fence-state semantics instead of duplicating the
@@ -248,6 +274,17 @@ not an active Cargo integration target in this repository.
   examples require the outer delimiter width to remain greater than the inner
   literal fence width, otherwise the formatted output becomes structurally
   incorrect. Date/Author: 2026-04-24 / Codex.
+
+- Decision: keep unmatched delimiter runs on the legacy stateless normalization
+  path. Rationale: existing tests rely on mixed-marker malformed input being
+  normalized line by line, while valid matched fenced blocks need stateful
+  shielding to preserve literal nested examples. Date/Author: 2026-04-24 /
+  Codex.
+
+- Decision: add the new CLI regression in `tests/cli_fences.rs` instead of
+  `tests/cli.rs`. Rationale: `tests/cli.rs` was too close to the 400-line file
+  limit, and a separate active integration target preserves coverage without
+  creating a file-size violation. Date/Author: 2026-04-24 / Codex.
 
 ## Plan of work
 
@@ -375,4 +412,17 @@ Expected:
 
 ## Outcomes & retrospective
 
-Pending implementation approval.
+Implemented nested-fence-safe normalization for `mdtablefix --fences`.
+`compress_fences` now analyses matched fenced blocks with `FenceTracker`,
+preserves literal nested fence-like lines, and keeps outer delimiters unchanged
+when shortening or changing their marker family would make nested literal
+content structural. `attach_orphan_specifiers` now tracks active fenced blocks
+so specifier-like lines inside an outer fence remain content.
+
+The implementation kept existing legacy behaviour for unmatched mixed-marker
+input by using the stateful shielding path only when a matching close exists in
+the original input. This preserved the existing regression expectations while
+fixing the valid nested-fence cases from issue `#262`.
+
+Validation passed with `make check-fmt`, `make lint`, `make test`,
+`make markdownlint`, and `make nixie`.

--- a/docs/execplans/issue-262-nested-code-block-handling.md
+++ b/docs/execplans/issue-262-nested-code-block-handling.md
@@ -451,9 +451,13 @@ Expected:
 - `FenceTracker` tests explicitly cover the outer-four-backticks and
   outer-tildes cases, including shorter inner tilde runs, that govern the new
   preprocessing behaviour.
-- `cargo test --test fences`, `cargo test --test cli_fences` for
-  `tests/cli_fences.rs`, `make check-fmt`, `make lint`, and `make test` all
-  pass.
+- Validation commands all pass:
+  - `cargo test --test fences`
+  - `cargo test --test cli_fences` (runs `tests/cli_fences.rs`)
+  - `cargo test fence_tracker` (covers the shared tracker target)
+  - `make check-fmt`
+  - `make lint`
+  - `make test`
 - If architecture documentation is updated, `make fmt`, `make markdownlint`,
   and `make nixie` also pass.
 

--- a/docs/execplans/replace-bespoke-wrapping-with-textwrap-and-unicode-width.md
+++ b/docs/execplans/replace-bespoke-wrapping-with-textwrap-and-unicode-width.md
@@ -1,9 +1,8 @@
 # Replace bespoke wrapping with `textwrap` and `unicode-width`
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
 
@@ -180,8 +179,8 @@ the plan prefers a smaller, safer first delivery and a follow-up issue.
 - Observation: the post-processing pass that rebalances trailing atomic or
   plain fragments can invalidate `wrap_first_fit`'s width guarantee if it moves
   a fragment without rechecking the destination line width. Evidence:
-  `rebalance_atomic_tails` on 2026-04-23 could turn `a four` / `five` into `a`
-  / `four five` at width `6`. Impact: any heuristic that mutates fitted lines
+  `rebalance_atomic_tails` on 2026-04-23 could turn `a four` / `five` into `a` /
+   `four five` at width `6`. Impact: any heuristic that mutates fitted lines
   after wrapping must be width-aware, or it can regress downstream layout
   assumptions.
 

--- a/docs/execplans/yaml-frontmatter.md
+++ b/docs/execplans/yaml-frontmatter.md
@@ -1,9 +1,8 @@
 # Preserve leading YAML frontmatter while formatting Markdown
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: DELIVERED
 
@@ -181,8 +180,8 @@ Stage D adds regression coverage. Put detector-specific unit tests in
 `src/frontmatter.rs` and a pipeline regression in `src/process.rs` or a small
 new test module. Add at least one behavioural CLI test in `tests/cli.rs`
 covering a document with leading frontmatter plus a paragraph or table body.
-The CLI test should enable `--breaks` and one ordinary formatting option such
-as `--wrap` so it proves both preservation and continued formatting.
+The CLI test should enable `--breaks` and one ordinary formatting option such as
+ `--wrap` so it proves both preservation and continued formatting.
 
 Stage E updates the docs. Add a short YAML frontmatter note and example to
 `README.md` so users know the block is preserved. Update `docs/architecture.md`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -7,8 +7,8 @@ Linux release targets.
 The project targets the stable Rust `1.89.0` toolchain, as specified in
 `rust-toolchain.toml`.
 
-This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml`
-(`rust-version = "1.89"`). The `build-test` job in `.github/workflows/ci.yml`
+This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml` (
+`rust-version = "1.89"`). The `build-test` job in `.github/workflows/ci.yml`
 uses this toolchain to guard against regressions.
 
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,8 +8,8 @@ The project targets the stable Rust `1.89.0` toolchain, as specified in
 `rust-toolchain.toml`.
 
 This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml`
-(`rust-version = "1.89"`). The `build-test` job in
-`.github/workflows/ci.yml` uses this toolchain to guard against regressions.
+(`rust-version = "1.89"`). The `build-test` job in `.github/workflows/ci.yml`
+uses this toolchain to guard against regressions.
 
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -7,9 +7,9 @@ Linux release targets.
 The project targets the stable Rust `1.89.0` toolchain, as specified in
 `rust-toolchain.toml`.
 
-This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml` (
-`rust-version = "1.89"`). The `build-test` job in `.github/workflows/ci.yml`
-uses this toolchain to guard against regressions.
+This Minimum Supported Rust Version (MSRV) is also declared in `Cargo.toml`
+(`rust-version = "1.89"`). The `build-test` job in
+`.github/workflows/ci.yml` uses this toolchain to guard against regressions.
 
 The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
 binaries for:

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -40,8 +40,8 @@ block found in the documentation comments[^3]:
 
 4. **Execution and Verification**: Finally, if compilation succeeds, the
    resulting executable is run. The test is considered to have passed if the
-   program runs to completion without panicking. The executable is then deleted.
-   [^2]
+   program runs to completion without panicking. The executable is then
+   deleted. [^2]
 
 The significance of this model cannot be overstated. It effectively transforms
 every doctest into a true integration test.[^6] The test code does not have
@@ -147,10 +147,10 @@ function within the doctest that returns a Result. This leverages the
 Termination trait, which is implemented for Result. The surrounding boilerplate
 can then be hidden from the rendered documentation.
 
-```Rust
+```rust
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// # use std::error::Error;
 /// #
 /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -171,10 +171,10 @@ rustdoc provides a lesser-known but more concise shorthand for this exact
 scenario. If a code block ends with the literal token (()), rustdoc will
 automatically wrap the code in a main function that returns a Result.
 
-```Rust
+```rust
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// let config = "key=value".parse::<MyConfig>()?;
 /// assert_eq!(config.get("key"), Some("value"));
 /// (()) // Note: No whitespace between parentheses
@@ -200,8 +200,7 @@ primary use cases include:
 
 1. **Hiding** `main` **Wrappers**: As demonstrated in the error-handling
    examples, the entire `fn main() -> Result<...> {... }` and `Ok(())`
-   scaffolding can be hidden, presenting the user with only the relevant code.[
-   ^9]
+   scaffolding can be hidden, showing only the relevant code.[^9]
 
 2. **Hiding Setup Code**: If an example requires some preliminary setup—like
    creating a temporary file, defining a helper struct for the test, or
@@ -273,8 +272,8 @@ table provides a comparative reference for the most common doctest attributes.
 
 - `edition20xx`: This attribute allows an example to be tested against a
   specific Rust edition. This is important for crates that support multiple
-  editions and need to demonstrate edition-specific features or migration paths.
-  [^4]
+  editions and need to demonstrate edition-specific features or migration
+  paths. [^4]
 
 ## The DRY Principle in Doctests: Managing Shared and Complex Logic
 
@@ -311,14 +310,14 @@ any pollution of the final binary or the public API.
 The typical implementation pattern is to create a private helper module within
 the library:
 
-```Rust
+```rust
 // In lib.rs or a submodule
 
 /// A function that requires a complex environment to test.
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// # use crate::doctest_helpers::setup_test_environment;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut ctx = setup_test_environment()?;
@@ -397,7 +396,7 @@ builds.[^13]
 
 **The Pattern**:
 
-```Rust
+```rust
 /// A socket that is only available on Unix platforms.
 #[cfg(any(target_os = "unix", doc))]
 pub struct UnixSocket;
@@ -431,10 +430,10 @@ Pattern 1: #\[cfg\] Inside the Code Block
 This pattern involves placing a #\[cfg\] attribute directly on the code within
 the doctest itself.
 
-```Rust
+```rust
 /// This example only runs if the "serde" feature is enabled.
 ///
-/// ```
+/// ```rust
 /// # #[cfg(feature = "serde")]
 /// # {
 /// #   let my_struct = MyStruct::new();
@@ -455,7 +454,7 @@ A more explicit and accurate pattern uses the cfg_attr attribute to
 conditionally add the ignore flag to the doctest's header. This is typically
 done with inner doc comments (//!).
 
-```Rust
+```rust
 //! #![cfg_attr(not(feature = "serde"), doc = "```ignore")]
 //! #![cfg_attr(feature = "serde", doc = "```")]
 //! // Example code that requires the "serde" feature.
@@ -479,7 +478,7 @@ feature-gated items in the generated documentation. This is achieved with the
 `#[doc(cfg(...))]` attribute, which requires enabling the
 `#![feature(doc_cfg)]` feature gate at the crate root.
 
-```Rust
+```rust
 // At the crate root (lib.rs)
 #![feature(doc_cfg)]
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -40,8 +40,8 @@ block found in the documentation comments[^3]:
 
 4. **Execution and Verification**: Finally, if compilation succeeds, the
    resulting executable is run. The test is considered to have passed if the
-   program runs to completion without panicking. The executable is then
-   deleted.[^2]
+   program runs to completion without panicking. The executable is then deleted.
+   [^2]
 
 The significance of this model cannot be overstated. It effectively transforms
 every doctest into a true integration test.[^6] The test code does not have
@@ -104,8 +104,8 @@ Doctests reside within documentation comments. Rust recognizes two types:
   (e.g., a module or the crate itself). They are typically used at the top of
   `lib.rs` or `mod.rs` to provide crate- or module-level documentation.[^8]
 
-Within these comments, a code block is denoted by triple back-ticks (```).
-While `rustdoc` defaults to Rust syntax, explicitly add the `rust` language
+Within these comments, a code block is denoted by triple back-ticks (```). While
+ `rustdoc` defaults to Rust syntax, explicitly add the `rust` language
 specifier for clarity.[^3] A doctest "passes" when it compiles and runs without
 panicking. To assert specific outcomes, use the standard macros `assert!`,
 `assert_eq!`, and `assert_ne!`.[^3]
@@ -200,8 +200,8 @@ primary use cases include:
 
 1. **Hiding** `main` **Wrappers**: As demonstrated in the error-handling
    examples, the entire `fn main() -> Result<...> {... }` and `Ok(())`
-   scaffolding can be hidden, presenting the user with only the relevant
-   code.[^9]
+   scaffolding can be hidden, presenting the user with only the relevant code.[
+   ^9]
 
 2. **Hiding Setup Code**: If an example requires some preliminary setup—like
    creating a temporary file, defining a helper struct for the test, or
@@ -273,8 +273,8 @@ table provides a comparative reference for the most common doctest attributes.
 
 - `edition20xx`: This attribute allows an example to be tested against a
   specific Rust edition. This is important for crates that support multiple
-  editions and need to demonstrate edition-specific features or migration
-  paths.[^4]
+  editions and need to demonstrate edition-specific features or migration paths.
+  [^4]
 
 ## The DRY Principle in Doctests: Managing Shared and Complex Logic
 
@@ -403,10 +403,10 @@ builds.[^13]
 pub struct UnixSocket;
 ```
 
-This `any` directive ensures the struct is compiled either when the target OS
-is `unix` OR when `rustdoc` is running. This correctly makes the item visible
-in the generated HTML. However, it is crucial to understand that this **does
-not** make the doctest for `UnixSocket` pass on non-Unix platforms.
+This `any` directive ensures the struct is compiled either when the target OS is
+ `unix` OR when `rustdoc` is running. This correctly makes the item visible in
+the generated HTML. However, it is crucial to understand that this **does not**
+make the doctest for `UnixSocket` pass on non-Unix platforms.
 
 This distinction highlights the "cfg duality." The `#[cfg(doc)]` attribute
 controls the *table of contents* of the documentation; it determines which

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -25,8 +25,8 @@ Managing this setup and teardown logic within each test function can lead to
 considerable boilerplate code and repetition, making tests harder to read and
 maintain.
 
-Fixtures address this by encapsulating these dependencies and their setup logic.
-[^1] For instance, if multiple tests require a logged-in user object or a
+Fixtures address this by encapsulating these dependencies and their setup
+logic.[^1] For instance, if multiple tests require a logged-in user object or a
 pre-populated database, instead of creating these in every test, a fixture can
 provide them. This approach allows developers to focus on the specific logic
 being tested rather than the auxiliary utilities.
@@ -768,8 +768,8 @@ To improve the ergonomics of working with async fixtures and values in tests,
   its type is `impl Future<Output = T>`. The `#[future]` attribute on such an
   argument allows developers to refer to it with type `T` directly in the test
   signature, removing the `impl Future` boilerplate. However, the value still
-  needs to be `.await`ed explicitly within the test body or by using `#[awt]`.[
-  ^4]
+  needs to be `.await`ed explicitly within the test body or by using
+  `#[awt]`.[^4]
 - `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire
   test function (`#[awt]`) or a specific `#[future]` argument (
   `#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
@@ -1284,15 +1284,15 @@ tests.
 
 The `test-with` crate allows for conditional execution of tests based on
 various runtime conditions, such as the presence of environment variables, the
-existence of specific files or folders, or the availability of network services.
-[^22] It can be used in conjunction with `rstest`. For example, an `rstest`
-test could be further annotated with `test-with` attributes to ensure it only
-runs if a particular database configuration file exists or if a dependent web
-service is reachable. The order of macros is important: `rstest` should
-typically generate the test cases first, and then `test-with` can apply its
-conditional execution logic to these generated tests.[^22] This allows `rstest`
-to focus on test structure and data provision, while `test-with` provides an
-orthogonal layer of control over test execution conditions.
+existence of specific files or folders, or the availability of network
+services. [^22] It can be used in conjunction with `rstest`. For example, an
+`rstest` test could be further annotated with `test-with` attributes to ensure
+it only runs if a particular database configuration file exists or if a
+dependent web service is reachable. The order of macros is important: `rstest`
+should typically generate the test cases first, and then `test-with` can apply
+its conditional execution logic to these generated tests.[^22] This allows
+`rstest` to focus on test structure and data provision, while `test-with`
+provides an orthogonal layer of control over test execution conditions.
 
 ## XI. Conclusion and Further Resources
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1276,23 +1276,22 @@ For developers who rely on logging frameworks like `log` or `tracing` for
 debugging tests, the `rstest-log` crate can simplify integration.[^21] Test
 runners often capture standard output and error streams, and logging frameworks
 require proper initialization. `rstest-log` likely provides attributes or
-wrappers to ensure that logging is correctly set up before each `rstest`
--generated test case runs, making it easier to get consistent log output from
-tests.
+wrappers to ensure that logging is correctly set up before each
+`rstest`-generated test case runs, making consistent log output easier.
 
 ### B. `test-with`: Conditional Testing with `rstest`
 
 The `test-with` crate allows for conditional execution of tests based on
 various runtime conditions, such as the presence of environment variables, the
 existence of specific files or folders, or the availability of network
-services. [^22] It can be used in conjunction with `rstest`. For example, an
-`rstest` test could be further annotated with `test-with` attributes to ensure
-it only runs if a particular database configuration file exists or if a
-dependent web service is reachable. The order of macros is important: `rstest`
-should typically generate the test cases first, and then `test-with` can apply
-its conditional execution logic to these generated tests.[^22] This allows
-`rstest` to focus on test structure and data provision, while `test-with`
-provides an orthogonal layer of control over test execution conditions.
+services. [^22] It can be used with `rstest`. For example, an `rstest` test
+could be further annotated with `test-with` attributes to ensure it only runs
+if a particular database configuration file exists or if a dependent web
+service is reachable. The order of macros is important: `rstest` should
+typically generate the test cases first, and then `test-with` can apply its
+conditional execution logic to these generated tests.[^22] This allows `rstest`
+to focus on test structure and data provision, while `test-with` provides an
+orthogonal layer of control over test execution conditions.
 
 ## XI. Conclusion and Further Resources
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -25,8 +25,8 @@ Managing this setup and teardown logic within each test function can lead to
 considerable boilerplate code and repetition, making tests harder to read and
 maintain.
 
-Fixtures address this by encapsulating these dependencies and their setup
-logic.[^1] For instance, if multiple tests require a logged-in user object or a
+Fixtures address this by encapsulating these dependencies and their setup logic.
+[^1] For instance, if multiple tests require a logged-in user object or a
 pre-populated database, instead of creating these in every test, a fixture can
 provide them. This approach allows developers to focus on the specific logic
 being tested rather than the auxiliary utilities.
@@ -768,11 +768,11 @@ To improve the ergonomics of working with async fixtures and values in tests,
   its type is `impl Future<Output = T>`. The `#[future]` attribute on such an
   argument allows developers to refer to it with type `T` directly in the test
   signature, removing the `impl Future` boilerplate. However, the value still
-  needs to be `.await`ed explicitly within the test body or by using
-  `#[awt]`.[^4]
+  needs to be `.await`ed explicitly within the test body or by using `#[awt]`.[
+  ^4]
 - `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire
-  test function (`#[awt]`) or a specific `#[future]` argument
-  (`#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
+  test function (`#[awt]`) or a specific `#[future]` argument (
+  `#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
   those futures.
 
 ```rust
@@ -918,9 +918,9 @@ By encapsulating temporary resource management within fixtures, tests become
 cleaner and less prone to errors related to resource setup or cleanup. The RAII
 (Resource Acquisition Is Initialization) pattern, common in Rust and
 exemplified by `tempfile::TempDir` (which cleans up the directory when
-dropped), works effectively with `rstest`'s fixture model. When a regular
-(non-`#[once]`) fixture returns a `TempDir` object, or an object that owns it,
-the resource is typically cleaned up after the test finishes, as the fixture's
+dropped), works effectively with `rstest`'s fixture model. When a regular (non-
+`#[once]`) fixture returns a `TempDir` object, or an object that owns it, the
+resource is typically cleaned up after the test finishes, as the fixture's
 return value goes out of scope. This localizes resource management logic to the
 fixture, keeping the test focused on its assertions. For temporary resources,
 regular (per-test) fixtures are generally preferred over `#[once]` fixtures to
@@ -1276,23 +1276,23 @@ For developers who rely on logging frameworks like `log` or `tracing` for
 debugging tests, the `rstest-log` crate can simplify integration.[^21] Test
 runners often capture standard output and error streams, and logging frameworks
 require proper initialization. `rstest-log` likely provides attributes or
-wrappers to ensure that logging is correctly set up before each
-`rstest`-generated test case runs, making it easier to get consistent log
-output from tests.
+wrappers to ensure that logging is correctly set up before each `rstest`
+-generated test case runs, making it easier to get consistent log output from
+tests.
 
 ### B. `test-with`: Conditional Testing with `rstest`
 
 The `test-with` crate allows for conditional execution of tests based on
 various runtime conditions, such as the presence of environment variables, the
-existence of specific files or folders, or the availability of network
-services.[^22] It can be used in conjunction with `rstest`. For example, an
-`rstest` test could be further annotated with `test-with` attributes to ensure
-it only runs if a particular database configuration file exists or if a
-dependent web service is reachable. The order of macros is important: `rstest`
-should typically generate the test cases first, and then `test-with` can apply
-its conditional execution logic to these generated tests.[^22] This allows
-`rstest` to focus on test structure and data provision, while `test-with`
-provides an orthogonal layer of control over test execution conditions.
+existence of specific files or folders, or the availability of network services.
+[^22] It can be used in conjunction with `rstest`. For example, an `rstest`
+test could be further annotated with `test-with` attributes to ensure it only
+runs if a particular database configuration file exists or if a dependent web
+service is reachable. The order of macros is important: `rstest` should
+typically generate the test cases first, and then `test-with` can apply its
+conditional execution logic to these generated tests.[^22] This allows `rstest`
+to focus on test structure and data provision, while `test-with` provides an
+orthogonal layer of control over test execution conditions.
 
 ## XI. Conclusion and Further Resources
 
@@ -1342,20 +1342,20 @@ provided by `rstest`:
 
 **Table 2: Key** `rstest` **Attributes Quick Reference**
 
-| Attribute                    | Core Purpose                                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| #[rstest]                    | Marks a function as a rstest test; enables fixture injection and parameterization.           |
-| #[fixture]                   | Defines a function that provides a test fixture (setup data or services).                    |
-| #[case(…)]                   | Defines a single parameterized test case with specific input values.                         |
-| #[values(…)]                 | Defines a list of values for an argument, generating tests for each value or combination.    |
-| #[once]                      | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
-| #[future]                    | Simplifies async argument types by removing impl Future boilerplate.                         |
-| #[awt]                       | (Function or argument level) Automatically .awaits future arguments in async tests.          |
-| #[from(original_name)]       | Allows renaming an injected fixture argument in the test function.                           |
-| #[with(…)]                   | Overrides default arguments of a fixture for a specific test.                                |
-| #[default(…)]                | Provides default values for arguments within a fixture function.                             |
-| #[timeout(…)]                | Sets a timeout for an asynchronous test.                                                     |
-| #[files("glob_pattern",…)]   | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
+| Attribute                  | Core Purpose                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| #[rstest]                  | Marks a function as a rstest test; enables fixture injection and parameterization.           |
+| #[fixture]                 | Defines a function that provides a test fixture (setup data or services).                    |
+| #[case(…)]                 | Defines a single parameterized test case with specific input values.                         |
+| #[values(…)]               | Defines a list of values for an argument, generating tests for each value or combination.    |
+| #[once]                    | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
+| #[future]                  | Simplifies async argument types by removing impl Future boilerplate.                         |
+| #[awt]                     | (Function or argument level) Automatically .awaits future arguments in async tests.          |
+| #[from(original_name)]     | Allows renaming an injected fixture argument in the test function.                           |
+| #[with(…)]                 | Overrides default arguments of a fixture for a specific test.                                |
+| #[default(…)]              | Provides default values for arguments within a fixture function.                             |
+| #[timeout(…)]              | Sets a timeout for an asynchronous test.                                                     |
+| #[files("glob_pattern",…)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 
 Mastering `rstest` can significantly elevate the quality and efficiency of
 testing practices for Rust developers, leading to more reliable and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -57,10 +57,10 @@ Pass `--fences` to normalise fenced code block delimiters before other
 processing. Safe outer fences are compressed to three backticks, which keeps
 simple code blocks consistent before later formatting steps run.
 
-Outer delimiters are compressed only when doing so is structurally safe. If a
-four-or-more-backtick fence, or a longer tilde fence, wraps literal inner
-fence-like content from the same marker family, the outer delimiter width is
-kept, so the inner content does not become a structural close after formatting.
+Outer delimiters are compressed only when doing so is structurally safe. If
+normalisation would turn an inner literal fence into a structural close, the
+outer fence is kept. This includes same-marker nested fences and the mixed case
+where a tilde outer fence wraps a literal inner backtick fence.
 
 `--fences` also attaches a lone language identifier immediately above an
 unlabelled fence to that fence. This orphan-specifier attachment only happens

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -51,16 +51,17 @@ Two trailing spaces at the end of a line produce a hard line break in rendered
 Markdown. `mdtablefix --wrap` preserves those trailing spaces on the final
 wrapped line, so hard-break semantics are not lost after reformatting.
 
-## Fence normalisation
+## Fence normalization
 
-Pass `--fences` to normalise fenced code block delimiters before other
+Pass `--fences` to normalize fenced code block delimiters before other
 processing. Safe outer fences are compressed to three backticks, which keeps
 simple code blocks consistent before later formatting steps run.
 
 Outer delimiters are compressed only when doing so is structurally safe. If
-normalisation would turn an inner literal fence into a structural close, the
-outer fence is kept. This includes same-marker nested fences and the mixed case
-where a tilde outer fence wraps a literal inner backtick fence.
+normalization would turn an inner literal fence into a structural close, the
+outer fence is kept, so the inner content remains literal. Preservation applies
+when the inner fence uses the same marker character as the outer fence, or when
+a tilde outer fence wraps a literal inner backtick fence.
 
 `--fences` also attaches a lone language identifier immediately above an
 unlabelled fence to that fence. This orphan-specifier attachment only happens
@@ -82,3 +83,15 @@ After running `mdtablefix --fences`:
     fn main() {}
     ```
     ````
+
+Before:
+
+    ````rust
+    fn main() {}
+    ````
+
+After running `mdtablefix --fences`:
+
+    ```rust
+    fn main() {}
+    ```

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -50,3 +50,39 @@ is applied only to prose paragraphs and prefixed lines.
 Two trailing spaces at the end of a line produce a hard line break in rendered
 Markdown. `mdtablefix --wrap` preserves those trailing spaces on the final
 wrapped line, so hard-break semantics are not lost after reformatting.
+
+## Fence normalisation
+
+Pass `--fences` to normalise fenced code block delimiters before other
+processing. Safe outer fences are compressed to three backticks, which keeps
+simple code blocks consistent before later formatting steps run.
+
+Outer delimiters are compressed only when doing so is structurally safe. If a
+four-or-more-backtick fence, or a longer tilde fence, wraps literal inner
+fence-like content from the same marker family, the outer delimiter width is
+kept so the inner content does not become a structural close after formatting.
+
+`--fences` also attaches a lone language identifier immediately above an
+unlabelled fence to that fence. This orphan-specifier attachment only happens
+when both the identifier line and the target fence are outside any already-open
+fenced block.
+
+Before:
+
+`````markdown
+````markdown
+```rust
+fn main() {}
+```
+````
+`````
+
+After running `mdtablefix --fences`:
+
+`````markdown
+````markdown
+```rust
+fn main() {}
+```
+````
+`````

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -69,20 +69,16 @@ fenced block.
 
 Before:
 
-`````markdown
-````markdown
-```rust
-fn main() {}
-```
-````
-`````
+    ````markdown
+    ```rust
+    fn main() {}
+    ```
+    ````
 
 After running `mdtablefix --fences`:
 
-`````markdown
-````markdown
-```rust
-fn main() {}
-```
-````
-`````
+    ````markdown
+    ```rust
+    fn main() {}
+    ```
+    ````

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -60,7 +60,7 @@ simple code blocks consistent before later formatting steps run.
 Outer delimiters are compressed only when doing so is structurally safe. If a
 four-or-more-backtick fence, or a longer tilde fence, wraps literal inner
 fence-like content from the same marker family, the outer delimiter width is
-kept so the inner content does not become a structural close after formatting.
+kept, so the inner content does not become a structural close after formatting.
 
 `--fences` also attaches a lone language identifier immediately above an
 unlabelled fence to that fence. This orphan-specifier attachment only happens

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -1,12 +1,12 @@
 //! Pre-processing utilities for normalizing fenced code block delimiters.
 //!
-//! `compress_fences` reduces any sequence of three or more backticks or
-//! tildes followed by optional language identifiers to exactly three
-//! backticks.
-//! It preserves indentation and the language list.
+//! `compress_fences` reduces safe outer delimiters to three backticks while
+//! preserving nested fence-like content whose marker runs are literal text.
 use std::sync::LazyLock;
 
 use regex::Regex;
+
+use crate::wrap::{FenceTracker, is_fence};
 
 static FENCE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\s*)(`{3,}|~{3,})([A-Za-z0-9_+.,-]*)\s*$").unwrap());
@@ -61,9 +61,109 @@ fn normalize_specifier(line: &str) -> (String, String) {
     (cleaned, indent)
 }
 
-/// Compress backtick fences to exactly three backticks.
+#[derive(Clone, Copy)]
+enum FenceRewrite {
+    Compress,
+    PreserveDelimiters,
+    PreserveAll,
+}
+
+struct OpeningAnalysis {
+    rewrite: FenceRewrite,
+}
+
+fn marker_char(marker: &str) -> Option<char> { marker.chars().next() }
+
+fn fence_line_with_marker(line: &str, marker: &str) -> Option<String> {
+    let cap = FENCE_RE.captures(line)?;
+    let indent = cap.get(1).map_or("", |m| m.as_str());
+    let lang = cap.get(3).map_or("", |m| m.as_str());
+    Some(if is_null_lang(lang) {
+        format!("{indent}{marker}")
+    } else {
+        format!("{indent}{marker}{lang}")
+    })
+}
+
+fn compressed_fence_line(line: &str) -> Option<String> { fence_line_with_marker(line, "```") }
+
+fn preserved_fence_line(line: &str) -> Option<String> {
+    let marker = FENCE_RE
+        .captures(line)
+        .and_then(|cap| cap.get(2))
+        .map(|m| m.as_str())?;
+    fence_line_with_marker(line, marker)
+}
+
+fn interior_fence_requires_preserved_delimiters(opening_marker: &str, line: &str) -> bool {
+    let Some((_indent, marker, _info)) = is_fence(line) else {
+        return false;
+    };
+    let Some(opening_ch) = marker_char(opening_marker) else {
+        return false;
+    };
+    let Some(marker_ch) = marker_char(marker) else {
+        return false;
+    };
+    marker_ch == opening_ch || marker_ch == '`'
+}
+
+fn analyze_opening(lines: &[String], opening_index: usize) -> Option<OpeningAnalysis> {
+    let (_indent, opening_marker, _info) = is_fence(&lines[opening_index])?;
+
+    let mut tracker = FenceTracker::new();
+    if !tracker.observe(&lines[opening_index]) {
+        return None;
+    }
+
+    let mut has_conflicting_interior_fence = false;
+    for line in lines.iter().skip(opening_index + 1) {
+        let was_in_fence = tracker.in_fence();
+        let observed_fence = tracker.observe(line);
+        if observed_fence && was_in_fence && !tracker.in_fence() {
+            return Some(OpeningAnalysis {
+                rewrite: opening_rewrite(lines, opening_index, has_conflicting_interior_fence),
+            });
+        }
+        if was_in_fence && interior_fence_requires_preserved_delimiters(opening_marker, line) {
+            has_conflicting_interior_fence = true;
+        }
+    }
+
+    None
+}
+
+fn opening_rewrite(
+    lines: &[String],
+    index: usize,
+    has_conflicting_interior_fence: bool,
+) -> FenceRewrite {
+    if FENCE_RE.captures(&lines[index]).is_none() {
+        return FenceRewrite::PreserveAll;
+    }
+    if has_conflicting_interior_fence {
+        FenceRewrite::PreserveDelimiters
+    } else {
+        FenceRewrite::Compress
+    }
+}
+
+fn rewrite_fence_line(line: &str, rewrite: FenceRewrite) -> String {
+    match rewrite {
+        FenceRewrite::Compress => compressed_fence_line(line).unwrap_or_else(|| line.to_owned()),
+        FenceRewrite::PreserveDelimiters => {
+            preserved_fence_line(line).unwrap_or_else(|| line.to_owned())
+        }
+        FenceRewrite::PreserveAll => line.to_owned(),
+    }
+}
+
+/// Compress safe outer fences to exactly three backticks.
 ///
 /// Lines that do not start with backtick fences are returned unchanged.
+/// Fence-like lines inside a wider fenced block are literal content and are
+/// returned unchanged. An outer delimiter is also preserved when shortening or
+/// changing it would make an inner literal fence line look structural.
 ///
 /// # Examples
 ///
@@ -74,22 +174,40 @@ fn normalize_specifier(line: &str) -> (String, String) {
 /// ```
 #[must_use]
 pub fn compress_fences(lines: &[String]) -> Vec<String> {
-    lines
-        .iter()
-        .map(|line| {
-            if let Some(cap) = FENCE_RE.captures(line) {
-                let indent = cap.get(1).map_or("", |m| m.as_str());
-                let lang = cap.get(3).map_or("", |m| m.as_str());
-                if is_null_lang(lang) {
-                    format!("{indent}```")
-                } else {
-                    format!("{indent}```{lang}")
-                }
-            } else {
-                line.clone()
-            }
-        })
-        .collect()
+    let mut tracker = FenceTracker::new();
+    let mut active_rewrite = None;
+    let mut out = Vec::with_capacity(lines.len());
+
+    for (index, line) in lines.iter().enumerate() {
+        if !tracker.in_fence() {
+            let Some(analysis) = analyze_opening(lines, index) else {
+                out.push(compressed_fence_line(line).unwrap_or_else(|| line.clone()));
+                continue;
+            };
+
+            let _ = tracker.observe(line);
+            let rewrite = analysis.rewrite;
+            active_rewrite = Some(rewrite);
+            out.push(rewrite_fence_line(line, rewrite));
+            continue;
+        }
+
+        let observed_fence = tracker.observe(line);
+        if !observed_fence {
+            out.push(line.clone());
+            continue;
+        }
+
+        if tracker.in_fence() {
+            out.push(line.clone());
+            continue;
+        }
+
+        let rewrite = active_rewrite.take().unwrap_or(FenceRewrite::PreserveAll);
+        out.push(rewrite_fence_line(line, rewrite));
+    }
+
+    out
 }
 
 /// Combine an opening fence with a language specifier.
@@ -108,16 +226,17 @@ pub fn compress_fences(lines: &[String]) -> Vec<String> {
 /// assert_eq!(attach_specifier_to_fence("  ```", "rust", "    "), "    ```rust");
 /// ```
 fn attach_specifier_to_fence(fence_line: &str, specifier: &str, spec_indent: &str) -> String {
-    let fence_indent = FENCE_RE
-        .captures(fence_line)
-        .and_then(|cap| cap.get(1))
-        .map_or("", |m| m.as_str());
+    let Some(cap) = FENCE_RE.captures(fence_line) else {
+        return fence_line.to_owned();
+    };
+    let fence_indent = cap.get(1).map_or("", |m| m.as_str());
+    let fence_marker = cap.get(2).map_or("```", |m| m.as_str());
     let final_indent = if fence_indent.is_empty() || spec_indent.starts_with(fence_indent) {
         spec_indent
     } else {
         fence_indent
     };
-    format!("{final_indent}```{specifier}")
+    format!("{final_indent}{fence_marker}{specifier}")
 }
 
 fn orphan_specifier_target(lines: &[String], start: usize) -> Option<usize> {
@@ -167,24 +286,35 @@ fn orphan_specifier_target_without_language(lines: &[String], start: usize) -> O
 #[must_use]
 pub fn attach_orphan_specifiers(lines: &[String]) -> Vec<String> {
     let mut out = Vec::with_capacity(lines.len());
+    let mut tracker = FenceTracker::new();
     let mut i = 0;
 
     while i < lines.len() {
         let line = &lines[i];
-        let (spec, indent) = normalize_specifier(line);
-        if ORPHAN_LANG_RE.is_match(&spec) && out.last().is_none_or(|l: &String| l.trim().is_empty())
-        {
-            if let Some(target) = orphan_specifier_target_without_language(lines, i + 1) {
-                out.push(attach_specifier_to_fence(&lines[target], &spec, &indent));
-                i = target + 1;
-                continue;
-            }
+        if tracker.in_fence() {
+            let _ = tracker.observe(line);
             out.push(line.clone());
             i += 1;
             continue;
         }
 
+        let (spec, indent) = normalize_specifier(line);
+        if ORPHAN_LANG_RE.is_match(&spec) && out.last().is_none_or(|l: &String| l.trim().is_empty())
+        {
+            if let Some(target) = orphan_specifier_target_without_language(lines, i + 1) {
+                out.push(attach_specifier_to_fence(&lines[target], &spec, &indent));
+                let _ = tracker.observe(&lines[target]);
+                i = target + 1;
+                continue;
+            }
+            out.push(line.clone());
+            let _ = tracker.observe(line);
+            i += 1;
+            continue;
+        }
+
         out.push(line.clone());
+        let _ = tracker.observe(line);
         i += 1;
     }
 

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -166,12 +166,18 @@ fn flush_original_block(block: PendingFenceBlock, out: &mut Vec<String>) {
 
 /// Normalize safe outer fence delimiters to exactly three backticks.
 ///
-/// Lines that are not fence delimiters are returned unchanged. Compatible
-/// backtick or tilde delimiters may be rewritten to three backticks when doing
-/// so preserves the document structure.
-/// Fence-like lines inside a wider fenced block are literal content and are
-/// returned unchanged. An outer delimiter is also preserved when shortening or
-/// changing it would make an inner literal fence line look structural.
+/// `compress_fences` returns non-fence lines unchanged. Compatible backtick or
+/// tilde delimiters in matched fenced blocks may be rewritten to three
+/// backticks when doing so preserves the document structure.
+/// Fence-like lines inside a wider matched fenced block are literal content and
+/// are returned unchanged. An outer delimiter is also preserved when
+/// shortening or changing it would make an inner literal fence line look
+/// structural.
+///
+/// Matched-block preservation does not apply to unclosed input. When input ends
+/// inside an unclosed fence, `compress_fences` uses `flush_unmatched_block` to
+/// fall back to stateless per-line rewriting, so fence-like lines inside that
+/// unclosed block may still be rewritten.
 ///
 /// # Examples
 ///

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -78,6 +78,7 @@ enum MarkerStrategy {
 
 struct PendingFenceBlock {
     opening_marker: String,
+    opening_rewritable: bool,
     has_conflicting_interior_fence: bool,
     lines: Vec<String>,
 }
@@ -159,6 +160,10 @@ fn flush_matched_block(block: PendingFenceBlock, out: &mut Vec<String>) {
     }
 }
 
+fn flush_original_block(block: PendingFenceBlock, out: &mut Vec<String>) {
+    out.extend(block.lines);
+}
+
 /// Normalize safe outer fence delimiters to exactly three backticks.
 ///
 /// Lines that are not fence delimiters are returned unchanged. Compatible
@@ -190,6 +195,7 @@ pub fn compress_fences(lines: &[String]) -> Vec<String> {
             let _ = tracker.observe(line);
             pending_block = Some(PendingFenceBlock {
                 opening_marker: opening_marker.to_owned(),
+                opening_rewritable: compressed_fence_line(line).is_some(),
                 has_conflicting_interior_fence: false,
                 lines: vec![line.clone()],
             });
@@ -220,7 +226,11 @@ pub fn compress_fences(lines: &[String]) -> Vec<String> {
             continue;
         }
 
-        flush_matched_block(block, &mut out);
+        if block.opening_rewritable && compressed_fence_line(line).is_some() {
+            flush_matched_block(block, &mut out);
+        } else {
+            flush_original_block(block, &mut out);
+        }
     }
 
     if let Some(block) = pending_block {

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -183,10 +183,6 @@ pub fn compress_fences(lines: &[String]) -> Vec<String> {
 
     for line in lines {
         if !tracker.in_fence() {
-            if FENCE_RE.captures(line).is_none() {
-                out.push(line.clone());
-                continue;
-            }
             let Some((_indent, opening_marker, _info)) = is_fence(line) else {
                 out.push(compressed_fence_line(line).unwrap_or_else(|| line.clone()));
                 continue;

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -159,9 +159,11 @@ fn flush_matched_block(block: PendingFenceBlock, out: &mut Vec<String>) {
     }
 }
 
-/// Compress safe outer fences to exactly three backticks.
+/// Normalize safe outer fence delimiters to exactly three backticks.
 ///
-/// Lines that do not start with backtick fences are returned unchanged.
+/// Lines that are not fence delimiters are returned unchanged. Compatible
+/// backtick or tilde delimiters may be rewritten to three backticks when doing
+/// so preserves the document structure.
 /// Fence-like lines inside a wider fenced block are literal content and are
 /// returned unchanged. An outer delimiter is also preserved when shortening or
 /// changing it would make an inner literal fence line look structural.

--- a/src/fences.rs
+++ b/src/fences.rs
@@ -2,6 +2,9 @@
 //!
 //! `compress_fences` reduces safe outer delimiters to three backticks while
 //! preserving nested fence-like content whose marker runs are literal text.
+//! The local `FENCE_RE` defines which delimiter lines this module can
+//! normalize, while `wrap::is_fence` and `FenceTracker` provide the structural
+//! Markdown fence semantics shared with wrapping.
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -65,19 +68,31 @@ fn normalize_specifier(line: &str) -> (String, String) {
 enum FenceRewrite {
     Compress,
     PreserveDelimiters,
-    PreserveAll,
 }
 
-struct OpeningAnalysis {
-    rewrite: FenceRewrite,
+#[derive(Clone, Copy)]
+enum MarkerStrategy {
+    Compressed,
+    PreserveDelimiter,
+}
+
+struct PendingFenceBlock {
+    opening_marker: String,
+    has_conflicting_interior_fence: bool,
+    lines: Vec<String>,
 }
 
 fn marker_char(marker: &str) -> Option<char> { marker.chars().next() }
 
-fn fence_line_with_marker(line: &str, marker: &str) -> Option<String> {
+fn rewrite_marker(line: &str, strategy: MarkerStrategy) -> Option<String> {
     let cap = FENCE_RE.captures(line)?;
     let indent = cap.get(1).map_or("", |m| m.as_str());
+    let original_marker = cap.get(2).map_or("", |m| m.as_str());
     let lang = cap.get(3).map_or("", |m| m.as_str());
+    let marker = match strategy {
+        MarkerStrategy::Compressed => "```",
+        MarkerStrategy::PreserveDelimiter => original_marker,
+    };
     Some(if is_null_lang(lang) {
         format!("{indent}{marker}")
     } else {
@@ -85,14 +100,12 @@ fn fence_line_with_marker(line: &str, marker: &str) -> Option<String> {
     })
 }
 
-fn compressed_fence_line(line: &str) -> Option<String> { fence_line_with_marker(line, "```") }
+fn compressed_fence_line(line: &str) -> Option<String> {
+    rewrite_marker(line, MarkerStrategy::Compressed)
+}
 
 fn preserved_fence_line(line: &str) -> Option<String> {
-    let marker = FENCE_RE
-        .captures(line)
-        .and_then(|cap| cap.get(2))
-        .map(|m| m.as_str())?;
-    fence_line_with_marker(line, marker)
+    rewrite_marker(line, MarkerStrategy::PreserveDelimiter)
 }
 
 fn interior_fence_requires_preserved_delimiters(opening_marker: &str, line: &str) -> bool {
@@ -108,39 +121,7 @@ fn interior_fence_requires_preserved_delimiters(opening_marker: &str, line: &str
     marker_ch == opening_ch || marker_ch == '`'
 }
 
-fn analyze_opening(lines: &[String], opening_index: usize) -> Option<OpeningAnalysis> {
-    let (_indent, opening_marker, _info) = is_fence(&lines[opening_index])?;
-
-    let mut tracker = FenceTracker::new();
-    if !tracker.observe(&lines[opening_index]) {
-        return None;
-    }
-
-    let mut has_conflicting_interior_fence = false;
-    for line in lines.iter().skip(opening_index + 1) {
-        let was_in_fence = tracker.in_fence();
-        let observed_fence = tracker.observe(line);
-        if observed_fence && was_in_fence && !tracker.in_fence() {
-            return Some(OpeningAnalysis {
-                rewrite: opening_rewrite(lines, opening_index, has_conflicting_interior_fence),
-            });
-        }
-        if was_in_fence && interior_fence_requires_preserved_delimiters(opening_marker, line) {
-            has_conflicting_interior_fence = true;
-        }
-    }
-
-    None
-}
-
-fn opening_rewrite(
-    lines: &[String],
-    index: usize,
-    has_conflicting_interior_fence: bool,
-) -> FenceRewrite {
-    if FENCE_RE.captures(&lines[index]).is_none() {
-        return FenceRewrite::PreserveAll;
-    }
+fn opening_rewrite(has_conflicting_interior_fence: bool) -> FenceRewrite {
     if has_conflicting_interior_fence {
         FenceRewrite::PreserveDelimiters
     } else {
@@ -154,7 +135,27 @@ fn rewrite_fence_line(line: &str, rewrite: FenceRewrite) -> String {
         FenceRewrite::PreserveDelimiters => {
             preserved_fence_line(line).unwrap_or_else(|| line.to_owned())
         }
-        FenceRewrite::PreserveAll => line.to_owned(),
+    }
+}
+
+fn flush_unmatched_block(block: PendingFenceBlock, out: &mut Vec<String>) {
+    out.extend(
+        block
+            .lines
+            .into_iter()
+            .map(|line| compressed_fence_line(&line).unwrap_or(line)),
+    );
+}
+
+fn flush_matched_block(block: PendingFenceBlock, out: &mut Vec<String>) {
+    let rewrite = opening_rewrite(block.has_conflicting_interior_fence);
+    let closing_index = block.lines.len() - 1;
+    for (index, line) in block.lines.into_iter().enumerate() {
+        if index == 0 || index == closing_index {
+            out.push(rewrite_fence_line(&line, rewrite));
+        } else {
+            out.push(line);
+        }
     }
 }
 
@@ -175,36 +176,57 @@ fn rewrite_fence_line(line: &str, rewrite: FenceRewrite) -> String {
 #[must_use]
 pub fn compress_fences(lines: &[String]) -> Vec<String> {
     let mut tracker = FenceTracker::new();
-    let mut active_rewrite = None;
+    let mut pending_block = None;
     let mut out = Vec::with_capacity(lines.len());
 
-    for (index, line) in lines.iter().enumerate() {
+    for line in lines {
         if !tracker.in_fence() {
-            let Some(analysis) = analyze_opening(lines, index) else {
+            if FENCE_RE.captures(line).is_none() {
+                out.push(line.clone());
+                continue;
+            }
+            let Some((_indent, opening_marker, _info)) = is_fence(line) else {
                 out.push(compressed_fence_line(line).unwrap_or_else(|| line.clone()));
                 continue;
             };
-
             let _ = tracker.observe(line);
-            let rewrite = analysis.rewrite;
-            active_rewrite = Some(rewrite);
-            out.push(rewrite_fence_line(line, rewrite));
+            pending_block = Some(PendingFenceBlock {
+                opening_marker: opening_marker.to_owned(),
+                has_conflicting_interior_fence: false,
+                lines: vec![line.clone()],
+            });
             continue;
         }
 
-        let observed_fence = tracker.observe(line);
-        if !observed_fence {
+        let Some(mut block) = pending_block.take() else {
             out.push(line.clone());
+            continue;
+        };
+
+        let observed_fence = tracker.observe(line);
+        if observed_fence
+            && tracker.in_fence()
+            && interior_fence_requires_preserved_delimiters(&block.opening_marker, line)
+        {
+            block.has_conflicting_interior_fence = true;
+        }
+        block.lines.push(line.clone());
+
+        if !observed_fence {
+            pending_block = Some(block);
             continue;
         }
 
         if tracker.in_fence() {
-            out.push(line.clone());
+            pending_block = Some(block);
             continue;
         }
 
-        let rewrite = active_rewrite.take().unwrap_or(FenceRewrite::PreserveAll);
-        out.push(rewrite_fence_line(line, rewrite));
+        flush_matched_block(block, &mut out);
+    }
+
+    if let Some(block) = pending_block {
+        flush_unmatched_block(block, &mut out);
     }
 
     out

--- a/src/wrap/tests/fence_tracker.rs
+++ b/src/wrap/tests/fence_tracker.rs
@@ -42,9 +42,33 @@ fn fence_tracker_ignores_shorter_closing_marker() {
 }
 
 #[test]
+fn fence_tracker_keeps_outer_backticks_open_for_inner_triple_backticks() {
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("````markdown"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("````"));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
 fn fence_tracker_requires_matching_marker_to_close() {
     let mut tracker = FenceTracker::default();
     assert!(tracker.observe("```"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("````"));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
+fn fence_tracker_ignores_other_marker_family_inside_outer_fence() {
+    let mut tracker = FenceTracker::default();
+    assert!(tracker.observe("````"));
     assert!(tracker.in_fence());
     assert!(tracker.observe("~~~"));
     assert!(tracker.in_fence());
@@ -83,6 +107,19 @@ fn fence_tracker_handles_inline_and_indented_markers() {
 fn fence_tracker_handles_tilde_fences() {
     let mut tracker = FenceTracker::new();
     assert!(tracker.observe("~~~~rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~~"));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
+fn fence_tracker_keeps_longer_tildes_open_for_inner_triple_tildes() {
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("~~~~markdown"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~rust"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~"));
     assert!(tracker.in_fence());
     assert!(tracker.observe("~~~~"));
     assert!(!tracker.in_fence());

--- a/src/wrap/tests/fence_tracker.rs
+++ b/src/wrap/tests/fence_tracker.rs
@@ -42,19 +42,6 @@ fn fence_tracker_ignores_shorter_closing_marker() {
 }
 
 #[test]
-fn fence_tracker_keeps_outer_backticks_open_for_inner_triple_backticks() {
-    let mut tracker = FenceTracker::new();
-    assert!(tracker.observe("````markdown"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("```rust"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("```"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("````"));
-    assert!(!tracker.in_fence());
-}
-
-#[test]
 fn fence_tracker_requires_matching_marker_to_close() {
     let mut tracker = FenceTracker::default();
     assert!(tracker.observe("```"));
@@ -62,28 +49,6 @@ fn fence_tracker_requires_matching_marker_to_close() {
     assert!(tracker.observe("~~~"));
     assert!(tracker.in_fence());
     assert!(tracker.observe("````"));
-    assert!(!tracker.in_fence());
-}
-
-#[test]
-fn fence_tracker_ignores_other_marker_family_inside_outer_fence() {
-    let mut tracker = FenceTracker::default();
-    assert!(tracker.observe("````"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("~~~"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("````"));
-    assert!(!tracker.in_fence());
-}
-
-#[test]
-fn fence_tracker_ignores_backticks_inside_outer_tilde_fence() {
-    let mut tracker = FenceTracker::default();
-    assert!(tracker.observe("~~~~"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("```"));
-    assert!(tracker.in_fence());
-    assert!(tracker.observe("~~~~"));
     assert!(!tracker.in_fence());
 }
 
@@ -123,17 +88,27 @@ fn fence_tracker_handles_tilde_fences() {
     assert!(!tracker.in_fence());
 }
 
-#[test]
-fn fence_tracker_keeps_longer_tildes_open_for_inner_triple_tildes() {
+#[rstest]
+#[case("````markdown", "```rust", "```", "````", false)]
+#[case("````", "~~~", "~~~", "````", false)]
+#[case("~~~~", "```", "```", "~~~~", false)]
+#[case("~~~~markdown", "~~~rust", "~~~", "~~~~", false)]
+fn fence_tracker_keeps_outer_fence_open_for_nested_markers(
+    #[case] outer_start: &str,
+    #[case] inner_start: &str,
+    #[case] inner_end: &str,
+    #[case] outer_end: &str,
+    #[case] expected_final_in_fence: bool,
+) {
     let mut tracker = FenceTracker::new();
-    assert!(tracker.observe("~~~~markdown"));
+    assert!(tracker.observe(outer_start));
     assert!(tracker.in_fence());
-    assert!(tracker.observe("~~~rust"));
+    assert!(tracker.observe(inner_start));
     assert!(tracker.in_fence());
-    assert!(tracker.observe("~~~"));
+    assert!(tracker.observe(inner_end));
     assert!(tracker.in_fence());
-    assert!(tracker.observe("~~~~"));
-    assert!(!tracker.in_fence());
+    assert!(tracker.observe(outer_end));
+    assert_eq!(tracker.in_fence(), expected_final_in_fence);
 }
 
 #[rstest]

--- a/src/wrap/tests/fence_tracker.rs
+++ b/src/wrap/tests/fence_tracker.rs
@@ -77,6 +77,17 @@ fn fence_tracker_ignores_other_marker_family_inside_outer_fence() {
 }
 
 #[test]
+fn fence_tracker_ignores_backticks_inside_outer_tilde_fence() {
+    let mut tracker = FenceTracker::default();
+    assert!(tracker.observe("~~~~"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("```"));
+    assert!(tracker.in_fence());
+    assert!(tracker.observe("~~~~"));
+    assert!(!tracker.in_fence());
+}
+
+#[test]
 fn fence_tracker_handles_inline_and_indented_markers() {
     let lines = [
         "```rust code fence on one line```",

--- a/tests/cli_fences.rs
+++ b/tests/cli_fences.rs
@@ -18,3 +18,40 @@ fn test_cli_fences_preserves_nested_backtick_block() {
         .success()
         .stdout(input);
 }
+
+#[test]
+fn test_cli_fences_preserves_nested_backticks_inside_tilde_block() {
+    let input = concat!(
+        "~~~~markdown\n",
+        "```rust\n",
+        "fn main() {}\n",
+        "```\n",
+        "~~~~\n",
+    );
+
+    run_cli_with_stdin(&["--fences"], input)
+        .success()
+        .stdout(input);
+}
+
+#[test]
+fn test_cli_fences_compresses_outer_backticks_while_preserving_inner_tildes() {
+    let input = concat!(
+        "````markdown\n",
+        "~~~rust\n",
+        "fn main() {}\n",
+        "~~~\n",
+        "````\n",
+    );
+    let expected = concat!(
+        "```markdown\n",
+        "~~~rust\n",
+        "fn main() {}\n",
+        "~~~\n",
+        "```\n",
+    );
+
+    run_cli_with_stdin(&["--fences"], input)
+        .success()
+        .stdout(expected);
+}

--- a/tests/cli_fences.rs
+++ b/tests/cli_fences.rs
@@ -1,0 +1,20 @@
+//! CLI regression tests for fence normalization edge cases.
+
+#[macro_use]
+mod prelude;
+use prelude::*;
+
+#[test]
+fn test_cli_fences_preserves_nested_backtick_block() {
+    let input = concat!(
+        "````markdown\n",
+        "```rust\n",
+        "fn main() {}\n",
+        "```\n",
+        "````\n",
+    );
+
+    run_cli_with_stdin(&["--fences"], input)
+        .success()
+        .stdout(input);
+}

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -27,6 +27,37 @@ fn compresses_tilde_fences() {
 }
 
 #[test]
+fn preserves_same_marker_nested_backtick_fences() {
+    let input = lines_vec!["````markdown", "```rust", "fn main() {}", "```", "````"];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}
+
+#[test]
+fn preserves_same_marker_nested_tilde_fences() {
+    let input = lines_vec!["~~~~markdown", "~~~rust", "fn main() {}", "~~~", "~~~~"];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}
+
+#[test]
+fn preserves_backtick_fences_nested_inside_tilde_fences() {
+    let input = lines_vec!["~~~markdown", "```rust", "fn main() {}", "```", "~~~"];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}
+
+#[test]
+fn preserves_tilde_content_inside_backtick_fences() {
+    let input = lines_vec!["````markdown", "~~~rust", "fn main() {}", "~~~", "````"];
+    let out = compress_fences(&input);
+    assert_eq!(
+        out,
+        lines_vec!["```markdown", "~~~rust", "fn main() {}", "~~~", "```"]
+    );
+}
+
+#[test]
 fn does_not_compress_mixed_fences() {
     let input = lines_vec!["~~~rust", "code", "```"];
     let out = compress_fences(&input);
@@ -49,6 +80,23 @@ fn fixes_orphaned_specifier() {
     let input = lines_vec!["Rust", "```", "fn main() {}", "```"];
     let out = attach_orphan_specifiers(&compress_fences(&input));
     assert_eq!(out, lines_vec!["```rust", "fn main() {}", "```"]);
+}
+
+#[test]
+fn does_not_attach_orphan_specifier_inside_outer_fence() {
+    let input = lines_vec!["````markdown", "Rust", "```", "fn main() {}", "```", "````"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, input);
+}
+
+#[test]
+fn attaches_orphan_specifier_without_shortening_preserved_outer_fence() {
+    let input = lines_vec!["Rust", "````", "```", "fn main() {}", "```", "````"];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(
+        out,
+        lines_vec!["````rust", "```", "fn main() {}", "```", "````"]
+    );
 }
 
 #[test]

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -90,6 +90,13 @@ fn does_not_attach_orphan_specifier_inside_outer_fence() {
 }
 
 #[test]
+fn does_not_attach_orphan_specifier_deeper_inside_outer_fence() {
+    let input = lines_vec!["````markdown", "```", "Rust", "fn main() {}", "```", "````",];
+    let out = attach_orphan_specifiers(&compress_fences(&input));
+    assert_eq!(out, input);
+}
+
+#[test]
 fn attaches_orphan_specifier_without_shortening_preserved_outer_fence() {
     let input = lines_vec!["Rust", "````", "```", "fn main() {}", "```", "````"];
     let out = attach_orphan_specifiers(&compress_fences(&input));

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -58,6 +58,13 @@ fn preserves_tilde_content_inside_backtick_fences() {
 }
 
 #[test]
+fn preserves_inner_fences_inside_spaced_info_fence() {
+    let input = lines_vec!["``` rust", "~~~example", "code", "~~~", "```"];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}
+
+#[test]
 fn does_not_compress_mixed_fences() {
     let input = lines_vec!["~~~rust", "code", "```"];
     let out = compress_fences(&input);

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -65,6 +65,13 @@ fn preserves_inner_fences_inside_spaced_info_fence() {
 }
 
 #[test]
+fn preserves_four_backtick_spaced_info_outer_fence() {
+    let input = lines_vec!["```` rust", "code", "````"];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}
+
+#[test]
 fn does_not_compress_mixed_fences() {
     let input = lines_vec!["~~~rust", "code", "```"];
     let out = compress_fences(&input);

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -26,49 +26,37 @@ fn compresses_tilde_fences() {
     assert_eq!(out, lines_vec!["```rust", "code", "```"]);
 }
 
-#[test]
-fn preserves_same_marker_nested_backtick_fences() {
-    let input = lines_vec!["````markdown", "```rust", "fn main() {}", "```", "````"];
+#[rstest]
+#[case(
+    lines_vec!["````markdown", "```rust", "fn main() {}", "```", "````"],
+    lines_vec!["````markdown", "```rust", "fn main() {}", "```", "````"]
+)]
+#[case(
+    lines_vec!["~~~~markdown", "~~~rust", "fn main() {}", "~~~", "~~~~"],
+    lines_vec!["~~~~markdown", "~~~rust", "fn main() {}", "~~~", "~~~~"]
+)]
+#[case(
+    lines_vec!["~~~markdown", "```rust", "fn main() {}", "```", "~~~"],
+    lines_vec!["~~~markdown", "```rust", "fn main() {}", "```", "~~~"]
+)]
+#[case(
+    lines_vec!["````markdown", "~~~rust", "fn main() {}", "~~~", "````"],
+    lines_vec!["```markdown", "~~~rust", "fn main() {}", "~~~", "```"]
+)]
+#[case(
+    lines_vec!["``` rust", "~~~example", "code", "~~~", "```"],
+    lines_vec!["``` rust", "~~~example", "code", "~~~", "```"]
+)]
+#[case(
+    lines_vec!["```` rust", "code", "````"],
+    lines_vec!["```` rust", "code", "````"]
+)]
+fn preserves_nested_or_spaced_fence_blocks(
+    #[case] input: Vec<String>,
+    #[case] expected: Vec<String>,
+) {
     let out = compress_fences(&input);
-    assert_eq!(out, input);
-}
-
-#[test]
-fn preserves_same_marker_nested_tilde_fences() {
-    let input = lines_vec!["~~~~markdown", "~~~rust", "fn main() {}", "~~~", "~~~~"];
-    let out = compress_fences(&input);
-    assert_eq!(out, input);
-}
-
-#[test]
-fn preserves_backtick_fences_nested_inside_tilde_fences() {
-    let input = lines_vec!["~~~markdown", "```rust", "fn main() {}", "```", "~~~"];
-    let out = compress_fences(&input);
-    assert_eq!(out, input);
-}
-
-#[test]
-fn preserves_tilde_content_inside_backtick_fences() {
-    let input = lines_vec!["````markdown", "~~~rust", "fn main() {}", "~~~", "````"];
-    let out = compress_fences(&input);
-    assert_eq!(
-        out,
-        lines_vec!["```markdown", "~~~rust", "fn main() {}", "~~~", "```"]
-    );
-}
-
-#[test]
-fn preserves_inner_fences_inside_spaced_info_fence() {
-    let input = lines_vec!["``` rust", "~~~example", "code", "~~~", "```"];
-    let out = compress_fences(&input);
-    assert_eq!(out, input);
-}
-
-#[test]
-fn preserves_four_backtick_spaced_info_outer_fence() {
-    let input = lines_vec!["```` rust", "code", "````"];
-    let out = compress_fences(&input);
-    assert_eq!(out, input);
+    assert_eq!(out, expected);
 }
 
 #[test]

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -84,28 +84,25 @@ fn fixes_orphaned_specifier() {
     assert_eq!(out, lines_vec!["```rust", "fn main() {}", "```"]);
 }
 
-#[test]
-fn does_not_attach_orphan_specifier_inside_outer_fence() {
-    let input = lines_vec!["````markdown", "Rust", "```", "fn main() {}", "```", "````"];
+#[rstest]
+#[case(
+    lines_vec!["````markdown", "Rust", "```", "fn main() {}", "```", "````"],
+    lines_vec!["````markdown", "Rust", "```", "fn main() {}", "```", "````"]
+)]
+#[case(
+    lines_vec!["````markdown", "```", "Rust", "fn main() {}", "```", "````"],
+    lines_vec!["````markdown", "```", "Rust", "fn main() {}", "```", "````"]
+)]
+#[case(
+    lines_vec!["Rust", "````", "```", "fn main() {}", "```", "````"],
+    lines_vec!["````rust", "```", "fn main() {}", "```", "````"]
+)]
+fn handles_orphan_specifiers_around_outer_fences(
+    #[case] input: Vec<String>,
+    #[case] expected: Vec<String>,
+) {
     let out = attach_orphan_specifiers(&compress_fences(&input));
-    assert_eq!(out, input);
-}
-
-#[test]
-fn does_not_attach_orphan_specifier_deeper_inside_outer_fence() {
-    let input = lines_vec!["````markdown", "```", "Rust", "fn main() {}", "```", "````",];
-    let out = attach_orphan_specifiers(&compress_fences(&input));
-    assert_eq!(out, input);
-}
-
-#[test]
-fn attaches_orphan_specifier_without_shortening_preserved_outer_fence() {
-    let input = lines_vec!["Rust", "````", "```", "fn main() {}", "```", "````"];
-    let out = attach_orphan_specifiers(&compress_fences(&input));
-    assert_eq!(
-        out,
-        lines_vec!["````rust", "```", "fn main() {}", "```", "````"]
-    );
+    assert_eq!(out, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds an ExecPlan documenting how to preserve nested fenced blocks during fence normalization (Issue #262). This living plan guides implementing a robust fix that avoids rewriting inner fence-like content.

## Changes
- Introduces docs/execplans/issue-262-nested_code_block-handling.md containing the full execution plan:
  - Purpose, references, constraints, tolerances, risks, progress, decisions, plan stages (A–E), concrete steps, and acceptance criteria.
  - Rationale for reusing shared fence-state semantics (FenceTracker) and aligning preprocessing with wrapping behavior.
  - Regression targets and testing strategy across fences tests, CLI, and fence_tracker tests.

## Rationale
- The plan responds to issue #262 by ensuring that four-backtick or four-tilde outer fences correctly normalize only the outer delimiters while preserving nested triple-backtick content.
- It leverages existing fence-tracking logic to avoid introducing a separate nested-fence state machine and to keep wrapping, fences, and specifier attachment consistent.

## Plan of work (high level)
- Stage A: add failing regression examples for nested fences (outer four-backtick/outer tilde with inner triple-backticks) and ensure CLI regression tests cover --fences behavior.
- Stage B: implement line-by-line compression with a FenceTracker to compress only real outer delimiters and preserve nested content.
- Stage C: update attach_orphan_specifiers to respect active fence state and avoid attaching inside fences.
- Stage D: extend FenceTracker-based tests with explicit nested-fence scenarios.
- Stage E: validate against tests and update architecture/docs if needed.

## Test plan
- Align with existing targets mentioned in the ExecPlan:
  - tests/fences.rs (unit/integration for fence handling)
  - tests/cli.rs (end-to-end CLI behavior with --fences)
  - src/wrap/tests/fence_tracker.rs (shared fence-tracker semantics)
- Ensure new coverage lives in active top-level test targets (not in non-Cargo-runner files).

## Acceptance criteria
- compress_fences compresses only actual outer delimiters; nested fence-like content remains unchanged.
- attach_orphan_specifiers does not attach lines inside an open fenced block.
- FenceTracker tests include explicit outer-four-backticks and outer-tilde scenarios.
- cargo test --test fences, cargo test --test cli, make check-fmt, make lint, and make test pass.
- If architecture docs change, related gates (fmt/markdown/nixie) pass as well.

## Progress
- [x] Add ExecPlan doc for nested fence handling
- [ ] Implement core changes in src/fences.rs and related modules (to be done)
- [ ] Extend tests and run full gates (to be done)

## Notes
- This PR focuses on documentation that guides and aligns future implementation work. It does not change public APIs. It serves as a single source of truth for the nested-fence handling approach and testing strategy.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/0d20afc3-1dba-45f8-bb0d-c8948f1c1c76

📝 Closes #262

## Summary by Sourcery

Make fence normalization and orphan specifier attachment preserve nested fenced blocks while aligning behavior with the shared FenceTracker semantics.

Bug Fixes:
- Ensure compress_fences only compresses safe outer fence delimiters and preserves nested fence-like content, including mixed backtick and tilde scenarios.
- Prevent attach_orphan_specifiers from attaching language specifiers to fences that reside inside an open fenced block.

Enhancements:
- Align fences::compress_fences and attach_orphan_specifiers with FenceTracker-based fence state tracking for consistent behavior across preprocessing and wrapping.
- Improve attach_specifier_to_fence so it retains the original fence marker family when attaching language specifiers.
- Document the updated fence normalization behavior and shared FenceTracker semantics in the architecture docs.
- Add an execution plan documenting the nested fenced block handling approach and validation strategy.

Documentation:
- Add a detailed ExecPlan for nested code block handling and update architecture documentation to describe the new FenceTracker-aligned fence normalization behavior.

Tests:
- Add unit tests for compress_fences covering nested backtick and tilde fences and preservation of inner literal fences.
- Add tests ensuring orphan specifiers are not attached inside outer fences and that preserved outer fences retain width when specifiers are attached.
- Extend FenceTracker tests to cover nested same-marker and mixed-marker fence scenarios that govern the new normalization behavior.
- Add a CLI regression test to verify --fences preserves nested fenced code blocks end to end.