### PR TITLE
Keep GFM footnote references with preceding code and link spans (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Fixed
 
+- Keep GFM footnote references coupled to sentence-ending punctuation on inline
+  code spans and Markdown links during wrapping, including when the span is
+  preceded by opening punctuation.
+  ([#299](https://github.com/leynos/mdtablefix/issues/299))
 - Keep opening brackets attached to following inline code spans and links during
   wrapping instead of stranding punctuation at line ends. (
   [#293](https://github.com/leynos/mdtablefix/issues/293))

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -145,10 +145,17 @@ The wrapping pipeline for `--wrap` is:
    `src/wrap/inline.rs` tokenizes prose with `tokenize::segment_inline`, groups
    the tokens into `InlineFragment` values via `determine_token_span`, and calls
     `textwrap::wrap_algorithms::wrap_first_fit` over the accumulated fragment
-   buffer. `determine_token_span` forward-couples opening punctuation tokens (
-   `(`, `[`, and CJK openers) to the next inline code span or Markdown link so
-   wrapping never leaves a lone opener at the end of a line. Trailing
-   punctuation after those atomic spans is grouped in the same pass.
+   buffer. Token predicates in `src/wrap/inline/predicates.rs` classify
+   punctuation, links, code spans, and footnote markers. Span grouping helpers
+   in `src/wrap/inline/span_helpers.rs` extend grouped spans over trailing
+   punctuation, couple adjacent footnote references, and merge chained inline
+   code or link tokens. `determine_token_span` forward-couples opening
+   punctuation tokens (`(`, `[`, and CJK openers) to the next inline code span
+   or Markdown link so wrapping never leaves a lone opener at the end of a
+   line. Trailing punctuation after those atomic spans is grouped in the same
+   pass, and GFM footnote references that immediately follow inline code or
+   links (including opener-coupled spans) stay attached to the preceding
+   punctuation cluster.
 
 4. **Post-processing and rendering.** The `postprocess` module applies
    `merge_whitespace_only_lines` and then `rebalance_atomic_tails` so
@@ -217,12 +224,20 @@ Table: Key types and functions.
 | `classify_block` | `src/wrap/block.rs` |
 | `FragmentKind`, `InlineFragment` | `src/wrap/inline/fragment.rs` |
 | `classify_fragment` | `src/wrap/inline/fragment.rs` |
+| Character and fragment predicates (`is_inline_code_token`, `looks_like_link`, `looks_like_footnote_ref`, …) | `src/wrap/inline/predicates.rs` |
+| `SpanKind`, span grouping helpers (`merge_code_span`, `try_couple_footnote_reference`, …) | `src/wrap/inline/span_helpers.rs` |
 | `build_fragments`, `wrap_preserving_code`, `render_line` | `src/wrap/inline.rs` |
 | `determine_token_span` | `src/wrap/inline.rs` |
 | `merge_whitespace_only_lines` | `src/wrap/inline/postprocess.rs` |
 | `rebalance_atomic_tails` | `src/wrap/inline/postprocess.rs` |
 | `ParagraphWriter`, `wrap_with_prefix` | `src/wrap/paragraph.rs` |
 | `ParagraphState`, `PrefixLine` | `src/wrap/paragraph.rs` |
+
+`SpanKind` in `src/wrap/inline/span_helpers.rs` records how a grouped token
+span behaves while `determine_token_span` walks the stream: `General` for
+ordinary prose, `Code` and `Link` for atomic inline spans, and `FootnoteRef`
+when a footnote marker has been promoted or grouped with preceding
+punctuation.
 
 ### Design constraints
 
@@ -233,7 +248,10 @@ Table: Key types and functions.
   overflow the target width. Opening punctuation that immediately precedes an
   inline code span or link is grouped with that span during token grouping so
   the opener is not left on the previous line. Trailing punctuation after those
-  spans follows the same grouping rules.
+  spans follows the same grouping rules. GFM footnote references that immediately
+  follow inline code or link spans without intervening whitespace are coupled
+  to the preceding punctuation cluster so the marker is not wrapped onto the
+  next line alone.
 - **Hard breaks.** Trailing two-space hard breaks must survive on the emitted
   line where they occur.
 - **Verbatim blocks.** Fenced code blocks must pass through unchanged, along

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -39,6 +39,12 @@ footnote references (`[^label]`) are treated as unbreakable units. A span is
 never split across lines; it moves as a whole to the next line when it would
 otherwise exceed the target width.
 
+When a footnote reference immediately follows an inline code span or Markdown
+link without intervening whitespace—for example `` `code`.[^ref] `` or
+`[text](url).[^ref]`—the reference stays on the same line as the preceding
+punctuation during wrapping. The same rule applies when opening punctuation is
+coupled to the span, such as `` (`code`).[^ref] ``.
+
 Opening brackets and other opening punctuation (`(`, `[`, and CJK openers such
 as `（` and `「`) that immediately precede an inline code span or Markdown link
 stay coupled to that span during wrapping. This prevents a lone opener from

--- a/src/wrap/inline.rs
+++ b/src/wrap/inline.rs
@@ -269,23 +269,19 @@ pub(super) fn determine_token_span(tokens: &[String], start: usize) -> (usize, u
 
     // Forward-couple opening punctuation to the next atomic span so wrapping
     // never leaves a lone `(` at the end of a line before inline code or a link.
-    if tokens[start].chars().all(is_opening_punct) {
-        if let Some(next) = tokens.get(start + 1) {
-            if is_inline_code_token(next) {
-                kind = SpanKind::Code;
-                end += 1;
-                width += UnicodeWidthStr::width(next.as_str());
-                end = extend_punctuation(tokens, end, &mut width);
-            } else if looks_like_link(next) {
-                kind = SpanKind::Link;
-                end += 1;
-                width += UnicodeWidthStr::width(next.as_str());
-                end = extend_punctuation(tokens, end, &mut width);
-            }
-        }
-
-        if matches!(kind, SpanKind::Code | SpanKind::Link) {
-            return (end, width);
+    if tokens[start].chars().all(is_opening_punct)
+        && let Some(next) = tokens.get(start + 1)
+    {
+        if is_inline_code_token(next) {
+            kind = SpanKind::Code;
+            end += 1;
+            width += UnicodeWidthStr::width(next.as_str());
+            end = extend_punctuation(tokens, end, &mut width);
+        } else if looks_like_link(next) {
+            kind = SpanKind::Link;
+            end += 1;
+            width += UnicodeWidthStr::width(next.as_str());
+            end = extend_punctuation(tokens, end, &mut width);
         }
     }
 

--- a/src/wrap/inline.rs
+++ b/src/wrap/inline.rs
@@ -314,6 +314,13 @@ pub(super) fn determine_token_span(tokens: &[String], start: usize) -> (usize, u
             continue;
         }
 
+        if matches!(kind, SpanKind::Code | SpanKind::Link) && looks_like_footnote_ref(token) {
+            width += UnicodeWidthStr::width(token.as_str());
+            end += 1;
+            end = extend_punctuation(tokens, end, &mut width);
+            continue;
+        }
+
         if kind == SpanKind::Link && is_link {
             width += UnicodeWidthStr::width(token.as_str());
             end += 1;

--- a/src/wrap/inline.rs
+++ b/src/wrap/inline.rs
@@ -207,27 +207,51 @@ fn merge_code_span(tokens: &[String], i: usize, width: &mut usize) -> usize {
     j
 }
 
-/// Promotes a general prose span into a footnote-reference span when adjacent
-/// sentence punctuation should stay attached to the marker.
-fn promote_footnote_span(
+/// Extends `end` by one token and any trailing punctuation that follows it.
+fn absorb_token_and_trailing_punctuation(
     tokens: &[String],
     end: usize,
     width: &mut usize,
+) -> usize {
+    *width += UnicodeWidthStr::width(tokens[end].as_str());
+    extend_punctuation(tokens, end + 1, width)
+}
+
+/// Couples an adjacent footnote reference into the current span when appropriate.
+///
+/// General prose spans require sentence punctuation immediately before the
+/// marker. Code and link spans already absorb trailing punctuation, so an
+/// adjacent footnote reference is always coupled.
+fn try_couple_footnote_reference(
+    tokens: &[String],
+    end: usize,
+    kind: SpanKind,
+    width: &mut usize,
 ) -> Option<(SpanKind, usize)> {
     let token = tokens.get(end)?;
-    let previous = end
-        .checked_sub(1)
-        .and_then(|previous| tokens.get(previous))?;
-
-    if looks_like_footnote_ref(token) && previous.chars().last().is_some_and(is_trailing_punct) {
-        *width += UnicodeWidthStr::width(token.as_str());
-        return Some((
-            SpanKind::FootnoteRef,
-            extend_punctuation(tokens, end + 1, width),
-        ));
+    if !looks_like_footnote_ref(token) {
+        return None;
     }
 
-    None
+    match kind {
+        SpanKind::General => {
+            let previous = end
+                .checked_sub(1)
+                .and_then(|previous| tokens.get(previous))?;
+            if !previous.chars().last().is_some_and(is_trailing_punct) {
+                return None;
+            }
+            Some((
+                SpanKind::FootnoteRef,
+                absorb_token_and_trailing_punctuation(tokens, end, width),
+            ))
+        }
+        SpanKind::Code | SpanKind::Link => Some((
+            kind,
+            absorb_token_and_trailing_punctuation(tokens, end, width),
+        )),
+        SpanKind::FootnoteRef => None,
+    }
 }
 
 /// Finds the next logical token group starting at `start`.
@@ -305,33 +329,24 @@ pub(super) fn determine_token_span(tokens: &[String], start: usize) -> (usize, u
 
         let is_link = looks_like_link(token);
         let is_code = is_inline_code_token(token);
-        if kind == SpanKind::General
-            && let Some((promoted_kind, promoted_end)) =
-                promote_footnote_span(tokens, end, &mut width)
+        // Footnote markers must be coupled before consecutive link/code chaining;
+        // otherwise `[^N]` stays a separate wrap token even when punctuation is
+        // already attached to the preceding atomic span.
+        if let Some((next_kind, next_end)) =
+            try_couple_footnote_reference(tokens, end, kind, &mut width)
         {
-            kind = promoted_kind;
-            end = promoted_end;
-            continue;
-        }
-
-        if matches!(kind, SpanKind::Code | SpanKind::Link) && looks_like_footnote_ref(token) {
-            width += UnicodeWidthStr::width(token.as_str());
-            end += 1;
-            end = extend_punctuation(tokens, end, &mut width);
+            kind = next_kind;
+            end = next_end;
             continue;
         }
 
         if kind == SpanKind::Link && is_link {
-            width += UnicodeWidthStr::width(token.as_str());
-            end += 1;
-            end = extend_punctuation(tokens, end, &mut width);
+            end = absorb_token_and_trailing_punctuation(tokens, end, &mut width);
             continue;
         }
 
         if kind == SpanKind::Code && is_code {
-            width += UnicodeWidthStr::width(token.as_str());
-            end += 1;
-            end = extend_punctuation(tokens, end, &mut width);
+            end = absorb_token_and_trailing_punctuation(tokens, end, &mut width);
             continue;
         }
 

--- a/src/wrap/inline.rs
+++ b/src/wrap/inline.rs
@@ -8,251 +8,39 @@
 mod footnote_tests;
 mod fragment;
 mod postprocess;
+mod predicates;
+mod span_helpers;
 #[cfg(test)]
 mod test_support;
 #[cfg(test)]
 mod tests;
+
 use std::ops::Range;
 
 use fragment::{InlineFragment, width_as_f64};
 use postprocess::{merge_whitespace_only_lines, rebalance_atomic_tails};
+use predicates::looks_like_link;
+pub(in crate::wrap::inline) use predicates::{
+    ends_with_footnote_ref,
+    fragment_is_link,
+    is_inline_code_token,
+    is_opening_punct,
+    is_trailing_punct,
+    is_whitespace_token,
+    looks_like_footnote_ref,
+};
+use span_helpers::{
+    SpanKind,
+    absorb_token_and_trailing_punctuation,
+    extend_punctuation,
+    merge_code_span,
+    should_couple_whitespace,
+    try_couple_footnote_reference,
+};
 use textwrap::wrap_algorithms::wrap_first_fit;
 use unicode_width::UnicodeWidthStr;
 
 use super::tokenize;
-
-/// Marks how a grouped token span should behave during wrapping.
-#[derive(Copy, Clone, PartialEq, Eq)]
-enum SpanKind {
-    /// Treat the span as ordinary prose.
-    General,
-    /// Treat the span as an inline code sequence.
-    Code,
-    /// Treat the span as a Markdown link or image link.
-    Link,
-    /// Treat the span as a GitHub Flavoured Markdown footnote reference.
-    FootnoteRef,
-}
-fn is_opening_punct(c: char) -> bool { matches!(c, '(' | '[') || "（［【《「『".contains(c) }
-fn is_trailing_punct(c: char) -> bool {
-    // ASCII closers + common Unicode closers and word-final punctuation
-    matches!(
-        c,
-        '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '"' | '\''
-    ) || "…—–»›）］】》」』、。，：；！？”.’".contains(c)
-}
-
-/// Returns whether `token` already looks like a complete Markdown link.
-///
-/// The `token` parameter is the rendered fragment text to inspect. The return
-/// value is `true` only for complete inline links or image links, and this
-/// helper never panics.
-fn looks_like_link(token: &str) -> bool {
-    (token.starts_with('[') || token.starts_with("!["))
-        && token.contains("](")
-        && token.ends_with(')')
-}
-
-/// Returns whether `token` looks like a complete GFM footnote reference.
-///
-/// The `token` parameter is the rendered fragment text to inspect. The return
-/// value is `true` for the compact `[^label]` shape when `label` is non-empty.
-/// This helper intentionally leaves label validation to the Markdown parser.
-fn looks_like_footnote_ref(token: &str) -> bool {
-    token
-        .strip_prefix("[^")
-        .and_then(|label| label.strip_suffix(']'))
-        .is_some_and(|label| !label.is_empty())
-}
-
-/// Returns whether `token` ends with an inline footnote reference.
-///
-/// The wrapper can group `word.[^label]` into a single fragment to avoid
-/// separating sentence punctuation from the marker. This predicate recognises
-/// that suffix shape without treating arbitrary prose as a standalone marker.
-fn ends_with_footnote_ref(token: &str) -> bool {
-    let Some(start) = token.rfind("[^") else {
-        return false;
-    };
-
-    looks_like_footnote_ref(&token[start..])
-}
-
-/// Returns whether `token` contains only Unicode whitespace.
-///
-/// The `token` parameter is the rendered fragment text to inspect. The return
-/// value is `true` when every character is whitespace, and this helper never
-/// panics.
-fn is_whitespace_token(token: &str) -> bool { token.chars().all(char::is_whitespace) }
-
-/// Returns whether `token` is a complete inline code span.
-///
-/// The `token` parameter is the rendered fragment text to inspect. The return
-/// value is `true` only for complete backtick-delimited spans, and this helper
-/// never panics.
-fn is_inline_code_token(token: &str) -> bool { token.starts_with('`') && token.ends_with('`') }
-
-/// Returns the substring beginning at the first Markdown link opener after any
-/// leading opener punctuation.
-///
-/// Non-link openers such as `(` are skipped, but a leading `[` or `![` that
-/// begins a link is preserved so opener-coupled links classify correctly.
-fn link_text_after_leading_openers(text: &str) -> &str {
-    let mut rest = text;
-    while !rest.is_empty() {
-        if rest.starts_with('[') || rest.starts_with("![") {
-            return rest;
-        }
-        let Some(ch) = rest.chars().next() else {
-            break;
-        };
-        if is_opening_punct(ch) {
-            rest = &rest[ch.len_utf8()..];
-        } else {
-            break;
-        }
-    }
-    rest
-}
-
-/// Strips one outer wrapper closing character from a link candidate when present.
-fn strip_outer_link_wrapper_suffix(text: &str) -> Option<&str> {
-    let last = text.chars().next_back()?;
-    if matches!(last, ')' | ']' | '）' | '］' | '」' | '』' | '》') {
-        Some(&text[..text.len() - last.len_utf8()])
-    } else {
-        None
-    }
-}
-
-/// Returns whether rendered fragment text contains a Markdown link, including
-/// links wrapped in outer opener punctuation.
-fn fragment_is_link(text: &str) -> bool {
-    if looks_like_link(text) {
-        return true;
-    }
-    let mut candidate = link_text_after_leading_openers(text);
-    while !candidate.is_empty() {
-        if looks_like_link(candidate) {
-            return true;
-        }
-        let Some(next) = strip_outer_link_wrapper_suffix(candidate) else {
-            break;
-        };
-        candidate = next;
-    }
-    false
-}
-
-/// Extends a grouped span over trailing punctuation tokens and updates `width`.
-///
-/// `tokens` supplies the token stream, `j` is the next token index to inspect,
-/// and `width` accumulates the display width of the current span. The return
-/// value is the exclusive end index after any attached punctuation, and the
-/// caller must pass a valid starting index within `tokens`.
-fn extend_punctuation(tokens: &[String], mut j: usize, width: &mut usize) -> usize {
-    while j < tokens.len() && tokens[j].chars().all(is_trailing_punct) {
-        *width += UnicodeWidthStr::width(tokens[j].as_str());
-        j += 1;
-    }
-    j
-}
-
-/// Decide whether whitespace between grouped tokens should stay attached to the
-/// current span.
-///
-/// Links absorb following whitespace when another link, inline code span, or
-/// punctuation immediately follows so that rendered Markdown keeps those items
-/// together. Code spans are only coupled with trailing punctuation so that two
-/// adjacent code spans can break across lines, but `code`, style suffixes still
-/// cling to the preceding span.
-fn should_couple_whitespace(kind: SpanKind, next_token: Option<&String>) -> bool {
-    match (kind, next_token) {
-        (SpanKind::Link, Some(next))
-            if looks_like_link(next)
-                || is_inline_code_token(next)
-                || next.chars().all(is_trailing_punct) =>
-        {
-            true
-        }
-        (SpanKind::Code, Some(next)) if next.chars().all(is_trailing_punct) => true,
-        _ => false,
-    }
-}
-
-/// Merges a backtick-opened code span into one grouped span and updates
-/// `width`.
-///
-/// `tokens` is the token stream, `i` is the index of a lone backtick opener,
-/// and `width` accumulates the grouped display width. The return value is the
-/// exclusive end index after the closing backtick and any attached
-/// punctuation. This helper relies on the invariant that `tokens[i]` is a lone
-/// backtick token.
-#[inline]
-fn merge_code_span(tokens: &[String], i: usize, width: &mut usize) -> usize {
-    debug_assert!(
-        tokens[i] == "`",
-        "merge_code_span requires a single backtick opener"
-    );
-    let mut j = i + 1;
-    while j < tokens.len() && tokens[j] != "`" {
-        *width += UnicodeWidthStr::width(tokens[j].as_str());
-        j += 1;
-    }
-    if j < tokens.len() {
-        *width += UnicodeWidthStr::width(tokens[j].as_str());
-        j += 1;
-        j = extend_punctuation(tokens, j, width);
-    }
-    j
-}
-
-/// Extends `end` by one token and any trailing punctuation that follows it.
-fn absorb_token_and_trailing_punctuation(
-    tokens: &[String],
-    end: usize,
-    width: &mut usize,
-) -> usize {
-    *width += UnicodeWidthStr::width(tokens[end].as_str());
-    extend_punctuation(tokens, end + 1, width)
-}
-
-/// Couples an adjacent footnote reference into the current span when appropriate.
-///
-/// General prose spans require sentence punctuation immediately before the
-/// marker. Code and link spans already absorb trailing punctuation, so an
-/// adjacent footnote reference is always coupled.
-fn try_couple_footnote_reference(
-    tokens: &[String],
-    end: usize,
-    kind: SpanKind,
-    width: &mut usize,
-) -> Option<(SpanKind, usize)> {
-    let token = tokens.get(end)?;
-    if !looks_like_footnote_ref(token) {
-        return None;
-    }
-
-    match kind {
-        SpanKind::General => {
-            let previous = end
-                .checked_sub(1)
-                .and_then(|previous| tokens.get(previous))?;
-            if !previous.chars().last().is_some_and(is_trailing_punct) {
-                return None;
-            }
-            Some((
-                SpanKind::FootnoteRef,
-                absorb_token_and_trailing_punctuation(tokens, end, width),
-            ))
-        }
-        SpanKind::Code | SpanKind::Link => Some((
-            kind,
-            absorb_token_and_trailing_punctuation(tokens, end, width),
-        )),
-        SpanKind::FootnoteRef => None,
-    }
-}
 
 /// Finds the next logical token group starting at `start`.
 ///

--- a/src/wrap/inline/footnote_tests.rs
+++ b/src/wrap/inline/footnote_tests.rs
@@ -20,26 +20,6 @@ fn determine_token_span_groups_punctuation_with_footnote_reference() {
     assert_eq!(width, unicode_width::UnicodeWidthStr::width("word.[^4]"));
 }
 
-#[test]
-fn determine_token_span_groups_footnote_reference_after_inline_code() {
-    let input = "`assert_ne!`.[^3]";
-    let tokens = segment_inline(input);
-    let (end, width) = determine_token_span(&tokens, 0);
-    let grouped = tokens[..end].join("");
-    assert_eq!(grouped, input);
-    assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
-}
-
-#[test]
-fn determine_token_span_groups_footnote_reference_after_link() {
-    let input = "[click here](https://example.com).[^1]";
-    let tokens = segment_inline(input);
-    let (end, width) = determine_token_span(&tokens, 0);
-    let grouped = tokens[..end].join("");
-    assert_eq!(grouped, input);
-    assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
-}
-
 #[rstest]
 #[case("`fn!()`.[^1]")]
 #[case("`value`,[^2]")]
@@ -48,6 +28,8 @@ fn determine_token_span_groups_footnote_reference_after_link() {
 #[case("[text](url),[^2]")]
 #[case("(`code`).[^1]")]
 #[case("([link](url)).[^1]")]
+#[case("`assert_ne!`.[^3]")]
+#[case("[click here](https://example.com).[^1]")]
 fn determine_token_span_groups_footnote_reference_after_atomic_span(#[case] input: &str) {
     let tokens = segment_inline(input);
     let (end, width) = determine_token_span(&tokens, 0);

--- a/src/wrap/inline/footnote_tests.rs
+++ b/src/wrap/inline/footnote_tests.rs
@@ -54,6 +54,20 @@ fn determine_token_span_groups_footnote_reference_after_atomic_span(#[case] inpu
     assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
 }
 
+#[rstest]
+#[case("`assert_ne!`. [^3]", "`assert_ne!`.")]
+#[case("`assert_ne!` [^3]", "`assert_ne!`")]
+fn determine_token_span_does_not_group_whitespace_separated_footnote_reference(
+    #[case] input: &str,
+    #[case] expected_group: &str,
+) {
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, 0);
+    let grouped = tokens[..end].join("");
+    assert_eq!(grouped, expected_group);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected_group));
+}
+
 #[test]
 fn segment_inline_splits_before_embedded_footnote_reference() {
     let tokens = segment_inline("word[^4]");

--- a/src/wrap/inline/footnote_tests.rs
+++ b/src/wrap/inline/footnote_tests.rs
@@ -46,6 +46,8 @@ fn determine_token_span_groups_footnote_reference_after_link() {
 #[case("`result`?[^3]")]
 #[case("[text](url).[^1]")]
 #[case("[text](url),[^2]")]
+#[case("(`code`).[^1]")]
+#[case("([link](url)).[^1]")]
 fn determine_token_span_groups_footnote_reference_after_atomic_span(#[case] input: &str) {
     let tokens = segment_inline(input);
     let (end, width) = determine_token_span(&tokens, 0);
@@ -66,6 +68,21 @@ fn determine_token_span_does_not_group_whitespace_separated_footnote_reference(
     let grouped = tokens[..end].join("");
     assert_eq!(grouped, expected_group);
     assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected_group));
+}
+
+#[test]
+fn determine_token_span_groups_footnote_reference_after_opener_coupled_code() {
+    let input = "See (`code`).[^1] for details";
+    let tokens = segment_inline(input);
+    let open_paren = tokens
+        .iter()
+        .position(|token| token == "(")
+        .expect("opening parenthesis token");
+    let (end, width) = determine_token_span(&tokens, open_paren);
+    let grouped = tokens[open_paren..end].join("");
+    let expected = "(`code`).[^1]";
+    assert_eq!(grouped, expected);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected));
 }
 
 #[test]

--- a/src/wrap/inline/footnote_tests.rs
+++ b/src/wrap/inline/footnote_tests.rs
@@ -21,6 +21,40 @@ fn determine_token_span_groups_punctuation_with_footnote_reference() {
 }
 
 #[test]
+fn determine_token_span_groups_footnote_reference_after_inline_code() {
+    let input = "`assert_ne!`.[^3]";
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, 0);
+    let grouped = tokens[..end].join("");
+    assert_eq!(grouped, input);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
+}
+
+#[test]
+fn determine_token_span_groups_footnote_reference_after_link() {
+    let input = "[click here](https://example.com).[^1]";
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, 0);
+    let grouped = tokens[..end].join("");
+    assert_eq!(grouped, input);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
+}
+
+#[rstest]
+#[case("`fn!()`.[^1]")]
+#[case("`value`,[^2]")]
+#[case("`result`?[^3]")]
+#[case("[text](url).[^1]")]
+#[case("[text](url),[^2]")]
+fn determine_token_span_groups_footnote_reference_after_atomic_span(#[case] input: &str) {
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, 0);
+    let grouped = tokens[..end].join("");
+    assert_eq!(grouped, input);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(input));
+}
+
+#[test]
 fn segment_inline_splits_before_embedded_footnote_reference() {
     let tokens = segment_inline("word[^4]");
     let actual: Vec<&str> = tokens.iter().map(String::as_str).collect();

--- a/src/wrap/inline/predicates.rs
+++ b/src/wrap/inline/predicates.rs
@@ -125,7 +125,7 @@ mod tests {
 
     fn footnote_label_strategy() -> BoxedStrategy<String> {
         prop::string::string_regex("[a-zA-Z0-9_-]+")
-            .unwrap()
+            .expect("failed to build footnote label regex strategy")
             .boxed()
     }
 

--- a/src/wrap/inline/predicates.rs
+++ b/src/wrap/inline/predicates.rs
@@ -47,7 +47,7 @@ pub(in crate::wrap::inline) fn is_whitespace_token(token: &str) -> bool {
 
 /// Returns whether `token` is a complete inline code span.
 pub(in crate::wrap::inline) fn is_inline_code_token(token: &str) -> bool {
-    token.starts_with('`') && token.ends_with('`')
+    token.len() > 1 && token.starts_with('`') && token.ends_with('`')
 }
 
 /// Returns the substring beginning at the first Markdown link opener after any

--- a/src/wrap/inline/predicates.rs
+++ b/src/wrap/inline/predicates.rs
@@ -1,0 +1,100 @@
+//! Token and fragment predicates for inline Markdown wrapping.
+//!
+//! These helpers classify segmented tokens and rendered fragment text so span
+//! grouping and post-wrap heuristics can recognise links, code, footnotes, and
+//! punctuation without duplicating detection rules.
+
+pub(in crate::wrap::inline) fn is_opening_punct(c: char) -> bool {
+    matches!(c, '(' | '[') || "（［【《「『".contains(c)
+}
+
+pub(in crate::wrap::inline) fn is_trailing_punct(c: char) -> bool {
+    // ASCII closers + common Unicode closers and word-final punctuation
+    matches!(
+        c,
+        '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '"' | '\''
+    ) || "…—–»›）］】》」』、。，：；！？”.’".contains(c)
+}
+
+/// Returns whether `token` already looks like a complete Markdown link.
+pub(in crate::wrap::inline) fn looks_like_link(token: &str) -> bool {
+    (token.starts_with('[') || token.starts_with("!["))
+        && token.contains("](")
+        && token.ends_with(')')
+}
+
+/// Returns whether `token` looks like a complete GFM footnote reference.
+pub(in crate::wrap::inline) fn looks_like_footnote_ref(token: &str) -> bool {
+    token
+        .strip_prefix("[^")
+        .and_then(|label| label.strip_suffix(']'))
+        .is_some_and(|label| !label.is_empty())
+}
+
+/// Returns whether `token` ends with an inline footnote reference.
+pub(in crate::wrap::inline) fn ends_with_footnote_ref(token: &str) -> bool {
+    let Some(start) = token.rfind("[^") else {
+        return false;
+    };
+
+    looks_like_footnote_ref(&token[start..])
+}
+
+/// Returns whether `token` contains only Unicode whitespace.
+pub(in crate::wrap::inline) fn is_whitespace_token(token: &str) -> bool {
+    token.chars().all(char::is_whitespace)
+}
+
+/// Returns whether `token` is a complete inline code span.
+pub(in crate::wrap::inline) fn is_inline_code_token(token: &str) -> bool {
+    token.starts_with('`') && token.ends_with('`')
+}
+
+/// Returns the substring beginning at the first Markdown link opener after any
+/// leading opener punctuation.
+pub(in crate::wrap::inline) fn link_text_after_leading_openers(text: &str) -> &str {
+    let mut rest = text;
+    while !rest.is_empty() {
+        if rest.starts_with('[') || rest.starts_with("![") {
+            return rest;
+        }
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        if is_opening_punct(ch) {
+            rest = &rest[ch.len_utf8()..];
+        } else {
+            break;
+        }
+    }
+    rest
+}
+
+/// Strips one outer wrapper closing character from a link candidate when present.
+fn strip_outer_link_wrapper_suffix(text: &str) -> Option<&str> {
+    let last = text.chars().next_back()?;
+    if matches!(last, ')' | ']' | '）' | '］' | '」' | '』' | '》') {
+        Some(&text[..text.len() - last.len_utf8()])
+    } else {
+        None
+    }
+}
+
+/// Returns whether rendered fragment text contains a Markdown link, including
+/// links wrapped in outer opener punctuation.
+pub(in crate::wrap::inline) fn fragment_is_link(text: &str) -> bool {
+    if looks_like_link(text) {
+        return true;
+    }
+    let mut candidate = link_text_after_leading_openers(text);
+    while !candidate.is_empty() {
+        if looks_like_link(candidate) {
+            return true;
+        }
+        let Some(next) = strip_outer_link_wrapper_suffix(candidate) else {
+            break;
+        };
+        candidate = next;
+    }
+    false
+}

--- a/src/wrap/inline/predicates.rs
+++ b/src/wrap/inline/predicates.rs
@@ -98,3 +98,86 @@ pub(in crate::wrap::inline) fn fragment_is_link(text: &str) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::{
+        is_inline_code_token,
+        is_opening_punct,
+        is_trailing_punct,
+        is_whitespace_token,
+        looks_like_footnote_ref,
+    };
+
+    fn backtick_run_strategy() -> BoxedStrategy<String> {
+        prop::collection::vec(Just('`'), 1..8)
+            .prop_map(|chars| chars.into_iter().collect::<String>())
+            .boxed()
+    }
+
+    fn arbitrary_short_string_strategy() -> BoxedStrategy<String> {
+        prop::collection::vec(any::<char>(), 0..24)
+            .prop_map(|chars| chars.into_iter().collect::<String>())
+            .boxed()
+    }
+
+    fn footnote_label_strategy() -> BoxedStrategy<String> {
+        prop::string::string_regex("[a-zA-Z0-9_-]+")
+            .unwrap()
+            .boxed()
+    }
+
+    #[test]
+    fn is_inline_code_token_rejects_lone_backtick_delimiter() {
+        let delimiter = char::from(b'`');
+        assert!(!is_inline_code_token(&delimiter.to_string()));
+    }
+
+    #[test]
+    fn is_inline_code_token_accepts_complete_span() {
+        let delimiter = char::from(b'`');
+        let token = format!("{delimiter}code{delimiter}");
+        assert!(is_inline_code_token(&token));
+    }
+
+    #[test]
+    fn is_inline_code_token_matches_backtick_delimited_length_rule() {
+        proptest!(|(token in backtick_run_strategy())| {
+            let expected = token.len() > 1 && token.starts_with('`') && token.ends_with('`');
+            prop_assert_eq!(is_inline_code_token(&token), expected);
+        });
+    }
+
+    #[test]
+    fn is_whitespace_token_matches_char_classification() {
+        proptest!(|(token in arbitrary_short_string_strategy())| {
+            prop_assert_eq!(
+                is_whitespace_token(&token),
+                token.chars().all(char::is_whitespace)
+            );
+        });
+    }
+
+    #[test]
+    fn opening_and_trailing_punct_are_mutually_exclusive_for_ascii_letters() {
+        for c in 'a'..='z' {
+            assert!(!is_opening_punct(c));
+            assert!(!is_trailing_punct(c));
+        }
+    }
+
+    #[test]
+    fn looks_like_footnote_ref_implies_non_empty_label() {
+        proptest!(|(label in footnote_label_strategy())| {
+            let token = format!("[^{label}]");
+            prop_assert!(looks_like_footnote_ref(&token));
+        });
+    }
+
+    #[test]
+    fn looks_like_footnote_ref_rejects_empty_label() {
+        assert!(!looks_like_footnote_ref("[^]"));
+    }
+}

--- a/src/wrap/inline/span_helpers.rs
+++ b/src/wrap/inline/span_helpers.rs
@@ -1,0 +1,127 @@
+//! Span-grouping helpers for inline token streams.
+//!
+//! These functions extend grouped spans over punctuation, whitespace, adjacent
+//! footnote markers, and chained inline code or link tokens during
+//! `determine_token_span`.
+
+use unicode_width::UnicodeWidthStr;
+
+use super::predicates::{
+    is_inline_code_token,
+    is_trailing_punct,
+    looks_like_footnote_ref,
+    looks_like_link,
+};
+
+/// Marks how a grouped token span should behave during wrapping.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub(in crate::wrap::inline) enum SpanKind {
+    /// Treat the span as ordinary prose.
+    General,
+    /// Treat the span as an inline code sequence.
+    Code,
+    /// Treat the span as a Markdown link or image link.
+    Link,
+    /// Treat the span as a GitHub Flavoured Markdown footnote reference.
+    FootnoteRef,
+}
+
+/// Extends a grouped span over trailing punctuation tokens and updates `width`.
+pub(in crate::wrap::inline) fn extend_punctuation(
+    tokens: &[String],
+    mut j: usize,
+    width: &mut usize,
+) -> usize {
+    while j < tokens.len() && tokens[j].chars().all(is_trailing_punct) {
+        *width += UnicodeWidthStr::width(tokens[j].as_str());
+        j += 1;
+    }
+    j
+}
+
+/// Decide whether whitespace between grouped tokens should stay attached to the
+/// current span.
+pub(in crate::wrap::inline) fn should_couple_whitespace(
+    kind: SpanKind,
+    next_token: Option<&String>,
+) -> bool {
+    match (kind, next_token) {
+        (SpanKind::Link, Some(next))
+            if looks_like_link(next)
+                || is_inline_code_token(next)
+                || next.chars().all(is_trailing_punct) =>
+        {
+            true
+        }
+        (SpanKind::Code, Some(next)) if next.chars().all(is_trailing_punct) => true,
+        _ => false,
+    }
+}
+
+/// Merges a backtick-opened code span into one grouped span and updates
+/// `width`.
+#[inline]
+pub(in crate::wrap::inline) fn merge_code_span(
+    tokens: &[String],
+    i: usize,
+    width: &mut usize,
+) -> usize {
+    debug_assert!(
+        tokens[i] == "`",
+        "merge_code_span requires a single backtick opener"
+    );
+    let mut j = i + 1;
+    while j < tokens.len() && tokens[j] != "`" {
+        *width += UnicodeWidthStr::width(tokens[j].as_str());
+        j += 1;
+    }
+    if j < tokens.len() {
+        *width += UnicodeWidthStr::width(tokens[j].as_str());
+        j += 1;
+        j = extend_punctuation(tokens, j, width);
+    }
+    j
+}
+
+/// Extends `end` by one token and any trailing punctuation that follows it.
+pub(in crate::wrap::inline) fn absorb_token_and_trailing_punctuation(
+    tokens: &[String],
+    end: usize,
+    width: &mut usize,
+) -> usize {
+    *width += UnicodeWidthStr::width(tokens[end].as_str());
+    extend_punctuation(tokens, end + 1, width)
+}
+
+/// Couples an adjacent footnote reference into the current span when appropriate.
+pub(in crate::wrap::inline) fn try_couple_footnote_reference(
+    tokens: &[String],
+    end: usize,
+    kind: SpanKind,
+    width: &mut usize,
+) -> Option<(SpanKind, usize)> {
+    let token = tokens.get(end)?;
+    if !looks_like_footnote_ref(token) {
+        return None;
+    }
+
+    match kind {
+        SpanKind::General => {
+            let previous = end
+                .checked_sub(1)
+                .and_then(|previous| tokens.get(previous))?;
+            if !previous.chars().last().is_some_and(is_trailing_punct) {
+                return None;
+            }
+            Some((
+                SpanKind::FootnoteRef,
+                absorb_token_and_trailing_punctuation(tokens, end, width),
+            ))
+        }
+        SpanKind::Code | SpanKind::Link => Some((
+            kind,
+            absorb_token_and_trailing_punctuation(tokens, end, width),
+        )),
+        SpanKind::FootnoteRef => None,
+    }
+}

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -9,4 +9,5 @@ mod inline_wrapping;
 mod link_ref_regex;
 mod link_reference_definitions;
 mod prefix;
+mod span_grouping_props;
 mod token_grouping;

--- a/src/wrap/tests/span_grouping_props.rs
+++ b/src/wrap/tests/span_grouping_props.rs
@@ -1,0 +1,39 @@
+//! Property tests for inline span grouping invariants.
+//!
+//! Validates that `determine_token_span` partitions token streams without gaps
+//! or overlaps and reports Unicode display widths that match grouped text.
+
+use proptest::prelude::*;
+use unicode_width::UnicodeWidthStr;
+
+use super::super::{inline::determine_token_span, tokenize::segment_inline};
+
+fn inline_text_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        prop::string::string_regex(r"[\w\s.,;:!?`()\[\]^-]{0,80}").unwrap(),
+        Just("`code`.[^1]".to_string()),
+        Just("[text](url).[^2]".to_string()),
+        Just("(`code`).[^3]".to_string()),
+        Just("See (`code`).[^4] for details.".to_string()),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn determine_token_span_partitions_segmented_tokens(input in inline_text_strategy()) {
+        let tokens = segment_inline(&input);
+        if tokens.is_empty() {
+            return Ok(());
+        }
+
+        let mut index = 0;
+        while index < tokens.len() {
+            let (end, width) = determine_token_span(&tokens, index);
+            prop_assert!(end > index, "span must advance at least one token");
+            let grouped = tokens[index..end].join("");
+            prop_assert_eq!(width, UnicodeWidthStr::width(grouped.as_str()));
+            index = end;
+        }
+        prop_assert_eq!(index, tokens.len());
+    }
+}

--- a/src/wrap/tests/span_grouping_props.rs
+++ b/src/wrap/tests/span_grouping_props.rs
@@ -10,7 +10,8 @@ use super::super::{inline::determine_token_span, tokenize::segment_inline};
 
 fn inline_text_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        prop::string::string_regex(r"[\w\s.,;:!?`()\[\]^-]{0,80}").unwrap(),
+        prop::string::string_regex(r"[\w\s.,;:!?`()\[\]^-]{0,80}")
+            .expect("invalid regex for span grouping property strategy"),
         Just("`code`.[^1]".to_string()),
         Just("[text](url).[^2]".to_string()),
         Just("(`code`).[^3]".to_string()),

--- a/tests/snapshots/wrap_unit__inline_footnote_reference_after_code_wrap.snap
+++ b/tests/snapshots/wrap_unit__inline_footnote_reference_after_code_wrap.snap
@@ -1,0 +1,6 @@
+---
+source: tests/wrap_unit.rs
+expression: "wrapped.join(\"\\n\")"
+---
+To assert specific outcomes, use the standard macros `assert!`, `assert_eq!`,
+and `assert_ne!`.[^3] This sentence follows the reference marker.

--- a/tests/snapshots/wrap_unit__inline_footnote_reference_after_opener_coupled_code_wrap.snap
+++ b/tests/snapshots/wrap_unit__inline_footnote_reference_after_opener_coupled_code_wrap.snap
@@ -1,0 +1,6 @@
+---
+source: tests/wrap_unit.rs
+expression: "wrapped.join(\"\\n\")"
+---
+See the standard macros (`assert!`, `assert_eq!`, and `assert_ne!`).[^3] This
+sentence follows the reference marker.

--- a/tests/wrap_unit.rs
+++ b/tests/wrap_unit.rs
@@ -264,6 +264,28 @@ fn wrap_text_keeps_footnote_reference_with_preceding_inline_code() {
     );
 }
 
+#[test]
+fn wrap_text_keeps_footnote_reference_with_opener_coupled_inline_code() {
+    let input = lines_vec![concat!(
+        "See the standard macros (`assert!`, `assert_eq!`, and `assert_ne!`).[^3] ",
+        "This sentence follows the reference marker.",
+    )];
+
+    let wrapped = wrap_text(&input, 80);
+
+    assert_footnote_reference_is_intact(&wrapped, "[^3]");
+    assert!(
+        wrapped
+            .iter()
+            .any(|line| line.contains("`assert_ne!`).[^3]"))
+    );
+
+    insta::assert_snapshot!(
+        "inline_footnote_reference_after_opener_coupled_code_wrap",
+        wrapped.join("\n")
+    );
+}
+
 /// Guards issue `#261` by asserting both fenced and four-space indented shell
 /// blocks remain byte-identical after `wrap_text` processes surrounding
 /// Markdown.

--- a/tests/wrap_unit.rs
+++ b/tests/wrap_unit.rs
@@ -242,6 +242,28 @@ fn wrap_text_snapshots_inline_footnote_reference_outputs() {
     );
 }
 
+#[test]
+fn wrap_text_keeps_footnote_reference_with_preceding_inline_code() {
+    let input = lines_vec![concat!(
+        "To assert specific outcomes, use the standard macros `assert!`, `assert_eq!`, and ",
+        "`assert_ne!`.[^3] This sentence follows the reference marker.",
+    )];
+
+    let wrapped = wrap_text(&input, 80);
+
+    assert_footnote_reference_is_intact(&wrapped, "[^3]");
+    assert!(
+        wrapped
+            .iter()
+            .any(|line| line.contains("`assert_ne!`.[^3]"))
+    );
+
+    insta::assert_snapshot!(
+        "inline_footnote_reference_after_code_wrap",
+        wrapped.join("\n")
+    );
+}
+
 /// Guards issue `#261` by asserting both fenced and four-space indented shell
 /// blocks remain byte-identical after `wrap_text` processes surrounding
 /// Markdown.

--- a/tests/wrap_unit.rs
+++ b/tests/wrap_unit.rs
@@ -242,48 +242,38 @@ fn wrap_text_snapshots_inline_footnote_reference_outputs() {
     );
 }
 
-#[test]
-fn wrap_text_keeps_footnote_reference_with_preceding_inline_code() {
-    let input = lines_vec![concat!(
+#[rstest]
+#[case(
+    concat!(
         "To assert specific outcomes, use the standard macros `assert!`, `assert_eq!`, and ",
         "`assert_ne!`.[^3] This sentence follows the reference marker.",
-    )];
-
-    let wrapped = wrap_text(&input, 80);
-
-    assert_footnote_reference_is_intact(&wrapped, "[^3]");
-    assert!(
-        wrapped
-            .iter()
-            .any(|line| line.contains("`assert_ne!`.[^3]"))
-    );
-
-    insta::assert_snapshot!(
-        "inline_footnote_reference_after_code_wrap",
-        wrapped.join("\n")
-    );
-}
-
-#[test]
-fn wrap_text_keeps_footnote_reference_with_opener_coupled_inline_code() {
-    let input = lines_vec![concat!(
+    ),
+    "[^3]",
+    "`assert_ne!`.[^3]",
+    "inline_footnote_reference_after_code_wrap"
+)]
+#[case(
+    concat!(
         "See the standard macros (`assert!`, `assert_eq!`, and `assert_ne!`).[^3] ",
         "This sentence follows the reference marker.",
-    )];
-
+    ),
+    "[^3]",
+    "`assert_ne!`).[^3]",
+    "inline_footnote_reference_after_opener_coupled_code_wrap"
+)]
+fn wrap_text_keeps_footnote_reference_with_preceding_atomic_span(
+    #[case] paragraph: &str,
+    #[case] marker: &str,
+    #[case] expected_snippet: &str,
+    #[case] snapshot_name: &str,
+) {
+    let input = lines_vec![paragraph];
     let wrapped = wrap_text(&input, 80);
 
-    assert_footnote_reference_is_intact(&wrapped, "[^3]");
-    assert!(
-        wrapped
-            .iter()
-            .any(|line| line.contains("`assert_ne!`).[^3]"))
-    );
+    assert_footnote_reference_is_intact(&wrapped, marker);
+    assert!(wrapped.iter().any(|line| line.contains(expected_snippet)));
 
-    insta::assert_snapshot!(
-        "inline_footnote_reference_after_opener_coupled_code_wrap",
-        wrapped.join("\n")
-    );
+    insta::assert_snapshot!(snapshot_name, wrapped.join("\n"));
 }
 
 /// Guards issue `#261` by asserting both fenced and four-space indented shell


