### PR TITLE
Stop code-block pipe lines gaining a trailing pipe (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
 
 ### Fixed
 
+- Stop appending a trailing `|` to lone pipe-prefixed lines in code blocks, so
+  shell pipeline continuations such as `| tee /tmp/test.log` are no longer
+  corrupted into unterminated pipelines. A same-marker line carrying an info
+  string is now treated as literal content rather than a closing fence, per
+  CommonMark.
+  ([#373](https://github.com/leynos/mdtablefix/issues/373))
 - Document `--wrap` as a parameterless 80-column flag.
   ([#388](https://github.com/leynos/mdtablefix/issues/388))
 - Keep reference-style links atomic while wrapping, so an opening bracket cannot

--- a/docs/adrs/0001-table-reflow-pipeline.md
+++ b/docs/adrs/0001-table-reflow-pipeline.md
@@ -19,6 +19,13 @@ continuation-row fixes exposed three coupled failure modes:
 These regressions produced malformed tables and markdownlint failures,
 including inconsistent column counts and separator widths.
 
+A further false positive surfaced later:
+
+- A degenerate candidate consisting of a single pipe-prefixed line with no
+  separator row, such as a shell pipeline continuation (`| tee /tmp/test.log`)
+  inside a code block, was treated as a one-cell table and reformatted with a
+  fabricated trailing `|`, corrupting otherwise literal content.
+
 ## Decision
 
 The table reflow pipeline now follows these rules:
@@ -35,6 +42,9 @@ The table reflow pipeline now follows these rules:
   columns at a minimum width of three dashes while preserving alignment markers.
 - Apply ellipsis replacement to buffered table lines before calling
   `reflow_table`, so the formatter sees the final cell contents.
+- Enforce a minimum-structure guard in `reflow_table`: a candidate with no
+  separator row that resolves to a single row of a single cell is not a table
+  and is returned unchanged rather than reformatted.
 
 ## Consequences
 
@@ -48,3 +58,6 @@ The table reflow pipeline now follows these rules:
 - The parser carries a private marker for leading empty continuation cells and
   re-escapes literal pipes in non-leading cells during row rebuilding, which
   keeps the behaviour deterministic and testable.
+- Degenerate single-cell candidates with no separator row are returned
+  unchanged, so stray pipe-prefixed lines (for example shell pipeline
+  continuations in code blocks) are never fabricated into one-cell tables.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -49,6 +49,8 @@
   matrix coverage.
 - [Nested code block handling](execplans/issue-262-nested-code-block-handling.md):
   Plan for nested code block handling.
+- [Code-block pipe lines](execplans/issue-373-code-block-pipe-line-trailing-pipe.md):
+  Plan for stopping code-block pipe lines from gaining a trailing pipe.
 - [Wrapping replacement](execplans/replace-bespoke-wrapping-with-textwrap-and-unicode-width.md):
   Plan for replacing bespoke wrapping internals with `textwrap` and
   `unicode-width`.

--- a/docs/execplans/issue-373-code-block-pipe-line-trailing-pipe.md
+++ b/docs/execplans/issue-373-code-block-pipe-line-trailing-pipe.md
@@ -1,0 +1,111 @@
+# Stop reflowing code-block pipe lines into table rows
+
+This ExecPlan (execution plan) is a living document. Keep these sections
+current as work proceeds: `Constraints`, `Tolerances`, `Risks`, `Progress`,
+`Surprises & discoveries`, `Decision log`, and `Outcomes & retrospective`.
+
+Status: COMPLETE
+
+Issue: <https://github.com/leynos/mdtablefix/issues/373>
+
+## Purpose / big picture
+
+A line inside a code block that begins with `|` — for example a shell pipeline
+continuation such as `| tee /tmp/test.log` (indented under the pipeline) — was
+being treated as a
+Markdown table row and "balanced" with an appended trailing `|`. The result,
+`| tee /tmp/test.log |`, is an unterminated shell pipeline that hangs or errors
+when copied and run. markdownlint does not catch the corruption, so it ships
+silently.
+
+After this change, content inside indented and fenced code blocks is treated as
+literal. A leading `|` in a code block is never rewritten with a trailing `|`,
+and the reported reproduction round-trips unchanged under the full stream
+pipeline.
+
+## Constraints
+
+- Do not add new dependencies; reuse existing table and fence code.
+- Do not change the public API exported from `src/lib.rs`.
+- Keep existing table reflow and fence normalization semantics stable for all
+  currently supported cases.
+- Reuse the shared `FenceTracker` close decision; do not duplicate fence logic
+  in `src/fences.rs`.
+- Keep code files under the repository's 400-line limit.
+
+## Tolerances
+
+- Multi-row or multi-column degenerate tables (without a separator) keep their
+  current behaviour; only the lone single-cell candidate is newly guarded.
+- Whitespace-only info strings on a closing fence still close the fence, matching
+  CommonMark's "spaces and tabs are ignored" allowance.
+
+## Risks
+
+- Over-broadening the minimum-structure guard could suppress legitimate
+  single-column tables. Mitigated by gating on the absence of a separator row
+  and a single row of a single cell.
+- Changing fence-close semantics could regress existing fence tests. Mitigated
+  by updating the one log-focused test that assumed an info-bearing closing
+  fence closes, and by full-suite validation.
+
+## Progress
+
+- [x] Minimum-structure guard added to `reflow_table` (`src/table.rs`).
+- [x] CommonMark closing-fence semantics enforced in `FenceTracker::observe`
+  (`src/wrap/fence.rs`).
+- [x] Unit, fence-tracker, and integration regression tests added.
+- [x] CHANGELOG, ADR 0001, and this ExecPlan recorded.
+
+## Surprises & discoveries
+
+- `tests/table/` is not compiled by any Cargo target (orphaned during an earlier
+  test reorg). The running process_stream coverage therefore lives in the
+  compiled `tests/table_continuations.rs` target; the orphaned
+  `tests/table/process_stream_tests.rs` case is retained for when a stub is
+  eventually wired in.
+
+## Decision log
+
+- Guard the degenerate candidate in `parse_and_validate` next to the existing
+  `rows_mismatched` bail-out rather than introducing a new abstraction.
+- Gate the fence close on an empty (whitespace-only) info string, routing an
+  info-bearing same-marker line to a dedicated `unchanged` arm with reason
+  `closing_fence_has_info_string` for accurate telemetry.
+
+## Plan of work
+
+1. Harden `reflow_table` so a lone single-cell candidate with no separator row
+   is returned unchanged.
+2. Tighten `FenceTracker::observe` to CommonMark closing-fence semantics so pipe
+   lines inside fenced blocks never leak into table detection.
+3. Lock behaviour with tests and record the fix in the changelog, ADR, and this
+   plan.
+
+## Concrete steps
+
+- `src/table.rs`: add the minimum-structure guard and a unit test.
+- `src/wrap/fence.rs`: bind the info string and gate the close on it; add a
+  distinct `unchanged` arm.
+- `src/wrap/tests/fence_tracker.rs`: update the log test that assumed an
+  info-bearing close, and add positive/negative coverage.
+- `tests/table_continuations.rs`: single-pipe passthrough, the ticket's exact
+  indented reproduction, and the fenced info-string case.
+- `tests/fences.rs`: info-string marker remains literal content.
+- `CHANGELOG.md`, `docs/adrs/0001-table-reflow-pipeline.md`, `docs/contents.md`.
+
+## Acceptance criteria
+
+- `| tee /tmp/test.log` passes through `reflow_table` unchanged.
+- The ticket's exact input is idempotent under `process_stream`.
+- A same-marker line with a non-whitespace info string does not close an open
+  fence; a bare or whitespace-only marker still does.
+- `make check-fmt`, `make lint`, `make test`, and `make markdownlint` pass.
+
+## Outcomes & retrospective
+
+The two-pronged fix removes the corruption at both the reflow entry point (the
+minimum-structure guard) and the fence-detection boundary (CommonMark
+closing-fence semantics), so pipe lines in both indented and fenced code blocks
+stay literal. The orphaned `tests/table/` directory remains a latent
+maintenance hazard; wiring it into Cargo is tracked separately.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -24,6 +24,11 @@ Pipe-looking lines indented by four or more columns are preserved as indented
 code blocks. For example, a source line with four leading spaces before
 `| not | a table |` is emitted verbatim rather than being table-reflowed.
 
+Content inside fenced code blocks is treated the same way. A line beginning
+with `|` inside such a block — for example a shell pipeline continuation such
+as `| tee /tmp/test.log` — is never treated as a Markdown table row and never
+gains an appended trailing `|`.
+
 Literal pipe characters inside cells must be written as `\|`. `mdtablefix`
 preserves that escaping during reflow, so a literal pipe remains part of the
 cell content rather than being interpreted as a column boundary.
@@ -238,6 +243,12 @@ normalization would turn an inner literal fence into a structural close, the
 outer fence is kept, so the inner content remains literal. Preservation applies
 when the inner fence uses the same marker character as the outer fence, or when
 a tilde outer fence wraps a literal inner backtick fence.
+
+A fence closes only on a bare marker line (`` ``` `` or `~~~`) optionally
+followed by ASCII spaces or tabs. A same-marker line that also carries an info
+string — trailing non-whitespace text — is literal content rather than a
+closing fence, per CommonMark. This keeps pipe lines and other content inside
+such blocks verbatim.
 
 If a language specifier starts a block, either at the start of the file or
 immediately after a blank line, and appears before the next unlabelled opening

--- a/src/table.rs
+++ b/src/table.rs
@@ -5,6 +5,7 @@
 //! Provides helpers used by the `reflow` module and `reflow_table` itself.
 
 use regex::Regex;
+use tracing::debug;
 
 static ESCAPED_PIPE_RE: std::sync::LazyLock<Regex> =
     lazy_regex!(r"\\\|", "escaped table pipe pattern should compile");
@@ -159,6 +160,12 @@ fn parse_and_validate(trimmed: &[String], sep_line: Option<&String>) -> Option<P
     let (sep_cells, sep_row_idx) = crate::reflow::detect_separator(sep_line, &rows, max_cols);
     let cleaned = crate::reflow::clean_rows(rows);
     if rows_mismatched(&cleaned, split_within_line) {
+        debug!(
+            reason = "rows_mismatched",
+            row_count = cleaned.len(),
+            has_separator = sep_cells.is_some(),
+            "table candidate rejected"
+        );
         return None;
     }
     let mut output_rows = cleaned.clone();
@@ -173,6 +180,12 @@ fn parse_and_validate(trimmed: &[String], sep_line: Option<&String>) -> Option<P
         && output_rows.len() == 1
         && output_rows.first().is_some_and(|row| row.len() == 1)
     {
+        debug!(
+            reason = "lone_single_cell",
+            row_count = output_rows.len(),
+            has_separator = sep_cells.is_some(),
+            "table candidate rejected"
+        );
         return None;
     }
     Some(ParsedTable {

--- a/src/table.rs
+++ b/src/table.rs
@@ -165,6 +165,16 @@ fn parse_and_validate(trimmed: &[String], sep_line: Option<&String>) -> Option<P
     if let Some(idx) = sep_index_within(sep_row_idx, output_rows.len()) {
         output_rows.remove(idx);
     }
+    // A lone single-cell candidate with no separator row is not a table: it is a
+    // stray pipe-prefixed line, such as a shell pipeline continuation inside a
+    // code block. Formatting it would fabricate a trailing pipe, so treat it as
+    // structurally insufficient and return the input unchanged.
+    if sep_cells.is_none()
+        && output_rows.len() == 1
+        && output_rows.first().is_some_and(|row| row.len() == 1)
+    {
+        return None;
+    }
     Some(ParsedTable {
         output_rows,
         sep_cells,
@@ -288,6 +298,16 @@ mod tests {
         let sep_cells = vec!["---".to_string()];
 
         assert!(format_separator_cells(&[3, 4], &sep_cells).is_empty());
+    }
+
+    #[test]
+    fn reflow_table_returns_lone_single_cell_line_unchanged() {
+        // A single pipe-prefixed line with no separator row is a stray pipe
+        // (for example a shell pipeline continuation), not a table. It must pass
+        // through verbatim rather than gaining a fabricated trailing pipe.
+        let lines = vec!["| tee /tmp/test.log".to_string()];
+
+        assert_eq!(reflow_table(&lines), lines);
     }
 
     #[test]

--- a/src/wrap/fence.rs
+++ b/src/wrap/fence.rs
@@ -185,19 +185,23 @@ impl FenceTracker {
             self.state = None;
         }
 
-        let Some((_indent, fence, _info)) = parsed else {
+        let Some((_indent, fence, info)) = parsed else {
             return false;
         };
 
         let mut chars = fence.chars();
         let marker_ch = chars.next().expect("FENCE_RE guarantees a non-empty fence");
         let marker_len = chars.count() + 1;
+        // CommonMark forbids an info string on a closing fence: a same-marker
+        // line carrying trailing text is literal content, not a close.
+        let closes_fence = info.trim().is_empty();
 
         match self.state {
             Some(open)
                 if depth == open.open_depth
                     && marker_ch == open.marker
-                    && marker_len >= open.marker_len =>
+                    && marker_len >= open.marker_len
+                    && closes_fence =>
             {
                 debug!(
                     transition = "matching_close",
@@ -208,6 +212,21 @@ impl FenceTracker {
                     "fence state changed"
                 );
                 self.state = None;
+            }
+            Some(open)
+                if depth == open.open_depth
+                    && marker_ch == open.marker
+                    && marker_len >= open.marker_len =>
+            {
+                trace!(
+                    transition = "unchanged",
+                    reason = "closing_fence_has_info_string",
+                    depth,
+                    open_depth = open.open_depth,
+                    marker_len,
+                    open_marker_len = open.marker_len,
+                    "fence marker did not change state"
+                );
             }
             Some(open) => {
                 trace!(

--- a/src/wrap/fence.rs
+++ b/src/wrap/fence.rs
@@ -193,8 +193,11 @@ impl FenceTracker {
         let marker_ch = chars.next().expect("FENCE_RE guarantees a non-empty fence");
         let marker_len = chars.count() + 1;
         // CommonMark forbids an info string on a closing fence: a same-marker
-        // line carrying trailing text is literal content, not a close.
-        let closes_fence = info.trim().is_empty();
+        // line carrying trailing text is literal content, not a close. Only
+        // ASCII spaces and tabs may follow a closing marker, so avoid the
+        // Unicode-aware `trim`, which would wrongly accept a no-break space
+        // (U+00A0) or form feed (U+000C) as blank trailing whitespace.
+        let closes_fence = info.bytes().all(|b| b == b' ' || b == b'\t');
 
         match self.state {
             Some(open)

--- a/src/wrap/tests.rs
+++ b/src/wrap/tests.rs
@@ -6,6 +6,7 @@
 mod blockquote;
 mod classify_block;
 mod fence_tracker;
+mod fence_tracker_logging;
 mod inline_wrapping;
 mod link_ref_regex;
 mod link_reference_definitions;

--- a/src/wrap/tests/fence_tracker.rs
+++ b/src/wrap/tests/fence_tracker.rs
@@ -5,7 +5,6 @@
 
 use proptest::prelude::*;
 use rstest::rstest;
-use tracing_test::traced_test;
 
 use crate::wrap::{FenceTracker, is_fence};
 
@@ -310,39 +309,35 @@ proptest! {
         prop_assert!(!obs.is_fence_marker);
         prop_assert!(!obs.is_in_fence);
     }
-}
 
-#[traced_test]
-#[test]
-fn fence_opening_logs_content_free_transition() {
-    let input = "```private-opening-info";
-    let mut tracker = FenceTracker::new();
+    /// A same-marker line carrying a non-blank info string is literal content,
+    /// not a closing fence, so the fence stays open regardless of marker length
+    /// or nesting depth. A subsequent bare marker at the opening depth closes it.
+    #[test]
+    fn observe_source_line_treats_info_string_marker_as_content(
+        open_depth in 0_usize..=4,
+        marker in prop_oneof![Just('`'), Just('~')],
+        open_len in 3_usize..=6,
+        extra in 0_usize..=3,
+        info in "[a-zA-Z][a-zA-Z0-9 ]{0,10}",
+    ) {
+        let run = marker.to_string();
+        let mut tracker = FenceTracker::new();
 
-    assert!(tracker.observe(input, 2));
-    assert!(logs_contain("transition=\"open\""));
-    assert!(logs_contain("depth=2"));
-    assert!(logs_contain("open_depth=2"));
-    assert!(logs_contain("marker_len=3"));
-    assert!(!logs_contain(input));
-    assert!(!logs_contain("private-opening-info"));
-}
+        let opening = quoted_line(open_depth, &format!("{}rust", run.repeat(open_len)));
+        prop_assert!(tracker.observe_source_line(&opening).is_in_fence);
 
-#[traced_test]
-#[test]
-fn matching_fence_closure_logs_content_free_transition() {
-    let opening = "````private-opening-info";
-    let closing = "````";
-    let mut tracker = FenceTracker::new();
+        // Same marker and depth, at least the opening length, but with an info
+        // string: not a valid close, so the fence remains open.
+        let info_marker = quoted_line(open_depth, &format!("{}{info}", run.repeat(open_len + extra)));
+        let obs = tracker.observe_source_line(&info_marker);
+        prop_assert!(obs.was_in_fence);
+        prop_assert!(obs.is_in_fence);
 
-    assert!(tracker.observe(opening, 1));
-    assert!(tracker.observe(closing, 1));
-    assert!(logs_contain("transition=\"matching_close\""));
-    assert!(logs_contain("depth=1"));
-    assert!(logs_contain("open_depth=1"));
-    assert!(logs_contain("marker_len=4"));
-    assert!(logs_contain("open_marker_len=4"));
-    assert!(!logs_contain(opening));
-    assert!(!logs_contain("private-opening-info"));
+        // A bare marker at the opening depth closes as usual.
+        let closing = quoted_line(open_depth, &run.repeat(open_len));
+        prop_assert!(!tracker.observe_source_line(&closing).is_in_fence);
+    }
 }
 
 #[test]
@@ -363,55 +358,21 @@ fn fence_tracker_treats_info_string_marker_as_content_not_close() {
     assert!(!tracker.in_fence(0));
 }
 
-#[traced_test]
-#[test]
-fn info_string_marker_logs_content_free_unchanged_transition() {
-    let opening = "````private-opening-info";
-    let info_marker = "````private-closing-info";
+#[rstest]
+#[case("```\u{a0}")]
+#[case("```\u{c}")]
+fn fence_tracker_rejects_non_ascii_whitespace_close(#[case] closing: &str) {
+    // CommonMark permits only ASCII spaces and tabs after a closing marker, so
+    // a no-break space (U+00A0) or form feed (U+000C) is literal content and
+    // must not close the fence.
     let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("```rust", 0));
+    assert!(tracker.in_fence(0));
 
-    assert!(tracker.observe(opening, 1));
-    // A same-length, same-marker line with an info string does not close.
-    assert!(tracker.observe(info_marker, 1));
-    assert!(tracker.in_fence(1));
-    assert!(logs_contain("transition=\"unchanged\""));
-    assert!(logs_contain("reason=\"closing_fence_has_info_string\""));
-    assert!(!logs_contain(opening));
-    assert!(!logs_contain(info_marker));
-    assert!(!logs_contain("private-closing-info"));
-}
+    assert!(tracker.observe(closing, 0));
+    assert!(tracker.in_fence(0));
 
-#[traced_test]
-#[test]
-fn depth_decrease_logs_content_free_implicit_closure() {
-    let opening = "```private-opening-info";
-    let shallower_line = "private shallower payload";
-    let mut tracker = FenceTracker::new();
-
-    assert!(tracker.observe(opening, 3));
-    assert!(!tracker.observe(shallower_line, 2));
-    assert!(logs_contain("transition=\"implicit_close\""));
-    assert!(logs_contain("reason=\"blockquote_depth_decreased\""));
-    assert!(logs_contain("depth=2"));
-    assert!(logs_contain("open_depth=3"));
-    assert!(logs_contain("open_marker_len=3"));
-    assert!(!logs_contain(opening));
-    assert!(!logs_contain(shallower_line));
-}
-
-#[traced_test]
-#[test]
-fn incompatible_marker_logs_content_free_unchanged_transition() {
-    let opening = "````private-opening-info";
-    let incompatible = "~~~private-incompatible-info";
-    let mut tracker = FenceTracker::new();
-
-    assert!(tracker.observe(opening, 1));
-    assert!(tracker.observe(incompatible, 1));
-    assert!(logs_contain("transition=\"unchanged\""));
-    assert!(logs_contain("reason=\"incompatible_active_opener\""));
-    assert!(logs_contain("marker_len=3"));
-    assert!(logs_contain("open_marker_len=4"));
-    assert!(!logs_contain(opening));
-    assert!(!logs_contain(incompatible));
+    // A bare marker still closes.
+    assert!(tracker.observe("```", 0));
+    assert!(!tracker.in_fence(0));
 }

--- a/src/wrap/tests/fence_tracker.rs
+++ b/src/wrap/tests/fence_tracker.rs
@@ -331,7 +331,7 @@ fn fence_opening_logs_content_free_transition() {
 #[test]
 fn matching_fence_closure_logs_content_free_transition() {
     let opening = "````private-opening-info";
-    let closing = "````private-closing-info";
+    let closing = "````";
     let mut tracker = FenceTracker::new();
 
     assert!(tracker.observe(opening, 1));
@@ -342,7 +342,43 @@ fn matching_fence_closure_logs_content_free_transition() {
     assert!(logs_contain("marker_len=4"));
     assert!(logs_contain("open_marker_len=4"));
     assert!(!logs_contain(opening));
-    assert!(!logs_contain(closing));
+    assert!(!logs_contain("private-opening-info"));
+}
+
+#[test]
+fn fence_tracker_treats_info_string_marker_as_content_not_close() {
+    // Per CommonMark, a closing fence must not carry an info string. A
+    // same-marker line bearing trailing text is literal content and leaves the
+    // fence open, while a bare (or whitespace-only) marker still closes it.
+    let mut tracker = FenceTracker::new();
+    assert!(tracker.observe("```rust", 0));
+    assert!(tracker.in_fence(0));
+
+    // Same marker, but a non-whitespace info string: not a close.
+    assert!(tracker.observe("```rust", 0));
+    assert!(tracker.in_fence(0));
+
+    // A bare marker closes as usual.
+    assert!(tracker.observe("```", 0));
+    assert!(!tracker.in_fence(0));
+}
+
+#[traced_test]
+#[test]
+fn info_string_marker_logs_content_free_unchanged_transition() {
+    let opening = "````private-opening-info";
+    let info_marker = "````private-closing-info";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(opening, 1));
+    // A same-length, same-marker line with an info string does not close.
+    assert!(tracker.observe(info_marker, 1));
+    assert!(tracker.in_fence(1));
+    assert!(logs_contain("transition=\"unchanged\""));
+    assert!(logs_contain("reason=\"closing_fence_has_info_string\""));
+    assert!(!logs_contain(opening));
+    assert!(!logs_contain(info_marker));
+    assert!(!logs_contain("private-closing-info"));
 }
 
 #[traced_test]

--- a/src/wrap/tests/fence_tracker_logging.rs
+++ b/src/wrap/tests/fence_tracker_logging.rs
@@ -1,0 +1,97 @@
+//! Transition-logging tests for the `FenceTracker` helper.
+//!
+//! These cases assert that fence-state transitions emit stable, content-free
+//! tracing events, so operators can diagnose fence handling without the logs
+//! leaking document text. They live apart from the behavioural cases in
+//! `fence_tracker` to keep each test module within the repository's file-size
+//! limit.
+
+use tracing_test::traced_test;
+
+use crate::wrap::FenceTracker;
+
+#[traced_test]
+#[test]
+fn fence_opening_logs_content_free_transition() {
+    let input = "```private-opening-info";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(input, 2));
+    assert!(logs_contain("transition=\"open\""));
+    assert!(logs_contain("depth=2"));
+    assert!(logs_contain("open_depth=2"));
+    assert!(logs_contain("marker_len=3"));
+    assert!(!logs_contain(input));
+    assert!(!logs_contain("private-opening-info"));
+}
+
+#[traced_test]
+#[test]
+fn matching_fence_closure_logs_content_free_transition() {
+    let opening = "````private-opening-info";
+    let closing = "````";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(opening, 1));
+    assert!(tracker.observe(closing, 1));
+    assert!(logs_contain("transition=\"matching_close\""));
+    assert!(logs_contain("depth=1"));
+    assert!(logs_contain("open_depth=1"));
+    assert!(logs_contain("marker_len=4"));
+    assert!(logs_contain("open_marker_len=4"));
+    assert!(!logs_contain(opening));
+    assert!(!logs_contain("private-opening-info"));
+}
+
+#[traced_test]
+#[test]
+fn info_string_marker_logs_content_free_unchanged_transition() {
+    let opening = "````private-opening-info";
+    let info_marker = "````private-closing-info";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(opening, 1));
+    // A same-length, same-marker line with an info string does not close.
+    assert!(tracker.observe(info_marker, 1));
+    assert!(tracker.in_fence(1));
+    assert!(logs_contain("transition=\"unchanged\""));
+    assert!(logs_contain("reason=\"closing_fence_has_info_string\""));
+    assert!(!logs_contain(opening));
+    assert!(!logs_contain(info_marker));
+    assert!(!logs_contain("private-closing-info"));
+}
+
+#[traced_test]
+#[test]
+fn depth_decrease_logs_content_free_implicit_closure() {
+    let opening = "```private-opening-info";
+    let shallower_line = "private shallower payload";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(opening, 3));
+    assert!(!tracker.observe(shallower_line, 2));
+    assert!(logs_contain("transition=\"implicit_close\""));
+    assert!(logs_contain("reason=\"blockquote_depth_decreased\""));
+    assert!(logs_contain("depth=2"));
+    assert!(logs_contain("open_depth=3"));
+    assert!(logs_contain("open_marker_len=3"));
+    assert!(!logs_contain(opening));
+    assert!(!logs_contain(shallower_line));
+}
+
+#[traced_test]
+#[test]
+fn incompatible_marker_logs_content_free_unchanged_transition() {
+    let opening = "````private-opening-info";
+    let incompatible = "~~~private-incompatible-info";
+    let mut tracker = FenceTracker::new();
+
+    assert!(tracker.observe(opening, 1));
+    assert!(tracker.observe(incompatible, 1));
+    assert!(logs_contain("transition=\"unchanged\""));
+    assert!(logs_contain("reason=\"incompatible_active_opener\""));
+    assert!(logs_contain("marker_len=3"));
+    assert!(logs_contain("open_marker_len=4"));
+    assert!(!logs_contain(opening));
+    assert!(!logs_contain(incompatible));
+}

--- a/tests/fences.rs
+++ b/tests/fences.rs
@@ -414,3 +414,19 @@ fn compresses_top_level_fence_after_quoted_block() {
         lines_vec!["> ````rust", "> code", "> ````", "```rust", "top", "```",]
     );
 }
+
+#[test]
+fn keeps_info_string_marker_as_literal_content() {
+    // A same-marker line carrying an info string is not a closing fence
+    // (CommonMark), so the block stays open through the pipe line and the whole
+    // fenced block round-trips verbatim rather than closing early.
+    let input = lines_vec![
+        "```rust",
+        "let table = build();",
+        "```rust extra info",
+        "| tee /tmp/test.log",
+        "```",
+    ];
+    let out = compress_fences(&input);
+    assert_eq!(out, input);
+}

--- a/tests/table/process_stream_tests.rs
+++ b/tests/table/process_stream_tests.rs
@@ -28,6 +28,18 @@ fn test_process_stream_ignores_code_fences() {
 
     let tilde_lines = lines_vec!["~~~", "| not | a | table |", "~~~"];
     assert_eq!(process_stream(&tilde_lines), tilde_lines);
+
+    // A same-marker line bearing an info string is literal content, not a
+    // closing fence (CommonMark), so the following pipe line stays fenced and
+    // must not be reflowed into a table row.
+    let info_string_lines = lines_vec![
+        "```rust",
+        "let table = build();",
+        "```rust extra info",
+        "| tee /tmp/test.log",
+        "```",
+    ];
+    assert_eq!(process_stream(&info_string_lines), info_string_lines);
 }
 
 #[rstest]

--- a/tests/table/process_stream_tests.rs
+++ b/tests/table/process_stream_tests.rs
@@ -28,18 +28,6 @@ fn test_process_stream_ignores_code_fences() {
 
     let tilde_lines = lines_vec!["~~~", "| not | a | table |", "~~~"];
     assert_eq!(process_stream(&tilde_lines), tilde_lines);
-
-    // A same-marker line bearing an info string is literal content, not a
-    // closing fence (CommonMark), so the following pipe line stays fenced and
-    // must not be reflowed into a table row.
-    let info_string_lines = lines_vec![
-        "```rust",
-        "let table = build();",
-        "```rust extra info",
-        "| tee /tmp/test.log",
-        "```",
-    ];
-    assert_eq!(process_stream(&info_string_lines), info_string_lines);
 }
 
 #[rstest]

--- a/tests/table_continuations.rs
+++ b/tests/table_continuations.rs
@@ -1,6 +1,7 @@
 //! Regression tests for Markdown tables that use continuation rows.
 
 use mdtablefix::{Options, process_stream, process_stream_opts, reflow_table};
+use proptest::prelude::*;
 use rstest::rstest;
 use unicode_width::UnicodeWidthStr;
 
@@ -216,6 +217,20 @@ fn process_stream_preserves_indented_pipe_continuation() {
         "Done.",
     ];
     assert_eq!(process_stream(&input), input);
+}
+
+proptest! {
+    /// A single pipe-prefixed line whose sole cell is ordinary content — no
+    /// embedded pipe and not a separator run — is not a table and must pass
+    /// through `reflow_table` unchanged, never gaining a trailing pipe.
+    #[test]
+    fn reflow_table_passes_arbitrary_lone_single_cell_through(
+        content in "[A-Za-z0-9][A-Za-z0-9 ./_-]{0,30}",
+    ) {
+        let input = vec![format!("| {content}")];
+        let output = reflow_table(&input);
+        prop_assert_eq!(output, input);
+    }
 }
 
 #[test]

