### PR TITLE
Keep inline citation links attached while wrapping (#325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hyphenated words are treated as indivisible during wrapping, so
 `very-long-word` will move to the next line intact rather than split at the
 hyphen. The wrap engine now delegates line fitting to the `textwrap` crate
 while preserving Markdown-aware token grouping for inline code, links, GFM
-footnote references, parenthesised inline citations such as
+footnote references, parenthesized inline citations such as
 `pattern([1](url))`, and hard breaks. The tool ignores fenced code blocks and
 respects escaped pipes (`\|`), making it safe to use on Markdown with mixed
 content.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Hyphenated words are treated as indivisible during wrapping, so
 `very-long-word` will move to the next line intact rather than split at the
 hyphen. The wrap engine now delegates line fitting to the `textwrap` crate
 while preserving Markdown-aware token grouping for inline code, links, GFM
-footnote references, and hard breaks. The tool ignores fenced code blocks and
+footnote references, parenthesised inline citations such as
+`pattern([1](url))`, and hard breaks. The tool ignores fenced code blocks and
 respects escaped pipes (`\|`), making it safe to use on Markdown with mixed
 content.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -222,11 +222,14 @@ The wrapping pipeline for `--wrap` is:
    code or link tokens. `determine_token_span` forward-couples opening
    punctuation tokens (`(`, `[`, and CJK openers) and hyphen-prefix tokens
    to the next inline code span or Markdown link so wrapping never leaves a
-   lone opener or prefix at the end of a line. Trailing punctuation after
-   those atomic spans is grouped in the same
-   pass, and GFM footnote references that immediately follow inline code or
-   links (including opener-coupled spans) stay attached to the preceding
-   punctuation cluster.
+   lone opener or prefix at the end of a line.
+   `try_couple_inline_link_after_opener` applies the same rule to
+   parenthesised inline citation links such as `([1](url))`, grouping the
+   opener and link as one `SpanKind::Link` so adjacent citations like
+   `([1](url))([2](url2))` do not split at the boundary. Trailing punctuation
+   after those atomic spans is grouped in the same pass, and GFM footnote
+   references that immediately follow inline code or links (including
+   opener-coupled spans) stay attached to the preceding punctuation cluster.
 
 4. **Post-processing and rendering.** The `postprocess` module applies
    `merge_whitespace_only_lines` and then `rebalance_atomic_tails` so
@@ -303,6 +306,7 @@ Table: Key types and functions.
 | `classify_fragment`                                                                                                                                                                                                                                          | `src/wrap/inline/fragment.rs`     |
 | Character and fragment predicates (`is_inline_code_token`, `looks_like_link`, `looks_like_footnote_ref`, …)                                                                                                                                                  | `src/wrap/inline/predicates.rs`   |
 | `SpanKind`, span grouping helpers (`merge_code_span`, `try_couple_footnote_reference`, …)                                                                                                                                                                    | `src/wrap/inline/span_helpers.rs` |
+| `try_couple_inline_link_after_opener`                                                                                                                                                                                                                        | `src/wrap/inline/span_helpers.rs` |
 | `build_fragments`, `wrap_preserving_code`, `render_line`                                                                                                                                                                                                     | `src/wrap/inline.rs`              |
 | `determine_token_span`                                                                                                                                                                                                                                       | `src/wrap/inline.rs`              |
 | `merge_whitespace_only_lines`                                                                                                                                                                                                                                | `src/wrap/inline/postprocess.rs`  |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -226,10 +226,19 @@ The wrapping pipeline for `--wrap` is:
    `try_couple_inline_link_after_opener` applies the same rule to
    parenthesized inline citation links such as `([1](url))`, grouping the
    opener and link as one `SpanKind::Link` so adjacent citations like
-   `([1](url))([2](url2))` do not split at the boundary. Trailing punctuation
-   after those atomic spans is grouped in the same pass, and GFM footnote
-   references that immediately follow inline code or links (including
-   opener-coupled spans) stay attached to the preceding punctuation cluster.
+   `([1](url))([2](url2))` do not split at the boundary. At the tokeniser
+   level, `segment_inline` also stops trailing-punctuation and plain-text
+   scans at an unescaped `([` boundary via `scan_trailing_punctuation_end` and
+   `scan_plain_text_end`, both using `starts_inline_citation`, so the citation
+   opener `(` is emitted as its own token instead of being swallowed into the
+   preceding token's punctuation cluster. That boundary gives
+   `determine_token_span` and `try_couple_inline_link_after_opener` a clean
+   opener token to couple with the following inline link, making the full
+   `([n](url))` span atomic, while escaped sequences such as `\([` bypass the
+   early exit and remain plain text. Trailing punctuation after those atomic
+   spans is grouped in the same pass, and GFM footnote references that
+   immediately follow inline code or links (including opener-coupled spans)
+   stay attached to the preceding punctuation cluster.
 
 4. **Post-processing and rendering.** The `postprocess` module applies
    `merge_whitespace_only_lines` and then `rebalance_atomic_tails` so
@@ -319,6 +328,7 @@ Table: Key types and functions.
 | `pending_prefix_for_next_segment` — Selects the original pending prefix for the first deferred segment, then the continuation indent for later segments.                                                                                                     | `src/wrap/paragraph.rs`           |
 | `apply_continuation_chunk` — Centralized join/update/dispatch entry point that reconciles a single continuation chunk with the active `PendingPrefix` buffer.                                                                                                | `src/wrap/continuation.rs`        |
 | `join_pending_continuation`                                                                                                                                                                                                                                  | `src/wrap/continuation.rs`        |
+| `starts_inline_citation`                                                                                                                                                                                                                                     | `src/wrap/tokenize/mod.rs`        |
 | `opening_fence_run_len` — Measures the length of an unescaped backtick run at the start of a byte slice; used to identify opening code-span fences.                                                                                                          | `src/wrap/tokenize/scanning.rs`   |
 | `scan_continuation_span_state` — Incrementally scans a continuation string given a known open fence length, returning the remaining open fence length or `None` when all spans are balanced; used to avoid O(N²) rescanning of the accumulated pending text. | `src/wrap/tokenize/scanning.rs`   |
 | `handle_pending_continuation`                                                                                                                                                                                                                                | `src/wrap.rs`                     |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -224,7 +224,7 @@ The wrapping pipeline for `--wrap` is:
    to the next inline code span or Markdown link so wrapping never leaves a
    lone opener or prefix at the end of a line.
    `try_couple_inline_link_after_opener` applies the same rule to
-   parenthesised inline citation links such as `([1](url))`, grouping the
+   parenthesized inline citation links such as `([1](url))`, grouping the
    opener and link as one `SpanKind::Link` so adjacent citations like
    `([1](url))([2](url2))` do not split at the boundary. Trailing punctuation
    after those atomic spans is grouped in the same pass, and GFM footnote

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -39,7 +39,7 @@ footnote references (`[^label]`) are treated as unbreakable units. A span is
 never split across lines; it moves as a whole to the next line when it would
 otherwise exceed the target width.
 
-Parenthesised inline citations such as `pattern([1](url))` are also treated as
+Parenthesized inline citations such as `pattern([1](url))` are also treated as
 unbreakable units, keeping the citation link and its surrounding parentheses
 together during wrapping.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -39,6 +39,10 @@ footnote references (`[^label]`) are treated as unbreakable units. A span is
 never split across lines; it moves as a whole to the next line when it would
 otherwise exceed the target width.
 
+Parenthesised inline citations such as `pattern([1](url))` are also treated as
+unbreakable units, keeping the citation link and its surrounding parentheses
+together during wrapping.
+
 When an inline code span is split across two or more soft-wrapped source lines,
 `--wrap` first joins the continuation lines into a single span before applying
 any line-length limit. The joined span is then treated as an indivisible unit:

--- a/src/wrap/inline.rs
+++ b/src/wrap/inline.rs
@@ -46,6 +46,7 @@ use span_helpers::{
     merge_code_span,
     should_couple_whitespace,
     try_couple_footnote_reference,
+    try_couple_inline_link_after_opener,
 };
 use textwrap::wrap_algorithms::wrap_first_fit;
 use unicode_width::UnicodeWidthStr;
@@ -136,6 +137,14 @@ pub(super) fn determine_token_span(tokens: &[String], start: usize) -> (usize, u
 
         let is_link = looks_like_link(token);
         let is_code = is_code_token(token);
+        if let Some((next_kind, next_end)) =
+            try_couple_inline_link_after_opener(tokens, end, &mut width)
+        {
+            kind = next_kind;
+            end = next_end;
+            continue;
+        }
+
         // Footnote markers must be coupled before consecutive link/code chaining;
         // otherwise `[^N]` stays a separate wrap token even when punctuation is
         // already attached to the preceding atomic span.

--- a/src/wrap/inline/span_helpers.rs
+++ b/src/wrap/inline/span_helpers.rs
@@ -8,6 +8,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::predicates::{
     is_inline_code_token,
+    is_opening_punct,
     is_trailing_punct,
     is_trailing_punctuation_token,
     looks_like_footnote_ref,
@@ -92,6 +93,24 @@ pub(in crate::wrap::inline) fn absorb_token_and_trailing_punctuation(
 ) -> usize {
     *width += UnicodeWidthStr::width(tokens[end].as_str());
     extend_punctuation(tokens, end + 1, width)
+}
+
+/// Couples an opener-followed inline link, such as `([1](url))`, into the
+/// current span.
+pub(in crate::wrap::inline) fn try_couple_inline_link_after_opener(
+    tokens: &[String],
+    end: usize,
+    width: &mut usize,
+) -> Option<(SpanKind, usize)> {
+    let opener = tokens.get(end)?;
+    let link = tokens.get(end + 1)?;
+    if !opener.chars().all(is_opening_punct) || !looks_like_link(link) {
+        return None;
+    }
+
+    *width += UnicodeWidthStr::width(opener.as_str());
+    *width += UnicodeWidthStr::width(link.as_str());
+    Some((SpanKind::Link, extend_punctuation(tokens, end + 2, width)))
 }
 
 /// Couples an adjacent footnote reference into the current span when appropriate.

--- a/src/wrap/tests/inline_wrapping.rs
+++ b/src/wrap/tests/inline_wrapping.rs
@@ -146,6 +146,20 @@ fn wrap_preserving_code_keeps_opening_bracket_with_inline_code(
     }
 }
 
+fn citation_link_starts(expected_citation: &str) -> Vec<String> {
+    let mut markers = Vec::new();
+    let mut remaining = expected_citation;
+    while let Some(open_index) = remaining.find('[') {
+        let candidate = &remaining[open_index..];
+        let Some(close_index) = candidate.find("](") else {
+            break;
+        };
+        markers.push(candidate[..close_index + 2].to_string());
+        remaining = &candidate[close_index + 2..];
+    }
+    markers
+}
+
 #[rstest]
 #[case(
     "The formatter keeps pattern([1](https://example.com/ref)) attached while wrapping.",
@@ -166,6 +180,11 @@ fn wrap_preserving_code_keeps_inline_citation_links_attached(
     #[case] expected_citation: &str,
 ) {
     let lines = wrap_preserving_code(input, width);
+    let citation_link_starts = citation_link_starts(expected_citation);
+    assert!(
+        !citation_link_starts.is_empty(),
+        "expected citation fixture must contain at least one inline link",
+    );
     assert!(
         lines.iter().any(|line| line.contains(expected_citation)),
         "expected citation to stay attached in {lines:?}",
@@ -175,11 +194,12 @@ fn wrap_preserving_code_keeps_inline_citation_links_attached(
         "opening parenthesis must not be stranded at line end: {lines:?}",
     );
     assert!(
-        lines
-            .iter()
-            .all(|line| !line.trim_start().starts_with("[1](")
-                && !line.trim_start().starts_with("[6](")
-                && !line.trim_start().starts_with("[7](")),
+        lines.iter().all(|line| {
+            let trimmed = line.trim_start();
+            citation_link_starts
+                .iter()
+                .all(|marker| !trimmed.starts_with(marker))
+        }),
         "citation link must not start a continuation line: {lines:?}",
     );
     assert!(

--- a/src/wrap/tests/inline_wrapping.rs
+++ b/src/wrap/tests/inline_wrapping.rs
@@ -1,4 +1,12 @@
-//! Tests for inline wrapping that preserves code spans and links.
+//! Tests for the inline wrapping pipeline.
+//!
+//! These cases exercise `wrap_preserving_code` and
+//! `attach_punctuation_to_previous_line` from `crate::wrap::inline`, covering
+//! trailing-punctuation coupling with links, hard-break preservation, and the
+//! `([n](url))` inline citation attachment introduced in issue #325. The suite
+//! uses `proptest` for generated wrapping cases and `rstest` for fixture-driven
+//! and snapshot tests, verifying that parenthesized citation links and adjacent
+//! citation chains are never split across wrapped lines.
 
 use std::fmt::Write as _;
 

--- a/src/wrap/tests/inline_wrapping.rs
+++ b/src/wrap/tests/inline_wrapping.rs
@@ -1,5 +1,7 @@
 //! Tests for inline wrapping that preserves code spans and links.
 
+use std::fmt::Write as _;
+
 use rstest::rstest;
 
 use super::{
@@ -51,6 +53,23 @@ proptest::proptest! {
             lines.iter().all(|line| line.trim() != punctuation.to_string()),
             "punctuation was orphaned in {lines:?}",
         );
+    }
+
+    #[test]
+    fn wrap_preserving_code_keeps_generated_inline_citations_attached(
+        wrap_width in 24usize..96,
+        prefix_len in 0usize..32,
+        citation_count in 1usize..6,
+    ) {
+        let citation = inline_citation_chain(citation_count);
+        let expected_citation = format!("pattern{citation}");
+        let input = format!(
+            "{}{expected_citation} trailing words force wrapping",
+            "lead ".repeat(prefix_len)
+        );
+        let lines = wrap_preserving_code(&input, wrap_width);
+
+        assert_inline_citation_invariants(&lines, &expected_citation);
     }
 }
 
@@ -160,6 +179,44 @@ fn citation_link_starts(expected_citation: &str) -> Vec<String> {
     markers
 }
 
+fn inline_citation_chain(citation_count: usize) -> String {
+    let mut citation = String::new();
+    for index in 1..=citation_count {
+        write!(citation, "([{index}](https://example.com/ref{index}))")
+            .expect("writing to String cannot fail");
+    }
+    citation
+}
+
+fn assert_inline_citation_invariants(lines: &[String], expected_citation: &str) {
+    let citation_link_starts = citation_link_starts(expected_citation);
+    assert!(
+        !citation_link_starts.is_empty(),
+        "expected citation fixture must contain at least one inline link",
+    );
+    assert!(
+        lines.iter().any(|line| line.contains(expected_citation)),
+        "expected citation to stay attached in {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| !line.ends_with('(')),
+        "opening citation punctuation must not be stranded at line end: {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| {
+            let trimmed = line.trim_start();
+            citation_link_starts
+                .iter()
+                .all(|marker| !trimmed.starts_with(marker))
+        }),
+        "citation link must not start a continuation line: {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| line.trim() != ")("),
+        "adjacent citation punctuation must not be orphaned: {lines:?}",
+    );
+}
+
 #[rstest]
 #[case(
     "The formatter keeps pattern([1](https://example.com/ref)) attached while wrapping.",
@@ -180,31 +237,41 @@ fn wrap_preserving_code_keeps_inline_citation_links_attached(
     #[case] expected_citation: &str,
 ) {
     let lines = wrap_preserving_code(input, width);
-    let citation_link_starts = citation_link_starts(expected_citation);
-    assert!(
-        !citation_link_starts.is_empty(),
-        "expected citation fixture must contain at least one inline link",
+    assert_inline_citation_invariants(&lines, expected_citation);
+}
+
+#[test]
+fn wrap_preserving_code_snapshots_single_inline_citation() {
+    let lines = wrap_preserving_code(
+        "The formatter keeps pattern([1](https://example.com/ref)) attached while wrapping.",
+        32,
     );
-    assert!(
-        lines.iter().any(|line| line.contains(expected_citation)),
-        "expected citation to stay attached in {lines:?}",
+    insta::assert_snapshot!(
+        lines.join("\n"),
+        @r###"
+The formatter keeps
+pattern([1](https://example.com/ref))
+attached while wrapping.
+"###
     );
-    assert!(
-        lines.iter().all(|line| !line.ends_with('(')),
-        "opening parenthesis must not be stranded at line end: {lines:?}",
+}
+
+#[test]
+fn wrap_preserving_code_snapshots_adjacent_inline_citations() {
+    let lines = wrap_preserving_code(
+        concat!(
+            "The formatter keeps runtime([6](https://example.com/command))",
+            "([7](https://example.com/event)) attached while wrapping."
+        ),
+        34,
     );
-    assert!(
-        lines.iter().all(|line| {
-            let trimmed = line.trim_start();
-            citation_link_starts
-                .iter()
-                .all(|marker| !trimmed.starts_with(marker))
-        }),
-        "citation link must not start a continuation line: {lines:?}",
-    );
-    assert!(
-        lines.iter().all(|line| line.trim() != ")("),
-        "adjacent citation punctuation must not be orphaned: {lines:?}",
+    insta::assert_snapshot!(
+        lines.join("\n"),
+        @r###"
+The formatter keeps
+runtime([6](https://example.com/command))([7](https://example.com/event))
+attached while wrapping.
+"###
     );
 }
 

--- a/src/wrap/tests/inline_wrapping.rs
+++ b/src/wrap/tests/inline_wrapping.rs
@@ -146,6 +146,48 @@ fn wrap_preserving_code_keeps_opening_bracket_with_inline_code(
     }
 }
 
+#[rstest]
+#[case(
+    "The formatter keeps pattern([1](https://example.com/ref)) attached while wrapping.",
+    32,
+    "pattern([1](https://example.com/ref))"
+)]
+#[case(
+    concat!(
+        "The formatter keeps runtime([6](https://example.com/command))",
+        "([7](https://example.com/event)) attached while wrapping."
+    ),
+    34,
+    "runtime([6](https://example.com/command))([7](https://example.com/event))",
+)]
+fn wrap_preserving_code_keeps_inline_citation_links_attached(
+    #[case] input: &str,
+    #[case] width: usize,
+    #[case] expected_citation: &str,
+) {
+    let lines = wrap_preserving_code(input, width);
+    assert!(
+        lines.iter().any(|line| line.contains(expected_citation)),
+        "expected citation to stay attached in {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| !line.ends_with('(')),
+        "opening parenthesis must not be stranded at line end: {lines:?}",
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|line| !line.trim_start().starts_with("[1](")
+                && !line.trim_start().starts_with("[6](")
+                && !line.trim_start().starts_with("[7](")),
+        "citation link must not start a continuation line: {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| line.trim() != ")("),
+        "adjacent citation punctuation must not be orphaned: {lines:?}",
+    );
+}
+
 #[test]
 fn wrap_preserving_code_glues_punctuation_after_code() {
     let lines = wrap_preserving_code("line with `code` !", 80);

--- a/src/wrap/tests/span_grouping_props.rs
+++ b/src/wrap/tests/span_grouping_props.rs
@@ -27,6 +27,14 @@ fn inline_text_strategy() -> impl Strategy<Value = String> {
     ]
 }
 
+/// Builds the `inline_citation_strategy` inputs for citation-specific cases.
+///
+/// This strategy produces a single `pattern()` citation, multiple
+/// back-to-back `pattern()` citations, and a `reference()` citation so the
+/// property exercises those citation forms directly. Unlike
+/// `inline_text_strategy`, which generates general inline text, this helper
+/// keeps the input space focused on the parenthesized inline-link shapes that
+/// validate citation coupling.
 fn inline_citation_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
         Just("pattern([1](https://github.com/leynos/mdtablefix/pull/url))".to_string()),
@@ -41,6 +49,12 @@ fn inline_citation_strategy() -> impl Strategy<Value = String> {
     ]
 }
 
+/// Reconstructs span text by partitioning `tokens` with `determine_token_span`.
+///
+/// The `tokens: &[String]` input is the segmented inline token stream. The
+/// helper advances by each `end` index returned from `determine_token_span` and
+/// returns a `Vec<String>` whose entries are the joined tokens for consecutive
+/// spans, making span-boundary validation explicit in property assertions.
 fn grouped_spans(tokens: &[String]) -> Vec<String> {
     let mut spans = Vec::new();
     let mut index = 0;

--- a/src/wrap/tests/span_grouping_props.rs
+++ b/src/wrap/tests/span_grouping_props.rs
@@ -16,7 +16,40 @@ fn inline_text_strategy() -> impl Strategy<Value = String> {
         Just("[text](url).[^2]".to_string()),
         Just("(`code`).[^3]".to_string()),
         Just("See (`code`).[^4] for details.".to_string()),
+        Just("pattern([1](https://github.com/leynos/mdtablefix/pull/url))".to_string()),
+        Just(
+            concat!(
+                "pattern([1](https://github.com/leynos/mdtablefix/pull/url))",
+                "([2](https://github.com/leynos/mdtablefix/issues/325))"
+            )
+            .to_string()
+        ),
     ]
+}
+
+fn inline_citation_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("pattern([1](https://github.com/leynos/mdtablefix/pull/url))".to_string()),
+        Just(
+            concat!(
+                "pattern([1](https://github.com/leynos/mdtablefix/pull/url))",
+                "([2](https://github.com/leynos/mdtablefix/issues/325))"
+            )
+            .to_string()
+        ),
+        Just("reference([42](https://github.com/leynos/mdtablefix/tree/main))".to_string()),
+    ]
+}
+
+fn grouped_spans(tokens: &[String]) -> Vec<String> {
+    let mut spans = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        let (end, _) = determine_token_span(tokens, index);
+        spans.push(tokens[index..end].join(""));
+        index = end;
+    }
+    spans
 }
 
 proptest! {
@@ -36,5 +69,23 @@ proptest! {
             index = end;
         }
         prop_assert_eq!(index, tokens.len());
+    }
+
+    #[test]
+    fn determine_token_span_keeps_inline_citation_chain_atomic(
+        prefix in prop::string::string_regex(r"[\w ]{0,32}")
+            .expect("invalid regex for citation prefix strategy"),
+        citation in inline_citation_strategy(),
+        suffix in prop::string::string_regex(r"[\w .,;:!?]{0,32}")
+            .expect("invalid regex for citation suffix strategy"),
+    ) {
+        let input = format!("{prefix}{citation}{suffix}");
+        let tokens = segment_inline(&input);
+        let spans = grouped_spans(&tokens);
+
+        prop_assert!(
+            spans.iter().any(|span| span.contains(&citation)),
+            "expected citation chain to stay within one span; tokens={tokens:?}, spans={spans:?}",
+        );
     }
 }