### PR DESCRIPTION
## Summary

Closes #299

When `mdtablefix --wrap` reflows a paragraph, GFM footnote reference markers
that immediately follow sentence-ending punctuation on inline code or link
spans were being wrapped onto the next line (for example, `` `assert_ne!`.[^3]
`` becoming `` `assert_ne!`.
[^3] ``). This change extends
[`determine_token_span`](src/wrap/inline.rs) so Code and Link spans absorb
adjacent footnote reference tokens after trailing punctuation has been
coupled, mirroring the existing `promote_footnote_span` behaviour without
changing span kind.

## Changes

- Add a Code/Link branch in the span-grouping loop in
  [`src/wrap/inline.rs`](src/wrap/inline.rs) to keep footnote markers with
  the preceding atomic span.
- Add unit tests in
  [`src/wrap/inline/footnote_tests.rs`](src/wrap/inline/footnote_tests.rs)
  for inline code and link shapes such as `` `assert_ne!`.[^3] `` and
  `[click here](https://example.com).[^1]`.
- Add an integration snapshot in
  [`tests/wrap_unit.rs`](tests/wrap_unit.rs) covering wrap output near a
  line boundary.

## Test plan

- [x] `make check-fmt`
- [x] `make lint`
- [x] `make test`
- [x] CodeRabbit review (`coderabbit review --agent`) — 0 findings

## Summary by Sourcery

Ensure GFM footnote references stay attached to preceding inline code and link spans during wrapping.

Bug Fixes:
- Prevent footnote reference markers after inline code or links from being wrapped onto the next line, keeping them grouped with the preceding span.

Tests:
- Add unit tests for footnote references following inline code and link spans across various punctuation shapes.
- Add an integration snapshot test to verify wrapped output keeps inline code footnote references intact near line boundaries.