--- a/tests/table_continuations.rs
+++ b/tests/table_continuations.rs
@@ -191,3 +191,44 @@ fn reflow_table_uses_unicode_display_widths(#[case] input: Vec<String>) {
 
     assert_uniform_display_widths(&output);
 }
+
+#[test]
+fn reflow_table_passes_single_pipe_line_through_verbatim() {
+    // A lone pipe-prefixed content line (for example a shell pipeline
+    // continuation) is not a table. It must pass through `reflow_table`
+    // unchanged rather than gaining a fabricated trailing pipe.
+    let input = lines_vec!["| tee /tmp/test.log"];
+    assert_eq!(reflow_table(&input), input);
+}
+
+#[test]
+fn process_stream_preserves_indented_pipe_continuation() {
+    // The reported reproduction: an indented (code block) shell pipeline whose
+    // continuation line begins with `|`. The block is literal, so the pipe line
+    // must not be reflowed into a table row, and the whole document is
+    // idempotent under the full stream pipeline.
+    let input = lines_vec![
+        "Run the helper:",
+        "",
+        "    timeout 300 make test 2>&1 \\",
+        "        | tee /tmp/test.log",
+        "",
+        "Done.",
+    ];
+    assert_eq!(process_stream(&input), input);
+}
+
+#[test]
+fn process_stream_keeps_pipe_line_in_fenced_block_with_info_string() {
+    // A same-marker line bearing an info string is literal content, not a
+    // closing fence (CommonMark). The fence stays open through the pipe line,
+    // which must therefore remain verbatim rather than becoming a table row.
+    let input = lines_vec![
+        "```rust",
+        "let table = build();",
+        "```rust extra info",
+        "| tee /tmp/test.log",
+        "```",
+    ];
+    assert_eq!(process_stream(&input), input);
+}