--- a/src/wrap/tests/token_grouping.rs
+++ b/src/wrap/tests/token_grouping.rs
@@ -56,6 +56,22 @@ fn determine_token_span_groups_citation_openers(
 }
 
 #[rstest]
+#[case("word [link](url)", 0, "word")]
+#[case("word([link](url))", 2, "[link](url))")]
+#[case("word([link](url))", 3, ")")]
+fn determine_token_span_does_not_overcouple_citation_tokens(
+    #[case] input: &str,
+    #[case] start: usize,
+    #[case] expected_group: &str,
+) {
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, start);
+    let grouped = tokens[start..end].join("");
+    assert_eq!(grouped, expected_group);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected_group));
+}
+
+#[rstest]
 #[case("word[link](url)", &["word", "[link](url)"])]
 #[case(
     "word[link](url)[another](url2)",
@@ -75,6 +91,8 @@ fn segment_inline_splits_before_embedded_links(#[case] input: &str, #[case] expe
 #[case(r"word\[link](url)")]
 #[case(r"\![img](url)")]
 #[case(r"word\![img](url)")]
+#[case(r"\([link](url))")]
+#[case(r"word\([link](url))")]
 fn segment_inline_preserves_escaped_link_literals(#[case] input: &str) {
     assert_eq!(segment_inline(input), vec![input.to_string()]);
 }

--- a/src/wrap/tests/token_grouping.rs
+++ b/src/wrap/tests/token_grouping.rs
@@ -1,4 +1,13 @@
-//! Token grouping tests for inline segmentation and span determination.
+//! Tests for inline tokenisation and span grouping.
+//!
+//! These cases exercise `segment_inline` tokenisation and
+//! `determine_token_span` span grouping from `crate::wrap`, covering
+//! trailing-punctuation grouping after code and link tokens, multi-token
+//! coupling for footnote references and adjacent links, splitting before
+//! embedded inline links, and the parenthesized inline citation coupling added
+//! in issue #325. The suite includes positive grouping cases, negative cases
+//! that prevent over-coupling at non-opener positions, and escaped-sequence
+//! preservation.
 
 use rstest::rstest;
 

--- a/src/wrap/tests/token_grouping.rs
+++ b/src/wrap/tests/token_grouping.rs
@@ -28,6 +28,8 @@ use super::super::{inline::determine_token_span, tokenize::segment_inline};
 #[case("（`code`）", "（`code`）")]
 #[case("「`code`」", "「`code`」")]
 #[case("([link](url))", "([link](url))")]
+#[case("word([link](url))", "word([link](url))")]
+#[case("word([1](url))([2](url2))", "word([1](url))([2](url2))")]
 #[case("[[link](url)]", "[[link](url)]")]
 fn determine_token_span_groups_related_tokens(#[case] input: &str, #[case] expected_group: &str) {
     let tokens = segment_inline(input);
@@ -38,11 +40,29 @@ fn determine_token_span_groups_related_tokens(#[case] input: &str, #[case] expec
 }
 
 #[rstest]
+#[case("word([link](url))", 1, "([link](url))")]
+#[case("word([1](url))([2](url2))", 1, "([1](url))([2](url2))")]
+#[case("word([1](url))([2](url2))", 4, "([2](url2))")]
+fn determine_token_span_groups_citation_openers(
+    #[case] input: &str,
+    #[case] start: usize,
+    #[case] expected_group: &str,
+) {
+    let tokens = segment_inline(input);
+    let (end, width) = determine_token_span(&tokens, start);
+    let grouped = tokens[start..end].join("");
+    assert_eq!(grouped, expected_group);
+    assert_eq!(width, unicode_width::UnicodeWidthStr::width(expected_group));
+}
+
+#[rstest]
 #[case("word[link](url)", &["word", "[link](url)"])]
 #[case(
     "word[link](url)[another](url2)",
     &["word", "[link](url)", "[another](url2)"]
 )]
