### PR TITLE
Format Markdown sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,13 @@
   shell pipeline continuations such as `| tee /tmp/test.log` are no longer
   corrupted into unterminated pipelines. A same-marker line carrying an info
   string is now treated as literal content rather than a closing fence, per
-  CommonMark.
-  ([#373](https://github.com/leynos/mdtablefix/issues/373))
+  CommonMark. ([#373](https://github.com/leynos/mdtablefix/issues/373))
 - Reflow the prose following a joined cross-line inline-code span in the same
   `--wrap` pass, so formatter output is immediately idempotent.
   ([#375](https://github.com/leynos/mdtablefix/issues/375))
 - Preserve authored line boundaries inside a cross-line inline-code span when
-  joining it would exceed the wrap width and every authored source line
-  already fits within that width, preventing new MD013 violations.
+  joining it would exceed the wrap width and every authored source line already
+  fits within that width, preventing new MD013 violations.
   ([#370](https://github.com/leynos/mdtablefix/issues/370))
 - Document `--wrap` as a parameterless 80-column flag.
   ([#388](https://github.com/leynos/mdtablefix/issues/388))

--- a/docs/execplans/issue-373-code-block-pipe-line-trailing-pipe.md
+++ b/docs/execplans/issue-373-code-block-pipe-line-trailing-pipe.md
@@ -12,11 +12,10 @@ Issue: <https://github.com/leynos/mdtablefix/issues/373>
 
 A line inside a code block that begins with `|` — for example a shell pipeline
 continuation such as `| tee /tmp/test.log` (indented under the pipeline) — was
-being treated as a
-Markdown table row and "balanced" with an appended trailing `|`. The result,
-`| tee /tmp/test.log |`, is an unterminated shell pipeline that hangs or errors
-when copied and run. markdownlint does not catch the corruption, so it ships
-silently.
+being treated as a Markdown table row and "balanced" with an appended trailing
+`|`. The result, `| tee /tmp/test.log |`, is an unterminated shell pipeline
+that hangs or errors when copied and run. markdownlint does not catch the
+corruption, so it ships silently.
 
 After this change, content inside indented and fenced code blocks is treated as
 literal. A leading `|` in a code block is never rewritten with a trailing `|`,
@@ -37,7 +36,8 @@ pipeline.
 
 - Multi-row or multi-column degenerate tables (without a separator) keep their
   current behaviour; only the lone single-cell candidate is newly guarded.
-- Whitespace-only info strings on a closing fence still close the fence, matching
+- Whitespace-only info strings on a closing fence still close the fence,
+  matching
   CommonMark's "spaces and tabs are ignored" allowance.
 
 ## Risks

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -24,9 +24,9 @@ Pipe-looking lines indented by four or more columns are preserved as indented
 code blocks. For example, a source line with four leading spaces before
 `| not | a table |` is emitted verbatim rather than being table-reflowed.
 
-Content inside fenced code blocks is treated the same way. A line beginning
-with `|` inside such a block — for example a shell pipeline continuation such
-as `| tee /tmp/test.log` — is never treated as a Markdown table row and never
+Content inside fenced code blocks is treated the same way. A line beginning with
+`|` inside such a block — for example a shell pipeline continuation such as
+`| tee /tmp/test.log` — is never treated as a Markdown table row and never
 gains an appended trailing `|`.
 
 Literal pipe characters inside cells must be written as `\|`. `mdtablefix`


### PR DESCRIPTION
## Summary

This branch normalizes the repository Markdown with `mdformat-all` so the
formatter’s own source tree reflects the estate-wide formatting policy.

## Review walkthrough

- Start with [the Makefile](https://github.com/leynos/mdtablefix/blob/estate-mdformat-all/Makefile) to confirm the formatting target invokes `mdformat-all`.
- Review [the README](https://github.com/leynos/mdtablefix/blob/estate-mdformat-all/README.md) and remaining Markdown files for formatter-only normalization.

## Validation

- `make fmt`: pass
- `make check-fmt`: pass
- `make markdownlint`: pass
- `make nixie`: pass

## Summary by Sourcery

Documentation:
- Reflow and normalize prose in existing documentation and changelog entries without changing their meaning.