### PR DESCRIPTION
## Summary

A line inside a code block that begins with `|` — for example a shell pipeline
continuation such as `| tee /tmp/test.log` — was treated as a Markdown table
row and "balanced" with an appended trailing `|`. The result was an
unterminated shell pipeline that hangs or errors when copied, and markdownlint
did not catch the corruption, so it shipped silently.

The fix removes the corruption at both boundaries:

- **Minimum-structure guard in `reflow_table`** (`src/table.rs`): a lone
  single-cell candidate with no separator row is now returned unchanged instead
  of being formatted with a fabricated trailing pipe.
- **CommonMark closing-fence semantics in `FenceTracker::observe`**
  (`src/wrap/fence.rs`): a same-marker line carrying a non-whitespace info
  string is literal content, not a closing fence, so pipe lines inside fenced
  blocks no longer leak into table detection.

## Tests

- Unit test for the lone single-cell passthrough.
- Fence-tracker coverage: an info-string marker does not close an open fence; a
  bare or whitespace-only marker still does.
- Integration regressions in `tests/table_continuations.rs` and `tests/fences.rs`,
  including the ticket's exact indented reproduction under the full stream
  pipeline.

## Documentation

- CHANGELOG `### Fixed` entry.
- ADR 0001 amended with the degenerate single-cell failure mode, decision, and
  consequence.
- New execution plan under `docs/execplans/`, linked from `docs/contents.md`.

All deterministic gates pass (`check-fmt`, `lint`, `test`, `markdownlint`,
`nixie`) and a `coderabbit review --agent` pass returned zero findings.

Closes #373

## References

- Lody session: https://lody.ai/leynos/sessions/bb8be57e-33f3-4711-aaaa-2b8b9de4111c

🤖 Generated with [Claude Code](https://claude.com/claude-code)