+#[case("word([link](url))", &["word", "(", "[link](url)", ")"])]
+#[case("([link](url))", &["(", "[link](url)", ")"])]
 #[case("word![img](url)", &["word", "![img](url)"])]
 fn segment_inline_splits_before_embedded_links(#[case] input: &str, #[case] expected: &[&str]) {
     let tokens = segment_inline(input);

--- a/src/wrap/tokenize/mod.rs
+++ b/src/wrap/tokenize/mod.rs
@@ -104,7 +104,7 @@ pub(super) fn segment_inline(text: &str) -> Vec<String> {
             let (tok, mut new_i) = parse_link_or_image(text, i);
             tokens.push(tok);
             let punct_start = new_i;
-            new_i = scan_while(text, new_i, is_trailing_punctuation);
+            new_i = scan_trailing_punctuation_end(text, new_i);
             if new_i > punct_start {
                 tokens.push(collect_range(text, punct_start, new_i));
             }
@@ -119,6 +119,26 @@ pub(super) fn segment_inline(text: &str) -> Vec<String> {
     tokens
 }
 
+fn scan_trailing_punctuation_end(text: &str, mut index: usize) -> usize {
+    while index < text.len() {
+        let Some(current) = text[index..].chars().next() else {
+            break;
+        };
+        if current == '('
+            && text
+                .get(index + 1..)
+                .is_some_and(|tail| tail.starts_with('['))
+        {
+            break;
+        }
+        if !is_trailing_punctuation(current) {
+            break;
+        }
+        index += current.len_utf8();
+    }
+    index
+}
+
 fn append_escaped_backtick(tokens: &mut Vec<String>) {
     if let Some(last) = tokens.last_mut() {
         last.push('`');
@@ -128,6 +148,10 @@ fn append_escaped_backtick(tokens: &mut Vec<String>) {
 }
 
 fn scan_plain_text_end(text: &str, bytes: &[u8], mut index: usize) -> usize {
+    if text[index..].starts_with("([") {
+        return index + 1;
+    }
+
     while index < text.len() {
         let Some(current) = text[index..].chars().next() else {
             break;
@@ -150,6 +174,12 @@ fn should_stop_plain_text(text: &str, bytes: &[u8], index: usize, current: (char
     let (ch, is_escaped) = current;
     if ch == '[' {
         return !is_escaped && !bracket_follows_escaped_bang(bytes, index);
+    }
+    if ch == '(' {
+        return !is_escaped
+            && text
+                .get(index + 1..)
+                .is_some_and(|tail| tail.starts_with('['));
     }
     looks_like_image_start(text, index, ch) && !is_escaped
 }

--- a/src/wrap/tokenize/mod.rs
+++ b/src/wrap/tokenize/mod.rs
@@ -124,11 +124,7 @@ fn scan_trailing_punctuation_end(text: &str, mut index: usize) -> usize {
         let Some(current) = text[index..].chars().next() else {
             break;
         };
-        if current == '('
-            && text
-                .get(index + 1..)
-                .is_some_and(|tail| tail.starts_with('['))
-        {
+        if starts_inline_citation(text, index) {
             break;
         }
         if !is_trailing_punctuation(current) {
@@ -137,6 +133,10 @@ fn scan_trailing_punctuation_end(text: &str, mut index: usize) -> usize {
         index += current.len_utf8();
     }
     index
+}
+
+fn starts_inline_citation(text: &str, index: usize) -> bool {
+    text.get(index..).is_some_and(|tail| tail.starts_with("(["))
 }
 
 fn append_escaped_backtick(tokens: &mut Vec<String>) {
@@ -148,7 +148,7 @@ fn append_escaped_backtick(tokens: &mut Vec<String>) {
 }
 
 fn scan_plain_text_end(text: &str, bytes: &[u8], mut index: usize) -> usize {
-    if text[index..].starts_with("([") {
+    if starts_inline_citation(text, index) && !has_odd_backslash_escape_bytes(bytes, index) {
         return index + 1;
     }
 
@@ -173,15 +173,20 @@ fn scan_plain_text_end(text: &str, bytes: &[u8], mut index: usize) -> usize {
 fn should_stop_plain_text(text: &str, bytes: &[u8], index: usize, current: (char, bool)) -> bool {
     let (ch, is_escaped) = current;
     if ch == '[' {
-        return !is_escaped && !bracket_follows_escaped_bang(bytes, index);
+        return !is_escaped
+            && !bracket_follows_escaped_bang(bytes, index)
+            && !bracket_follows_escaped_open_paren(bytes, index);
     }
     if ch == '(' {
-        return !is_escaped
-            && text
-                .get(index + 1..)
-                .is_some_and(|tail| tail.starts_with('['));
+        return !is_escaped && starts_inline_citation(text, index);
     }
     looks_like_image_start(text, index, ch) && !is_escaped
+}
+
+fn bracket_follows_escaped_open_paren(bytes: &[u8], index: usize) -> bool {
+    index.checked_sub(1).is_some_and(|previous| {
+        bytes[previous] == b'(' && has_odd_backslash_escape_bytes(bytes, previous)
+    })
 }
 
 fn is_closed_inline_code_span(token: &str) -> bool {

--- a/tests/wrap/cli.rs
+++ b/tests/wrap/cli.rs
@@ -82,6 +82,71 @@ fn test_cli_wrap_reflows_markdown(
     Ok(())
 }
 
+#[rstest]
+#[case::single(
+    concat!(
+        "This paragraph keeps pattern([1](https://github.com/leynos/mdtablefix/pull/url)) ",
+        "attached while the command-line wrapper reflows surrounding prose."
+    ),
+    "pattern([1](https://github.com/leynos/mdtablefix/pull/url))",
+)]
+#[case::adjacent(
+    concat!(
+        "This paragraph keeps pattern([1](https://github.com/leynos/mdtablefix/pull/url))",
+        "([2](https://github.com/leynos/mdtablefix/issues/325)) attached while wrapping."
+    ),
+    concat!(
+        "pattern([1](https://github.com/leynos/mdtablefix/pull/url))",
+        "([2](https://github.com/leynos/mdtablefix/issues/325))"
+    ),
+)]
+fn test_cli_wrap_keeps_inline_citation_links_attached(
+    #[case] paragraph: &str,
+    #[case] expected_citation: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let assertion = run_cli_with_stdin(&["--wrap"], &format!("{paragraph}\n"))?;
+    let success = assertion.success();
+    let output = String::from_utf8_lossy(&success.get_output().stdout);
+    let lines = output.lines().collect::<Vec<_>>();
+    let link_starts = citation_link_starts(expected_citation);
+
+    assert!(
+        output.contains(expected_citation),
+        "expected citation to stay attached in CLI output: {output}",
+    );
+    assert!(
+        lines.iter().all(|line| !line.ends_with('(')),
+        "opening citation punctuation must not be stranded: {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| {
+            let trimmed = line.trim_start();
+            link_starts
+                .iter()
+                .all(|marker| !trimmed.starts_with(marker))
+        }),
+        "citation link must not start a continuation line: {lines:?}",
+    );
+    assert!(
+        lines.iter().all(|line| line.trim() != ")("),
+        "adjacent citation punctuation must not be orphaned: {lines:?}",
+    );
+    Ok(())
+}
+
+fn citation_link_starts(expected_citation: &str) -> Vec<String> {
+    let mut markers = Vec::new();
+    let mut remaining = expected_citation;
+    while let Some(start) = remaining.find('[') {
+        let after_start = &remaining[start..];
+        if let Some(end) = after_start.find("](") {
+            markers.push(after_start[..end + 2].to_owned());
+        }
+        remaining = &after_start[1..];
+    }
+    markers
+}
+
 /// Ensures `--wrap` preserves an explicit language specifier on fences.
 #[test]
 fn test_cli_wrap_preserves_language() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/wrap/cli.rs
+++ b/tests/wrap/cli.rs
@@ -134,6 +134,12 @@ fn test_cli_wrap_keeps_inline_citation_links_attached(
     Ok(())
 }
 
+/// Extracts link-start markers from `expected_citation`.
+///
+/// Given an `expected_citation: &str`, this helper returns a `Vec<String>` of
+/// derived marker prefixes such as `"[1]("`. The CLI citation tests use those
+/// markers for dynamic assertions instead of hard-coded citation text, avoiding
+/// false negatives when citation content or ordering changes.
 fn citation_link_starts(expected_citation: &str) -> Vec<String> {
     let mut markers = Vec::new();
     let mut remaining = expected_citation;


### PR DESCRIPTION
## Summary

This branch keeps parenthesised inline citation links attached while prose is wrapped. It treats `word([1](url))` and adjacent citation groups as atomic wrapping spans, so the formatter no longer leaves bare opening parentheses at line ends or emits standalone `)(` fragments.

Closes #325.

## Review walkthrough

- Start with [src/wrap/tokenize/mod.rs](https://github.com/leynos/mdtablefix/blob/8227142e35d761cf00e04b90e17154247a3b55fc/src/wrap/tokenize/mod.rs) to see how `([` boundaries are split before link parsing and how adjacent citation punctuation avoids `)(` tokens.
- Then review [src/wrap/inline/span_helpers.rs](https://github.com/leynos/mdtablefix/blob/8227142e35d761cf00e04b90e17154247a3b55fc/src/wrap/inline/span_helpers.rs) and [src/wrap/inline.rs](https://github.com/leynos/mdtablefix/blob/8227142e35d761cf00e04b90e17154247a3b55fc/src/wrap/inline.rs) for the opener-followed-link span coupling.
- Finish with [src/wrap/tests/token_grouping.rs](https://github.com/leynos/mdtablefix/blob/8227142e35d761cf00e04b90e17154247a3b55fc/src/wrap/tests/token_grouping.rs) and [src/wrap/tests/inline_wrapping.rs](https://github.com/leynos/mdtablefix/blob/8227142e35d761cf00e04b90e17154247a3b55fc/src/wrap/tests/inline_wrapping.rs) for single and adjacent citation regressions.

## Validation

- `cargo test --all-targets --all-features wrap::tests`: passed.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed.
- `coderabbit review --agent`: attempted three times; each attempt connected and stalled at `preparing_sandbox` without findings, rate-limit output, or completion.

## Notes

The local `make fmt` target also attempted Markdown formatting, but that generated unrelated documentation churn. Those generated Markdown changes were discarded before the committed branch was pushed.

## Summary by Sourcery

Ensure inline citation-style links and their surrounding punctuation are treated as atomic spans during wrapping to avoid awkward line breaks.

Bug Fixes:
- Prevent line wrapping from leaving opening parentheses or adjacent citation punctuation (e.g., ")(") orphaned around inline links.

Enhancements:
- Adjust inline tokenization to split before "([" and to treat opener-followed links and trailing punctuation as a single span when wrapping.

Tests:
- Add regression tests for token grouping and inline wrapping of parenthesised inline links and adjacent citation-style references.